### PR TITLE
remove Form.widgetList and only keep Form.widgetMap.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/Property.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/Property.java
@@ -25,6 +25,8 @@ import org.apache.avro.Schema;
 import org.talend.daikon.SimpleNamedThing;
 import org.talend.daikon.strings.ToStringIndentUtil;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * A property that is part of a {@link Properties}.
  */
@@ -239,6 +241,7 @@ public class Property extends SimpleNamedThing implements AnyProperty {
         return possibleValues;
     }
 
+    @JsonIgnore // to avoid swagger to fail because of the 2 similar following methods.
     public Property setPossibleValues(List<?> possibleValues) {
         this.possibleValues = possibleValues;
         return this;


### PR DESCRIPTION
the Form used to have a list of widget and a map with the same set of widgets.
To simplify the class, the understanding and the serialization I removed the list and kept only the map which I changed to an LinkedHashMap to have keep the insertion order that is required for the widget list.