### PR TITLE
Feature/tcomp 175 runtime output records

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/talend6/Talend6IncomingSchemaEnforcer.java
+++ b/daikon/src/main/java/org/talend/daikon/talend6/Talend6IncomingSchemaEnforcer.java
@@ -1,0 +1,179 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.talend6;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.IndexedRecord;
+import org.talend.daikon.avro.util.AvroUtils;
+
+/**
+ * <b>You should almost certainly not be using this class.</b>
+ * 
+ * This class acts as a wrapper around arbitrary values to coerce the Talend 6 Studio types in a generated POJO to a
+ * {@link IndexedRecord} object that can be processed in the next component..
+ * <p>
+ * A wrapper like this should be attached before an output component, for example, to ensure that its incoming data with
+ * the constraints imposed by the Studio meet the contract of the component framework, for example:
+ * <ul>
+ * <li>Coercing the types of the Talend POJO objects to expected Avro schema types.</li>
+ * <li>Unwrapping data in a routines.system.Dynamic column into flat fields.</li>
+ * </ul>
+ * <p>
+ * One instance of this object can be created per incoming schema and reused.
+ */
+public class Talend6IncomingSchemaEnforcer implements IndexedRecord, Talend6SchemaConstants {
+
+    /**
+     * The design-time schema from the Studio that determines how incoming java column data will be interpreted.
+     */
+    private final Schema incomingDesignTimeSchema;
+
+    /**
+     * The position of the dynamic column in the incoming schema. This is -1 if there is no dynamic column. There can be
+     * a maximum of one dynamic column in the schema.
+     */
+    private final int incomingDynamicColumn;
+
+    /**
+     * The {@link Schema} of the actual runtime data that will be provided by this object. This will only be null if
+     * dynamic columns exist, but they have not been finished initializing.
+     */
+    private Schema incomingRuntimeSchema;
+
+    /** The fields constructed from dynamic columns. This will only be non-null during construction. */
+    private List<Schema.Field> fieldsFromDynamicColumns = null;
+
+    /** The values wrapped by this object. */
+    private Object[] wrapped = null;
+
+    /**
+     * Access the indexed fields by their name. We should prefer accessing them by index for performance, but this
+     * complicates the logic of dynamic columns quite a bit.
+     */
+    private final Map<String, Integer> columnToFieldIndex = new HashMap<>();
+
+    public Talend6IncomingSchemaEnforcer(Schema incoming) {
+        this.incomingDesignTimeSchema = incoming;
+        this.incomingRuntimeSchema = incoming;
+
+        // Find the dynamic column, if any.
+        incomingDynamicColumn = AvroUtils.isIncludeAllFields(incoming)
+                ? Integer.valueOf(incoming.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION)) : -1;
+        if (incomingDynamicColumn != -1) {
+            incomingRuntimeSchema = null;
+            fieldsFromDynamicColumns = new ArrayList<>();
+        }
+
+        // Add all of the runtime columns except any dynamic column to the index map.
+        for (Schema.Field f : incoming.getFields()) {
+            if (f.pos() != incomingDynamicColumn) {
+                columnToFieldIndex.put(f.name(), f.pos());
+            }
+        }
+    }
+
+    /**
+     * Take all of the parameters from the dynamic metadata and adapt it to a field for the runtime Schema.
+     */
+    public void initDynamicColumn(String name, String dbName, String type, String dbType, int dbTypeId, int length, int precision,
+            String format, String description, boolean isKey, boolean isNullable, String refFieldName, String refModuleName) {
+        if (!needsInitDynamicColumns())
+            return;
+
+        // Add each column to the field index and the incoming runtime schema.
+        // TODO(rskraba): do something other than STRING!
+        Schema fieldSchema = Schema.create(Schema.Type.STRING);
+        if (isNullable) {
+            fieldSchema = SchemaBuilder.nullable().type(fieldSchema);
+        }
+        fieldsFromDynamicColumns.add(new Schema.Field(name, fieldSchema, description, (Object) null));
+    }
+
+    /**
+     * Called when dynamic columns have finished being initialized. After this call, the {@link #getSchema()} can be
+     * used to get the runtime schema.
+     */
+    public void initDynamicColumnsFinished() {
+        if (!needsInitDynamicColumns())
+            return;
+
+        // Copy all of the fields that were initialized from dynamic columns into the runtime Schema.
+        List<Schema.Field> fields = new ArrayList<Schema.Field>();
+        for (Schema.Field designField : incomingDesignTimeSchema.getFields()) {
+            // Replace the dynamic column by all of its contents.
+            if (designField.pos() == incomingDynamicColumn) {
+                fields.addAll(fieldsFromDynamicColumns);
+            } else {
+                // Make a complete copy of the field (it can't be reused).
+                Schema.Field designFieldCopy = new Schema.Field(designField.name(), designField.schema(), designField.doc(),
+                        designField.defaultVal());
+                for (Map.Entry<String, Object> e : designField.getObjectProps().entrySet()) {
+                    designFieldCopy.addProp(e.getKey(), e.getValue());
+                }
+                fields.add(designFieldCopy);
+            }
+        }
+        incomingRuntimeSchema = Schema.createRecord(incomingDesignTimeSchema.getName(), incomingDesignTimeSchema.getDoc(),
+                incomingDesignTimeSchema.getNamespace(), incomingDesignTimeSchema.isError());
+        incomingRuntimeSchema.setFields(fields);
+
+        // Map all of the fields from the runtime Schema to their index.
+        for (Schema.Field f : incomingRuntimeSchema.getFields()) {
+            columnToFieldIndex.put(f.name(), f.pos());
+        }
+
+        // And indicate that initialization is finished.
+        fieldsFromDynamicColumns = null;
+    }
+
+    /**
+     * @return true only if there is a dynamic column and they haven't been finished initializing yet. When this returns
+     * true, the enforcer can't be used yet and {@link #getSchema()} is guaranteed to return null.
+     */
+    public boolean needsInitDynamicColumns() {
+        return fieldsFromDynamicColumns != null;
+    }
+
+    @Override
+    public Schema getSchema() {
+        return incomingRuntimeSchema;
+    }
+
+    public Schema getDesignSchema() {
+        return incomingDesignTimeSchema;
+    }
+
+    public void put(String name, Object v) {
+        put(columnToFieldIndex.get(name), v);
+    }
+
+    @Override
+    public void put(int i, Object v) {
+        if (wrapped == null)
+            wrapped = new Object[incomingRuntimeSchema.getFields().size()];
+
+        // TODO(rskraba): do something other than STRING!
+        wrapped[i] = v == null ? v : String.valueOf(v);
+    }
+
+    @Override
+    public Object get(int i) {
+        return wrapped[i];
+    }
+}

