### PR TITLE
TDKN-47 : changet WidgetType into a String, for easy extension.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/presentation/Widget.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/presentation/Widget.java
@@ -25,77 +25,77 @@ import org.talend.daikon.strings.ToStringIndentUtil;
  */
 public class Widget implements ToStringIndent {
 
-    public enum WidgetType {
-        /**
-         * No special widget is requested, the default for the property's type is to be used.
-         */
-        DEFAULT,
+    /**
+     * No special widget is requested, the default for the property's type is to be used.
+     */
+    public static final String DEFAULT_WIDGET_TYPE = "widget.type.default";
 
-        /**
-         * Presentation of a schema editor.
-         */
-        SCHEMA_EDITOR,
+    /**
+     * Presentation of a schema editor.
+     */
+    public static final String SCHEMA_EDITOR_WIDGET_TYPE = "widget.type.schema.editor";
 
-        /**
-         * Presentation of a reference to a schema on one line. This shows the name of the schema and provides a button
-         * to open the schema editor/viewer in a dialog.
-         */
-        SCHEMA_REFERENCE,
+    /**
+     * Presentation of a reference to a schema on one line. This shows the name of the schema and provides a button
+     * to open the schema editor/viewer in a dialog.
+     */
+    public static final String SCHEMA_REFERENCE_WIDGET_TYPE = "widget.type.schema.reference";
 
-        /**
-         * Provides a means of selecting a name or name/description from a set of names, possibly arranged in a
-         * hierarchy. This is to be used for a large number of names, as this has search capability.
-         *
-         * The NAME_SELECTION_AREA will operate on a property whose occur max times is -1, and whose possible values can be picked
-         * in {@code List<NamedThing>} and that will set the values as another {@code List<NamedThing>}. It will show everything
-         * on the list and then once complete will set the values of the list only to those that are selected.
-         */
-        NAME_SELECTION_AREA,
+    /**
+     * Provides a means of selecting a name or name/description from a set of names, possibly arranged in a
+     * hierarchy. This is to be used for a large number of names, as this has search capability.
+     *
+     * The NAME_SELECTION_AREA will operate on a property whose occur max times is -1, and whose possible values can be picked
+     * in {@code List<NamedThing>} and that will set the values as another {@code List<NamedThing>}. It will show everything
+     * on the list and then once complete will set the values of the list only to those that are selected.
+     */
+    public static final String NAME_SELECTION_AREA_WIDGET_TYPE = "widget.type.name.selection.area";
 
-        /**
-         * A reference to a named selection. This just shows the selected name and a button to get a dialog that has the
-         * {@link #NAME_SELECTION_AREA}.
-         */
-        NAME_SELECTION_REFERENCE,
+    /**
+     * A reference to a named selection. This just shows the selected name and a button to get a dialog that has the
+     * {@link #NAME_SELECTION_AREA}.
+     */
+    public static final String NAME_SELECTION_REFERENCE_WIDGET_TYPE = "widget.type.name.selection.widget";
 
-        /**
-         * A reference to a component. This could be a reference to this component, another single component in the
-         * enclosing scope's type, or a specified component instance. This is rendered as a single line with the type of
-         * reference in a combo box. This is only used with the components system in conjunction with the
-         * {@code ComponentReferenceProperties}.
-         */
-        COMPONENT_REFERENCE,
+    /**
+     * A reference to a component. This could be a reference to this component, another single component in the
+     * enclosing scope's type, or a specified component instance. This is rendered as a single line with the type of
+     * reference in a combo box. This is only used with the components system in conjunction with the
+     * {@code ComponentReferenceProperties}.
+     */
+    public static final String COMPONENT_REFERENCE_WIDGET_TYPE = "widget.type.component.reference";
 
-        /**
-         * A button
-         */
-        BUTTON,
+    /**
+     * A button
+     */
+    public static final String BUTTON_WIDGET_TYPE = "widget.type.button";
 
-        /**
-         * A table, the widget content shall be a {@link Properties} that will provide a MAIN form (see
-         * {@link Form#MAIN}). The main form shall contain a list of widget that will represent each table column and
-         * which content should be a Property. Each Property is going to be used as the column definition, the
-         * {@link Property#getDisplayName()} shall be used as the Column header. Each Property (=column) has a value of
-         * type List<T> in which the first element is the first row element for this column and the second in the list
-         * is the second row value for this column.
-         * 
-         */
-        TABLE,
-        /*
-         * a Text editable widget that hides the text to the user, mainly used for passwords.
-         */
-        HIDDEN_TEXT,
-        /*
-         * a File widget.
-         */
-        FILE,
-        /**
-         * Tell the client that the property possible values ({@link Property#getPossibleValues()} must be used as
-         * unique choice for the value of the property.
-         **/
-        ENUMERATION
+    /**
+     * A table, the widget content shall be a {@link Properties} that will provide a MAIN form (see
+     * {@link Form#MAIN}). The main form shall contain a list of widget that will represent each table column and
+     * which content should be a Property. Each Property is going to be used as the column definition, the
+     * {@link Property#getDisplayName()} shall be used as the Column header. Each Property (=column) has a value of
+     * type List<T> in which the first element is the first row element for this column and the second in the list
+     * is the second row value for this column.
+     * 
+     */
+    public static final String TABLE_WIDGET_TYPE = "widget.type.table";
 
-    }
+    /*
+     * a Text editable widget that hides the text to the user, mainly used for passwords.
+     */
+    public static final String HIDDEN_TEXT_WIDGET_TYPE = "widget.type.hidden.text";
+
+    /*
+     * a File widget.
+     */
+    public static final String FILE_WIDGET_TYPE = "widget.type.file";
+
+    /**
+     * Tell the client that the property possible values ({@link Property#getPossibleValues()} must be used as
+     * unique choice for the value of the property.
+     **/
+    public static final String ENUMERATION_WIDGET_TYPE = "widget.type.enumeration";
 
     /**
      * The row in the form where this property is to be presented. Starting with 1.
@@ -113,7 +113,7 @@ public class Widget implements ToStringIndent {
      * The type of widget to be used to express this property. This is used only if there is a choice given the type of
      * property.
      */
-    private WidgetType widgetType = WidgetType.DEFAULT;
+    private String widgetType = DEFAULT_WIDGET_TYPE;
 
     /**
      * Is the validation associated with this expected to be long running (so that the UI should give a wait indication.
@@ -192,11 +192,11 @@ public class Widget implements ToStringIndent {
         return hidden;
     }
 
-    public WidgetType getWidgetType() {
+    public String getWidgetType() {
         return widgetType;
     }
 
-    public Widget setWidgetType(WidgetType widgetType) {
+    public Widget setWidgetType(String widgetType) {
         this.widgetType = widgetType;
         return this;
     }
@@ -228,7 +228,7 @@ public class Widget implements ToStringIndent {
     }
 
     public void setCallBefore(boolean callBefore) {
-        if (widgetType == WidgetType.SCHEMA_REFERENCE || widgetType == WidgetType.NAME_SELECTION_REFERENCE) {
+        if (widgetType == SCHEMA_REFERENCE_WIDGET_TYPE || widgetType == NAME_SELECTION_REFERENCE_WIDGET_TYPE) {
             this.callBeforeActivate = callBefore;
             this.callBeforePresent = !callBefore;
         } else {

--- a/daikon/src/test/java/org/talend/daikon/properties/testproperties/TestProperties.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/testproperties/TestProperties.java
@@ -29,7 +29,6 @@ import org.talend.daikon.properties.ValidationResult;
 import org.talend.daikon.properties.ValidationResult.Result;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.presentation.Widget;
-import org.talend.daikon.properties.presentation.Widget.WidgetType;
 import org.talend.daikon.properties.service.Repository;
 import org.talend.daikon.properties.testproperties.nestedprop.NestedProperties;
 import org.talend.daikon.properties.testproperties.nestedprop.inherited.InheritedProperties;
@@ -125,10 +124,10 @@ public class TestProperties extends Properties {
         Form form = Form.create(this, Form.MAIN);
         mainForm = form;
         form.addRow(userId);
-        form.addRow(widget(password).setWidgetType(WidgetType.HIDDEN_TEXT));
+        form.addRow(widget(password).setWidgetType(HIDDEN_TEXT_WIDGET_TYPE));
         form.addRow(testPI);
-        form.addRow(widget(nameList).setWidgetType(Widget.WidgetType.NAME_SELECTION_AREA));
-        form.addRow(widget(nameListRef).setWidgetType(Widget.WidgetType.NAME_SELECTION_REFERENCE));
+        form.addRow(widget(nameList).setWidgetType(Widget.NAME_SELECTION_AREA_WIDGET_TYPE));
+        form.addRow(widget(nameListRef).setWidgetType(Widget.NAME_SELECTION_REFERENCE_WIDGET_TYPE));
 
         form = Form.create(this, "restoreTest");
         restoreForm = form;


### PR DESCRIPTION
Widget type was an enum but was too closed and not open to free widget so I changed the type to a simple String and transformed all existing widgets to static final strings of the Widget class.
Please do not merge until the Studio has been adapted, it breaks the APIs.