### PR TITLE
Fix concurrent access to DecimalFormat fields in BigDecimalParser

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
+++ b/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
@@ -1,14 +1,15 @@
 package org.talend.daikon.number;
 
-import org.apache.commons.lang.StringUtils;
-
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
 
 /**
  * Main goal of this class is to provide BigDecimal instance from a String.
@@ -27,18 +28,18 @@ public class BigDecimalParser {
 
     private static final Pattern TWO_DIFFERENT_SEPARATORS_PATTERN = Pattern.compile(".*\\d+([. ])\\d+[,]\\d+[)]?");
 
-    public static DecimalFormat US_DECIMAL_PATTERN = new DecimalFormat("#,##0.##", DecimalFormatSymbols.getInstance(Locale.US));
+    public static final DecimalFormat US_DECIMAL_PATTERN = new DecimalFormat("#,##0.##", DecimalFormatSymbols.getInstance(Locale.US));
 
-    public static DecimalFormat US_DECIMAL_PATTERN_ALT = new DecimalFormat("#,##0.##;(#)",
+    public static final DecimalFormat US_DECIMAL_PATTERN_ALT = new DecimalFormat("#,##0.##;(#)",
             DecimalFormatSymbols.getInstance(Locale.US));
 
-    public static DecimalFormat EU_DECIMAL_PATTERN = new DecimalFormat("#,##0.##",
+    public static final DecimalFormat EU_DECIMAL_PATTERN = new DecimalFormat("#,##0.##",
             DecimalFormatSymbols.getInstance(Locale.FRENCH));
 
-    public static DecimalFormat EU_SCIENTIFIC_DECIMAL_PATTERN = new DecimalFormat("0.###E0",
+    public static final DecimalFormat EU_SCIENTIFIC_DECIMAL_PATTERN = new DecimalFormat("0.###E0",
             DecimalFormatSymbols.getInstance(Locale.FRENCH));
 
-    public static DecimalFormat US_SCIENTIFIC_DECIMAL_PATTERN = new DecimalFormat("0.###E0",
+    public static final DecimalFormat US_SCIENTIFIC_DECIMAL_PATTERN = new DecimalFormat("0.###E0",
             DecimalFormatSymbols.getInstance(Locale.US));
 
     private BigDecimalParser() {
@@ -91,11 +92,13 @@ public class BigDecimalParser {
         try {
             return new BigDecimal(from);
         } catch (NumberFormatException e) {
-            for (DecimalFormat format : new DecimalFormat[] { US_DECIMAL_PATTERN, US_DECIMAL_PATTERN_ALT }) {
-                try {
-                    return toBigDecimal(format.parse(from));
-                } catch (ParseException e1) {
-                    // nothing to do, just test next format
+            for (final DecimalFormat format : Arrays.asList(US_DECIMAL_PATTERN, US_DECIMAL_PATTERN_ALT)) {
+                synchronized (format) { // Each value of 'format' is a constant, safe to use in synchronized.
+                    try {
+                        return toBigDecimal(format.parse(from));
+                    } catch (ParseException e1) {
+                        // nothing to do, just test next format
+                    }
                 }
             }
             throw new NumberFormatException("'" + from + "' can not parsed as a number");


### PR DESCRIPTION
* Add missing 'final' keyword for constant DecimalFormat fields.
* Adds synchronized on DecimalFormat instance before using it for parsing big decimal.