--- a/daikon/src/main/java/org/talend/daikon/talend6/Talend6IncomingSchemaEnforcer.java
+++ b/daikon/src/main/java/org/talend/daikon/talend6/Talend6IncomingSchemaEnforcer.java
@@ -19,6 +19,7 @@ import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
 import org.talend.daikon.avro.util.AvroUtils;
 
@@ -37,12 +38,12 @@ import org.talend.daikon.avro.util.AvroUtils;
  * <p>
  * One instance of this object can be created per incoming schema and reused.
  */
-public class Talend6IncomingSchemaEnforcer implements IndexedRecord, Talend6SchemaConstants {
+public class Talend6IncomingSchemaEnforcer implements Talend6SchemaConstants {
 
     /**
      * The design-time schema from the Studio that determines how incoming java column data will be interpreted.
      */
-    private final Schema incomingDesignTimeSchema;
+    private final Schema incomingDesignSchema;
 
     /**
      * The position of the dynamic column in the incoming schema. This is -1 if there is no dynamic column. There can be
@@ -60,7 +61,7 @@ public class Talend6IncomingSchemaEnforcer implements IndexedRecord, Talend6Sche
     private List<Schema.Field> fieldsFromDynamicColumns = null;
 
     /** The values wrapped by this object. */
-    private Object[] wrapped = null;
+    private GenericData.Record wrapped = null;
 
     /**
      * Access the indexed fields by their name. We should prefer accessing them by index for performance, but this
@@ -69,7 +70,7 @@ public class Talend6IncomingSchemaEnforcer implements IndexedRecord, Talend6Sche
     private final Map<String, Integer> columnToFieldIndex = new HashMap<>();
 
     public Talend6IncomingSchemaEnforcer(Schema incoming) {
-        this.incomingDesignTimeSchema = incoming;
+        this.incomingDesignSchema = incoming;
         this.incomingRuntimeSchema = incoming;
 
         // Find the dynamic column, if any.
@@ -97,8 +98,22 @@ public class Talend6IncomingSchemaEnforcer implements IndexedRecord, Talend6Sche
             return;
 
         // Add each column to the field index and the incoming runtime schema.
-        // TODO(rskraba): do something other than STRING!
-        Schema fieldSchema = Schema.create(Schema.Type.STRING);
+        // TODO(rskraba): validate all types coming from the studio and add annotations.
+        Schema fieldSchema = null;
+        if ("id_String".equals(type)) {
+            fieldSchema = Schema.create(Schema.Type.STRING);
+        } else if ("id_Boolean".equals(type)) {
+            fieldSchema = Schema.create(Schema.Type.BOOLEAN);
+        } else if ("id_Integer".equals(type)) {
+            fieldSchema = Schema.create(Schema.Type.INT);
+        } else if ("id_Long".equals(type)) {
+            fieldSchema = Schema.create(Schema.Type.LONG);
+        } else if ("id_Double".equals(type)) {
+            fieldSchema = Schema.create(Schema.Type.DOUBLE);
+        } else if ("id_Float".equals(type)) {
+            fieldSchema = Schema.create(Schema.Type.FLOAT);
+        }
+
         if (isNullable) {
             fieldSchema = SchemaBuilder.nullable().type(fieldSchema);
         }
@@ -114,23 +129,28 @@ public class Talend6IncomingSchemaEnforcer implements IndexedRecord, Talend6Sche
             return;
 
         // Copy all of the fields that were initialized from dynamic columns into the runtime Schema.
+        boolean dynamicFieldsAdded = false;
         List<Schema.Field> fields = new ArrayList<Schema.Field>();
-        for (Schema.Field designField : incomingDesignTimeSchema.getFields()) {
+        for (Schema.Field designField : incomingDesignSchema.getFields()) {
             // Replace the dynamic column by all of its contents.
             if (designField.pos() == incomingDynamicColumn) {
                 fields.addAll(fieldsFromDynamicColumns);
-            } else {
-                // Make a complete copy of the field (it can't be reused).
-                Schema.Field designFieldCopy = new Schema.Field(designField.name(), designField.schema(), designField.doc(),
-                        designField.defaultVal());
-                for (Map.Entry<String, Object> e : designField.getObjectProps().entrySet()) {
-                    designFieldCopy.addProp(e.getKey(), e.getValue());
-                }
-                fields.add(designFieldCopy);
+                dynamicFieldsAdded = true;
             }
+            // Make a complete copy of the field (it can't be reused).
+            Schema.Field designFieldCopy = new Schema.Field(designField.name(), designField.schema(), designField.doc(),
+                    designField.defaultVal());
+            for (Map.Entry<String, Object> e : designField.getObjectProps().entrySet()) {
+                designFieldCopy.addProp(e.getKey(), e.getValue());
+            }
+            fields.add(designFieldCopy);
         }
-        incomingRuntimeSchema = Schema.createRecord(incomingDesignTimeSchema.getName(), incomingDesignTimeSchema.getDoc(),
-                incomingDesignTimeSchema.getNamespace(), incomingDesignTimeSchema.isError());
+        if (!dynamicFieldsAdded) {
+            fields.addAll(fieldsFromDynamicColumns);
+        }
+
+        incomingRuntimeSchema = Schema.createRecord(incomingDesignSchema.getName(), incomingDesignSchema.getDoc(),
+                incomingDesignSchema.getNamespace(), incomingDesignSchema.isError());
         incomingRuntimeSchema.setFields(fields);
 
         // Map all of the fields from the runtime Schema to their index.
@@ -150,30 +170,100 @@ public class Talend6IncomingSchemaEnforcer implements IndexedRecord, Talend6Sche
         return fieldsFromDynamicColumns != null;
     }
 
-    @Override
-    public Schema getSchema() {
+    public Schema getRuntimeSchema() {
         return incomingRuntimeSchema;
     }
 
     public Schema getDesignSchema() {
-        return incomingDesignTimeSchema;
+        return incomingDesignSchema;
     }
 
     public void put(String name, Object v) {
         put(columnToFieldIndex.get(name), v);
     }
 
-    @Override
     public void put(int i, Object v) {
         if (wrapped == null)
-            wrapped = new Object[incomingRuntimeSchema.getFields().size()];
+            wrapped = new GenericData.Record(getRuntimeSchema());
 
-        // TODO(rskraba): do something other than STRING!
-        wrapped[i] = v == null ? v : String.valueOf(v);
+        if (v == null) {
+            wrapped.put(i, null);
+            return;
+        }
+
+        // TODO(rskraba): check type validation for correctness with studio objects.
+        Schema.Field f = incomingRuntimeSchema.getFields().get(i);
+        Schema fieldSchema = AvroUtils.unwrapIfNullable(f.schema());
+
+        Object datum = null;
+
+        switch (fieldSchema.getType()) {
+        case ARRAY:
+            break;
+        case BOOLEAN:
+            if (v instanceof Boolean)
+                datum = (Boolean) v;
+            else
+                datum = Boolean.valueOf(String.valueOf(v));
+            break;
+        case FIXED:
+        case BYTES:
+            if (v instanceof byte[])
+                datum = (byte[]) v;
+            else
+                datum = String.valueOf(v).getBytes();
+            break;
+        case DOUBLE:
+            if (v instanceof Number)
+                datum = ((Number) v).doubleValue();
+            else
+                datum = Double.valueOf(String.valueOf(v));
+            break;
+        case ENUM:
+            break;
+        case FLOAT:
+            if (v instanceof Number)
+                datum = ((Number) v).floatValue();
+            else
+                datum = Float.valueOf(String.valueOf(v));
+            break;
+        case INT:
+            if (v instanceof Number)
+                datum = ((Number) v).intValue();
+            else
+                datum = Integer.valueOf(String.valueOf(v));
+            break;
+        case LONG:
+            if (v instanceof Number)
+                datum = ((Number) v).longValue();
+            else
+                datum = Long.valueOf(String.valueOf(v));
+            break;
+        case MAP:
+            break;
+        case NULL:
+            datum = null;
+        case RECORD:
+            break;
+        case STRING:
+            datum = String.valueOf(v);
+            break;
+        case UNION:
+            break;
+        default:
+            break;
+        }
+
+        wrapped.put(i, datum);
     }
 
-    @Override
-    public Object get(int i) {
-        return wrapped[i];
+    /**
+     * @return An IndexedRecord created from the values stored in this enforcer and clears out any existing values.
+     */
+    public IndexedRecord createIndexedRecord() {
+        // Send the data to a new instance of IndexedRecord and clear out the existing values.
+        IndexedRecord copy = wrapped;
+        wrapped = null;
+        return copy;
     }
 }

--- a/daikon/src/main/java/org/talend/daikon/talend6/Talend6OutgoingSchemaEnforcer.java
+++ b/daikon/src/main/java/org/talend/daikon/talend6/Talend6OutgoingSchemaEnforcer.java
@@ -60,9 +60,11 @@ public class Talend6OutgoingSchemaEnforcer implements IndexedRecord, Talend6Sche
     private final int outgoingDynamicColumn;
 
     /**
-     * The {@link Schema} of dynamic column, it will be calculated only once and be used for initial routines.system.DynamicMetadata
+     * The {@link Schema} of dynamic column, it will be calculated only once and be used for initial
+     * routines.system.DynamicMetadata
      */
     private Schema outgoingDynamicRuntimeSchema;
+
     /**
      * The name and position of fields in the wrapped record that need to be put into the dynamic column of the output
      * record.
@@ -74,9 +76,8 @@ public class Talend6OutgoingSchemaEnforcer implements IndexedRecord, Talend6Sche
         this.byIndex = byIndex;
 
         // Find the dynamic column, if any.
-        outgoingDynamicColumn = AvroUtils.isIncludeAllFields(outgoing)
-                ? Integer.valueOf(outgoing.getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION))
-                : -1;
+        outgoingDynamicColumn = AvroUtils.isIncludeAllFields(outgoing) ? Integer.valueOf(outgoing
+                .getProp(Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION)) : -1;
     }
 
     /**
@@ -96,8 +97,7 @@ public class Talend6OutgoingSchemaEnforcer implements IndexedRecord, Talend6Sche
             } else {
                 copyFieldList = getDynamicSchemaByName();
             }
-            outgoingDynamicRuntimeSchema = Schema.createRecord("dynamic", null, null,
-                    false);
+            outgoingDynamicRuntimeSchema = Schema.createRecord("dynamic", null, null, false);
             outgoingDynamicRuntimeSchema.setFields(copyFieldList);
         }
     }
@@ -171,11 +171,11 @@ public class Talend6OutgoingSchemaEnforcer implements IndexedRecord, Talend6Sche
     }
 
     /**
-     * @param value        The incoming value for the field. This can be null when null is a valid value, or if there is no
-     *                     corresponding wrapped field.
+     * @param value The incoming value for the field. This can be null when null is a valid value, or if there is no
+     * corresponding wrapped field.
      * @param wrappedField The incoming field description (a valid Avro Schema). This can be null if there is no
-     *                     corresponding wrapped field.
-     * @param outField     The outgoing field description that must be enforced. This must not be null.
+     * corresponding wrapped field.
+     * @param outField The outgoing field description that must be enforced. This must not be null.
      * @return
      */
     private Object transformValue(Object value, Field wrappedField, Field outField) {
@@ -221,8 +221,8 @@ public class Talend6OutgoingSchemaEnforcer implements IndexedRecord, Talend6Sche
     }
 
     /**
-     * @return A list of all of the unresolved columns's schema, when the unresolved columns are determined by the position of the
-     * Dynamic column in enforced schema.
+     * @return A list of all of the unresolved columns's schema, when the unresolved columns are determined by the
+     * position of the Dynamic column in enforced schema.
      */
     private List<Schema.Field> getDynamicSchemaByIndex() {
         List<Schema.Field> fields = new ArrayList<>();
@@ -233,7 +233,6 @@ public class Talend6OutgoingSchemaEnforcer implements IndexedRecord, Talend6Sche
         }
         return fields;
     }
