### PR TITLE
TDKN-26 Rename the Talend6 Schema constants to refer to 'di' instead …

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/talend6/Talend6SchemaConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/talend6/Talend6SchemaConstants.java
@@ -27,25 +27,25 @@ public interface Talend6SchemaConstants {
      * Can apply to table and columns. --------------------------------------
      */
 
-    public final static String TALEND6_ID = "talend6.column.id"; //$NON-NLS-1$
+    public final static String TALEND6_ID = "di.column.id"; //$NON-NLS-1$
 
-    public final static String TALEND6_COMMENT = "talend6.table.comment"; //$NON-NLS-1$
+    public final static String TALEND6_COMMENT = "di.table.comment"; //$NON-NLS-1$
 
-    public final static String TALEND6_LABEL = "talend6.table.label"; //$NON-NLS-1$
+    public final static String TALEND6_LABEL = "di.table.label"; //$NON-NLS-1$
 
     /** Property is present if readonly, otherwise not present. */
     public final static String TALEND6_IS_READ_ONLY = SchemaConstants.TALEND_IS_LOCKED; //$NON-NLS-1$
 
     /** The key will have this as a prefix, pointing to the value. */
-    public final static String TALEND6_ADDITIONAL_PROPERTIES = "talend6.prop."; //$NON-NLS-1$
+    public final static String TALEND6_ADDITIONAL_PROPERTIES = "di.prop."; //$NON-NLS-1$
 
     /*
      * Table custom properties. ---------------------------------------------
      */
 
-    public final static String TALEND6_TABLE_NAME = "talend6.table.name"; //$NON-NLS-1$
+    public final static String TALEND6_TABLE_NAME = "di.table.name"; //$NON-NLS-1$
 
-    public final static String TALEND6_TABLE_TYPE = "talend6.table.type"; //$NON-NLS-1$
+    public final static String TALEND6_TABLE_TYPE = "di.table.type"; //$NON-NLS-1$
 
     /*
      * Column custom properties. --------------------------------------------
@@ -56,7 +56,7 @@ public interface Talend6SchemaConstants {
 
     public final static String TALEND6_COLUMN_SOURCE_TYPE = SchemaConstants.TALEND_COLUMN_DB_TYPE;
 
-    public final static String TALEND6_COLUMN_TALEND_TYPE = "talend6.column.talendType"; //$NON-NLS-1$
+    public final static String TALEND6_COLUMN_TALEND_TYPE = "di.column.talendType"; //$NON-NLS-1$
 
     public final static String TALEND6_COLUMN_PATTERN = SchemaConstants.TALEND_COLUMN_PATTERN;
 
@@ -64,10 +64,10 @@ public interface Talend6SchemaConstants {
     public final static String TALEND6_COLUMN_LENGTH = SchemaConstants.TALEND_COLUMN_DB_LENGTH;
 
     /** String representation of an int. */
-    public final static String TALEND6_COLUMN_ORIGINAL_LENGTH = "talend6.column.originalLength"; //$NON-NLS-1$
+    public final static String TALEND6_COLUMN_ORIGINAL_LENGTH = "di.column.originalLength"; //$NON-NLS-1$
 
     /** Property is present if nullable, otherwise not present. */
-    public final static String TALEND6_COLUMN_IS_NULLABLE = "talend6.column.isNullable"; //$NON-NLS-1$
+    public final static String TALEND6_COLUMN_IS_NULLABLE = "di.column.isNullable"; //$NON-NLS-1$
 
     /** String representation of an int. */
     public final static String TALEND6_COLUMN_PRECISION = SchemaConstants.TALEND_COLUMN_PRECISION;
@@ -78,26 +78,26 @@ public interface Talend6SchemaConstants {
     public final static String TALEND6_COLUMN_DEFAULT = SchemaConstants.TALEND_COLUMN_DEFAULT;
 
     /** cf TDKN-36. to link to the custom fields of the studio */
-    public final static String TALEND6_COLUMN_CUSTOM = "talend6.column.custom"; //$NON-NLS-1$
+    public final static String TALEND6_COLUMN_CUSTOM = "di.column.custom"; //$NON-NLS-1$
 
     public final static String TALEND6_COLUMN_ORIGINAL_DB_COLUMN_NAME = SchemaConstants.TALEND_COLUMN_DB_COLUMN_NAME;
 
-    public final static String TALEND6_COLUMN_RELATED_ENTITY = "talend6.column.relatedEntity"; //$NON-NLS-1$
+    public final static String TALEND6_COLUMN_RELATED_ENTITY = "di.column.relatedEntity"; //$NON-NLS-1$
 
-    public final static String TALEND6_COLUMN_RELATIONSHIP_TYPE = "talend6.column.relationshipType"; //$NON-NLS-1$
+    public final static String TALEND6_COLUMN_RELATIONSHIP_TYPE = "di.column.relationshipType"; //$NON-NLS-1$
 
-    public final static String TALEND6_DYNAMIC_COLUMN_POSITION = "talend6.dynamic.column.position"; //$NON-NLS-1$
+    public final static String TALEND6_DYNAMIC_COLUMN_POSITION = "di.dynamic.column.position"; //$NON-NLS-1$
 
-    public final static String TALEND6_DYNAMIC_COLUMN_NAME = "talend6.dynamic.column.name"; //$NON-NLS-1$
+    public final static String TALEND6_DYNAMIC_COLUMN_NAME = "di.dynamic.column.name"; //$NON-NLS-1$
 
-    public final static String TALEND6_DYNAMIC_COLUMN_ID = "talend6.dynamic.column.id"; //$NON-NLS-1$
+    public final static String TALEND6_DYNAMIC_COLUMN_ID = "di.dynamic.column.id"; //$NON-NLS-1$
 
-    public final static String TALEND6_DYNAMIC_COLUMN_COMMENT = "talend6.dynamic.column.comment"; //$NON-NLS-1$
+    public final static String TALEND6_DYNAMIC_COLUMN_COMMENT = "di.dynamic.column.comment"; //$NON-NLS-1$
 
     /** Property is present if readonly, otherwise not present. */
-    public final static String TALEND6_DYNAMIC_IS_READ_ONLY = "talend6.dynamic.readOnly"; //$NON-NLS-1$
+    public final static String TALEND6_DYNAMIC_IS_READ_ONLY = "di.dynamic.readOnly"; //$NON-NLS-1$
 
     /** The key will have this as a prefix, pointing to the value. */
-    public final static String TALEND6_DYNAMIC_ADDITIONAL_PROPERTIES = "talend6.dynamic.prop."; //$NON-NLS-1$
+    public final static String TALEND6_DYNAMIC_ADDITIONAL_PROPERTIES = "di.dynamic.prop."; //$NON-NLS-1$
 
 }


### PR DESCRIPTION
…of 'talend6'

This *might* break jobs that were created with Talend 6.2.0RC1 and before, but should be done before Talend 6.2.0GA.

I was unable to test the impact, so we might want to wait until after the GA and do the conversion with a mapping table between 6.2.0 and 6.2.1.