-
 
     /**
      * @return A map of all of the unresolved columns, when the unresolved columns are determined by the names of the
@@ -259,8 +258,8 @@ public class Talend6OutgoingSchemaEnforcer implements IndexedRecord, Talend6Sche
     }
 
     /**
-     * @return A list of all of the unresolved columns's schema, when the unresolved columns are determined by the names of the
-     * resolved column in enforced schema.
+     * @return A list of all of the unresolved columns's schema, when the unresolved columns are determined by the names
+     * of the resolved column in enforced schema.
      */
     private List<Schema.Field> getDynamicSchemaByName() {
         List<Schema.Field> fields = new ArrayList<>();
@@ -277,6 +276,5 @@ public class Talend6OutgoingSchemaEnforcer implements IndexedRecord, Talend6Sche
         }
         return fields;
     }
-
 
 }

--- a/daikon/src/main/java/org/talend/daikon/talend6/Talend6SchemaConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/talend6/Talend6SchemaConstants.java
@@ -76,7 +76,7 @@ public interface Talend6SchemaConstants {
     public final static String TALEND6_COLUMN_SCALE = SchemaConstants.TALEND_COLUMN_SCALE;
 
     public final static String TALEND6_COLUMN_DEFAULT = SchemaConstants.TALEND_COLUMN_DEFAULT;
-    
+
     /** cf TDKN-36. to link to the custom fields of the studio */
     public final static String TALEND6_COLUMN_CUSTOM = "talend6.column.custom"; //$NON-NLS-1$
 

--- a/daikon/src/test/java/org/talend/daikon/talend6/Talend6IncomingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/talend6/Talend6IncomingSchemaEnforcerTest.java
@@ -1,0 +1,139 @@
+package org.talend.daikon.talend6;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.talend.daikon.avro.util.AvroUtils;
+
+/**
+ * Unit tests for {Talend6SchemaOutputEnforcer}.
+ */
+@SuppressWarnings("nls")
+public class Talend6IncomingSchemaEnforcerTest {
+
+    /**
+     * An actual record that a component would like to be emitted, which may or may not contain enriched schema
+     * information.
+     */
+    private IndexedRecord componentRecord;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Before
+    public void setup() {
+        Schema componentSchema = SchemaBuilder.builder().record("Record").fields() //
+                .name("id").type().intType().noDefault() //
+                .name("name").type().stringType().noDefault() //
+                .name("age").type().intType().noDefault() //
+                .name("valid").type().booleanType().noDefault() //
+                .name("address").type().stringType().noDefault() //
+                .name("comment").type().stringType().noDefault() //
+                .endRecord();
+        componentRecord = new GenericData.Record(componentSchema);
+        componentRecord.put(0, 1);
+        componentRecord.put(1, "User");
+        componentRecord.put(2, 100);
+        componentRecord.put(3, true);
+        componentRecord.put(4, "Main Street");
+        componentRecord.put(5, "This is a record with six columns.");
+    }
+
+    @Test
+    public void testDynamicColumn_DynamicColumnAtStart() {
+        // The design time schema after enforcement.
+        Schema talend6Schema = SchemaBuilder.builder().record("Record").fields() //
+                .name("out1").type().bytesType().noDefault() //
+                .name("out2").type().stringType().noDefault() //
+                .name("out3").type().stringType().noDefault() //
+                .endRecord();
+        talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0");
+
+        Talend6IncomingSchemaEnforcer enforcer = new Talend6IncomingSchemaEnforcer(talend6Schema);
+
+        // The enforcer isn't usable yet.
+        assertThat(enforcer.getDesignSchema(), is(talend6Schema));
+        assertThat(enforcer.needsInitDynamicColumns(), is(true));
+        assertThat(enforcer.getSchema(), nullValue());
+
+        enforcer.initDynamicColumn("id", null, "id_String", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("name", null, "id_String", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("age", null, "id_String", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("valid", null, "id_String", null, 0, 0, 0, null, null, false, false, null, null);
+        assertThat(enforcer.needsInitDynamicColumns(), is(true));
+        enforcer.initDynamicColumnsFinished();
+        assertThat(enforcer.needsInitDynamicColumns(), is(false));
+
+        // Check the run-time schema
+        assertThat(enforcer.getDesignSchema(), is(talend6Schema));
+        assertThat(enforcer.getSchema(), not(nullValue()));
+
+        // TODO: other than string... other than non-nullable.
+
+        Schema incomingDynamicRuntimeSchema = enforcer.getSchema();
+        assertThat(incomingDynamicRuntimeSchema.getFields().size(), is(6));
+        assertThat(incomingDynamicRuntimeSchema.getField("id").schema().getType(), is(Schema.Type.STRING));
+        assertThat(incomingDynamicRuntimeSchema.getField("name").schema().getType(), is(Schema.Type.STRING));
+        assertThat(incomingDynamicRuntimeSchema.getField("age").schema().getType(), is(Schema.Type.STRING));
+        assertThat(incomingDynamicRuntimeSchema.getField("valid").schema().getType(), is(Schema.Type.STRING));
+
+        // TODO: check copied properties
+    }
+
+    @Test
+    public void testDynamicColumn_DynamicColumnAtMiddle() {
+        // The expected schema after enforcement.
+        Schema talend6Schema = SchemaBuilder.builder().record("Record").fields() //
+                .name("out1").type().intType().noDefault() //
+                .name("out2").type().bytesType().noDefault() //
+                .name("out3").type().stringType().noDefault() //
+                .endRecord();
+        talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "1");
+
+        Talend6IncomingSchemaEnforcer enforcer = new Talend6IncomingSchemaEnforcer(talend6Schema);
+
+        // TODO
+    }
+
+    @Test
+    public void testDynamicColumn_DynamicColumnAtEnd() {
+        // The expected schema after enforcement.
+        Schema talend6Schema = SchemaBuilder.builder().record("Record").fields() //
+                .name("out1").type().intType().noDefault() //
+                .name("out2").type().stringType().noDefault() //
+                .name("out3").type().bytesType().noDefault() //
+                .endRecord();
+        talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "3");
+
+        Talend6IncomingSchemaEnforcer enforcer = new Talend6IncomingSchemaEnforcer(talend6Schema);
+
+        // TODO
+    }
+
+    @Test
+    public void testDynamicColumn_getOutOfBounds() {
+        Schema talend6Schema = SchemaBuilder.builder().record("Record").fields() //
+                .name("id").type().intType().noDefault() //
+                .endRecord();
+        Talend6OutgoingSchemaEnforcer enforcer = new Talend6OutgoingSchemaEnforcer(talend6Schema, false);
+        enforcer.setWrapped(componentRecord);
+
+        assertThat(enforcer.get(0), is((Object) 1));
+
+        thrown.expect(ArrayIndexOutOfBoundsException.class);
+        enforcer.get(1); // Only one field available.
+    }
+}

--- a/daikon/src/test/java/org/talend/daikon/talend6/Talend6OutgoingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/talend6/Talend6OutgoingSchemaEnforcerTest.java
@@ -60,7 +60,7 @@ public class Talend6OutgoingSchemaEnforcerTest {
                 .name("out3").type().intType().noDefault() //
                 .endRecord();
         talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
-        talend6Schema = AvroUtils.setProperty(talend6Schema,Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0");
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0");
 
         Talend6OutgoingSchemaEnforcer enforcer = new Talend6OutgoingSchemaEnforcer(talend6Schema, true);
 
@@ -101,8 +101,7 @@ public class Talend6OutgoingSchemaEnforcerTest {
                 .name("out3").type().intType().noDefault() //
                 .endRecord();
         talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
-        talend6Schema = AvroUtils.setProperty(talend6Schema,Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "1");
-
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "1");
 
         Talend6OutgoingSchemaEnforcer enforcer = new Talend6OutgoingSchemaEnforcer(talend6Schema, true);
 
@@ -143,8 +142,7 @@ public class Talend6OutgoingSchemaEnforcerTest {
                 .name("out3").type().intType().noDefault() //
                 .endRecord();
         talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
-        talend6Schema = AvroUtils.setProperty(talend6Schema,Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "3");
-
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "3");
 
         Talend6OutgoingSchemaEnforcer enforcer = new Talend6OutgoingSchemaEnforcer(talend6Schema, true);
 
@@ -185,8 +183,7 @@ public class Talend6OutgoingSchemaEnforcerTest {
                 .name("age").type().intType().noDefault() //
                 .endRecord();
         talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
-        talend6Schema = AvroUtils.setProperty(talend6Schema,Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0");
-
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0");
 
         Talend6OutgoingSchemaEnforcer enforcer = new Talend6OutgoingSchemaEnforcer(talend6Schema, false);
 
@@ -227,8 +224,7 @@ public class Talend6OutgoingSchemaEnforcerTest {
                 .name("age").type().intType().noDefault() //
                 .endRecord();
         talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
-        talend6Schema = AvroUtils.setProperty(talend6Schema,Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "1");
-
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "1");
 
         Talend6OutgoingSchemaEnforcer enforcer = new Talend6OutgoingSchemaEnforcer(talend6Schema, false);
 
@@ -269,8 +265,7 @@ public class Talend6OutgoingSchemaEnforcerTest {
                 .name("age").type().intType().noDefault() //
                 .endRecord();
         talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
-        talend6Schema = AvroUtils.setProperty(talend6Schema,Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "3");
-
+        talend6Schema = AvroUtils.setProperty(talend6Schema, Talend6SchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "3");
 
         Talend6OutgoingSchemaEnforcer enforcer = new Talend6OutgoingSchemaEnforcer(talend6Schema, false);
 


### PR DESCRIPTION
For https://jira.talendforge.org/browse/TCOMP-175, we need to make sure that output components are getting an IndexedRecord with the "actual" schema of the discovered data (including dynamic columns).  

It looks like we can do this more efficiently with the same pattern as enforcing outgoing schemas, so I've added the additional helper class, which *should not* be used by other components (and will certainly be moved to DI code with the others from TCOMP-176).

This goes along with https://github.com/Talend/tdi-studio-se/pull/370, but to be discussed here!