### PR TITLE
TDM-5337 Share TDM avro schema custom properties in DAIKON

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/avro/SchemaEDIConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/SchemaEDIConstants.java
@@ -3,7 +3,12 @@ package org.talend.daikon.avro;
 /**
  * Constants and enums used to augment avro schema for EDI representations.
  * <p/>
- * Used when Avro schema represents an EDI document.
+ * Used when an Avro schema represents an EDI document.
+ * <p/>
+ * Complements {@link SchemaExternalConstants}
+ * <p/>
+ * The properties described here are intended for those systems that need to
+ * manipulate EDI data. All other systems can safely ignore them.
  *
  */
 public final class SchemaEDIConstants {
@@ -15,13 +20,13 @@ public final class SchemaEDIConstants {
     }
 
     /**
-     * EDI element type. @link(EDIElementType) for possible values.
+     * EDI element type. {@link EDIElementType} for possible values.
      * <p/>
      * Avro schema type level.
      * <p/>
      * Optional. When omitted, defaults to ELEMENT.
      */
-    public static final String EDI_ELEM_TYPE_PROPERTY = "talend.edi.element.type";
+    public static final String EDI_ELEM_TYPE = "talend.edi.element.type";
 
     /**
      * In EDI, a reference to the corresponding specifications.
@@ -30,7 +35,7 @@ public final class SchemaEDIConstants {
      * <p/>
      * Optional.
      */
-    public static final String EDI_ELEM_REF_PROPERTY = "talend.edi.element.ref";
+    public static final String EDI_ELEM_REF = "talend.edi.element.ref";
 
     /**
      * An EDI type for an element. These match classical EDI types.

--- a/daikon/src/main/java/org/talend/daikon/avro/SchemaEDIConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/SchemaEDIConstants.java
@@ -11,7 +11,8 @@ public final class SchemaEDIConstants {
     /**
      * This utility class is best used as a static import.
      */
-    private SchemaEDIConstants() {}
+    private SchemaEDIConstants() {
+    }
 
     /**
      * EDI element type. @link(EDIElementType) for possible values.
@@ -35,7 +36,11 @@ public final class SchemaEDIConstants {
      * An EDI type for an element. These match classical EDI types.
      */
     public enum EDIElementType {
-        TRANSACTION, SEGMENT, COMPOSITE, LOOP, ELEMENT
+        TRANSACTION,
+        SEGMENT,
+        COMPOSITE,
+        LOOP,
+        ELEMENT
     };
 
 }

--- a/daikon/src/main/java/org/talend/daikon/avro/SchemaEDIConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/SchemaEDIConstants.java
@@ -1,0 +1,41 @@
+package org.talend.daikon.avro;
+
+/**
+ * Constants and enums used to augment avro schema for EDI representations.
+ * <p/>
+ * Used when Avro schema represents an EDI document.
+ *
+ */
+public final class SchemaEDIConstants {
+
+    /**
+     * This utility class is best used as a static import.
+     */
+    private SchemaEDIConstants() {}
+
+    /**
+     * EDI element type. @link(EDIElementType) for possible values.
+     * <p/>
+     * Avro schema type level.
+     * <p/>
+     * Optional. When omitted, defaults to ELEMENT.
+     */
+    public static final String EDI_ELEM_TYPE_PROPERTY = "talend.edi.element.type";
+
+    /**
+     * In EDI, a reference to the corresponding specifications.
+     * <p/>
+     * Avro schema type level property for "type": "record" and "type": "enum".
+     * <p/>
+     * Optional.
+     */
+    public static final String EDI_ELEM_REF_PROPERTY = "talend.edi.element.ref";
+
+    /**
+     * An EDI type for an element. These match classical EDI types.
+     */
+    public enum EDIElementType {
+        TRANSACTION, SEGMENT, COMPOSITE, LOOP, ELEMENT
+    };
+
+}

--- a/daikon/src/main/java/org/talend/daikon/avro/SchemaExternalConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/SchemaExternalConstants.java
@@ -1,0 +1,131 @@
+package org.talend.daikon.avro;
+
+
+/**
+ * Constants and enums used for avro schema custom properties.
+ * <p/>
+ * When an avro schema is built from external metadata or used to read/write
+ * from non-avro sources, avro schema primitives may not be enough to represent
+ * the external metadata semantics.
+ *
+ */
+public final class SchemaExternalConstants {
+
+    /**
+     * This utility class is best used as a static import.
+     */
+    private SchemaExternalConstants() {}
+
+    // -------------------------------------------------------------------------
+    // General purpose properties
+    // -------------------------------------------------------------------------
+    /**
+     * Element name in source/target system if it differs from the avro name.
+     * <p/>
+     * Avro schema type level property for "type": "record" and "type": "enum"
+     * and Field level for all types.
+     * <p/>
+     * Optional. Only needed when original name contains characters that avro
+     * does not support (These characters are usually replaced with underscore
+     * to form a valid Avro name).
+     */
+    public static final String ORIGINAL_NAME_PROPERTY = "talend.original.name";
+
+    /**
+     * For a string and other bounded simple types, indicates the maximum number
+     * of characters.
+     * <p/>
+     * Avro schema type level property for "type": "string" and "type": "enum".
+     * <p/>
+     * Optional. By default, strings are unbounded.
+     */
+    public static final String MAX_LENGTH_PROPERTY = "talend.max.len";
+
+    /**
+     * For an enum, provides a description for each of the symbols.
+     * <p/>
+     * labels are separated by the pipe character. labels are is the exact order
+     * of symbols.
+     * <p/>
+     * Avro schema type level for "type": "enum".
+     * <p/>
+     * Optional. By default, the description is the symbol itself.
+     */
+    public static final String ENUM_LABELS_PROPERTY = "talend.enum.labels";
+
+    /**
+     * Sequence number of a field within its parent record.
+     * <p/>
+     * This is useful when there is some reason the original sequence numbering
+     * was not preserved in the avro schema.
+     * <p/>
+     * Avro schema field level.
+     * <p/>
+     * Optional. By default, sequence number is the order of the field within
+     * its parent.
+     */
+    public static final String FIELD_SEQNO_PROPERTY = "talend.field.seqno";
+
+    /**
+     * For a bounded array, indicates the upper bound if any.
+     * <p/>
+     * Avro schema field level. Field must be of "type": "array".
+     * <p/>
+     * Optional. Arrays in avro are always unbounded. if there is an upper
+     * bound, we use this extra property.
+     */
+    public static final String MAX_OCCURS_PROPERTY = "talend.max.occurs";
+
+    /**
+     * In the original system, invisible elements do not appear but their
+     * children do. Usually needed when elements need to be grouped but the
+     * group itself must not be materialized (and is therefore invisible). When
+     * such an element is materialized in the Avro schema, this custom property
+     * preserves the "invisible" character of the field in the original system.
+     * <p/>
+     * Avro schema field level.
+     * <p/>
+     * Optional. By default, elements are visible.
+     */
+    public static final String FIELD_INVISIBLE_PROPERTY = "talend.field.invisible";
+
+    // -------------------------------------------------------------------------
+    // Storage related properties
+    // -------------------------------------------------------------------------
+    /**
+     * When structures must be implemented as standalone, reusable, this is
+     * the relative path where the standalone structure should be stored.
+     * <p/>
+     * Reusable structures are referenced by other structures.
+     * <p/>
+     * Avro schema type level property for "type": "record" and "type": "enum".
+     * <p/>
+     * Optional.
+     */
+    public static final String STORE_PATH_PROPERTY = "talend.store.path";
+
+    // -------------------------------------------------------------------------
+    // Representation properties
+    // -------------------------------------------------------------------------
+    /**
+     * Indicates the representation that should be associated to this
+     * structure by default.
+     * <p/>
+     * Avro schema type level property for "type": "record".
+     * <p/>
+     * Optional. By default, the representation will be avro. Otherwise
+     * use the {@link Representation} Enum.
+     */
+    public static final String DEFAULT_REP_PROPERTY = "talend.default.rep";
+
+    /**
+     * An external representation. These are the various external formats
+     * structures can be serialized to or deserialized from.
+     */
+    public enum Representation {
+        XML, JSON, AVRO, X12, EDIFACT, HL7V2, COBOL, TEXT_DELIMITED, TEXT_POSITIONAL, SAP_IDOC, JAVA, MAP, NCPDP, DATABASE
+    };
+
+
+
+}

--- a/daikon/src/main/java/org/talend/daikon/avro/SchemaExternalConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/SchemaExternalConstants.java
@@ -1,6 +1,5 @@
 package org.talend.daikon.avro;
 
-
 /**
  * Constants and enums used for avro schema custom properties.
  * <p/>
@@ -14,7 +13,8 @@ public final class SchemaExternalConstants {
     /**
      * This utility class is best used as a static import.
      */
-    private SchemaExternalConstants() {}
+    private SchemaExternalConstants() {
+    }
 
     // -------------------------------------------------------------------------
     // General purpose properties
@@ -123,9 +123,20 @@ public final class SchemaExternalConstants {
      * structures can be serialized to or deserialized from.
      */
     public enum Representation {
-        XML, JSON, AVRO, X12, EDIFACT, HL7V2, COBOL, TEXT_DELIMITED, TEXT_POSITIONAL, SAP_IDOC, JAVA, MAP, NCPDP, DATABASE
+        XML,
+        JSON,
+        AVRO,
+        X12,
+        EDIFACT,
+        HL7V2,
+        COBOL,
+        TEXT_DELIMITED,
+        TEXT_POSITIONAL,
+        SAP_IDOC,
+        JAVA,
+        MAP,
+        NCPDP,
+        DATABASE
     };
-
-
 
 }

--- a/daikon/src/main/java/org/talend/daikon/avro/SchemaExternalConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/SchemaExternalConstants.java
@@ -1,11 +1,14 @@
 package org.talend.daikon.avro;
 
 /**
- * Constants and enums used for avro schema custom properties.
+ * Constants and enums used for external avro schema custom properties.
  * <p/>
  * When an avro schema is built from external metadata or used to read/write
  * from non-avro sources, avro schema primitives may not be enough to represent
  * the external metadata semantics.
+ * <p/>
+ * The properties described here are intended for those systems that need to
+ * manipulate such external data. All other systems can safely ignore them.
  *
  */
 public final class SchemaExternalConstants {
@@ -29,7 +32,7 @@ public final class SchemaExternalConstants {
      * does not support (These characters are usually replaced with underscore
      * to form a valid Avro name).
      */
-    public static final String ORIGINAL_NAME_PROPERTY = "talend.original.name";
+    public static final String ORIGINAL_NAME = "talend.original.name";
 
     /**
      * For a string and other bounded simple types, indicates the maximum number
@@ -39,7 +42,7 @@ public final class SchemaExternalConstants {
      * <p/>
      * Optional. By default, strings are unbounded.
      */
-    public static final String MAX_LENGTH_PROPERTY = "talend.max.len";
+    public static final String MAX_LENGTH = "talend.max.len";
 
     /**
      * For an enum, provides a description for each of the symbols.
@@ -51,7 +54,7 @@ public final class SchemaExternalConstants {
      * <p/>
      * Optional. By default, the description is the symbol itself.
      */
-    public static final String ENUM_LABELS_PROPERTY = "talend.enum.labels";
+    public static final String ENUM_LABELS = "talend.enum.labels";
 
     /**
      * Sequence number of a field within its parent record.
@@ -64,7 +67,7 @@ public final class SchemaExternalConstants {
      * Optional. By default, sequence number is the order of the field within
      * its parent.
      */
-    public static final String FIELD_SEQNO_PROPERTY = "talend.field.seqno";
+    public static final String FIELD_SEQNO = "talend.field.seqno";
 
     /**
      * For a bounded array, indicates the upper bound if any.
@@ -74,7 +77,7 @@ public final class SchemaExternalConstants {
      * Optional. Arrays in avro are always unbounded. if there is an upper
      * bound, we use this extra property.
      */
-    public static final String MAX_OCCURS_PROPERTY = "talend.max.occurs";
+    public static final String MAX_OCCURS = "talend.max.occurs";
 
     /**
      * In the original system, invisible elements do not appear but their
@@ -87,28 +90,34 @@ public final class SchemaExternalConstants {
      * <p/>
      * Optional. By default, elements are visible.
      */
-    public static final String FIELD_INVISIBLE_PROPERTY = "talend.field.invisible";
+    public static final String FIELD_INVISIBLE = "talend.field.invisible";
 
     // -------------------------------------------------------------------------
     // Storage related properties
     // -------------------------------------------------------------------------
     /**
-     * When structures must be implemented as standalone, reusable, this is
-     * the relative path where the standalone structure should be stored.
+     * An avro schema may correspond to a number of external structures. Worst
+     * case is every record and every enum in the avro schema is a separate
+     * structure (this is an extreme case).
+     * <p§/>
+     * In multi-structure systems, structures need a location to store them.
+     * This property preserves such location so that the structure could be
+     * created in the correct place when the avro schema is imported.
      * <p/>
-     * Reusable structures are referenced by other structures.
+     * This is some kind of path that the multi-structure system understands.
+     * This is not necessarily a file system location or URI.
      * <p/>
      * Avro schema type level property for "type": "record" and "type": "enum".
      * <p/>
      * Optional.
      */
-    public static final String STORE_PATH_PROPERTY = "talend.store.path";
+    public static final String STORE_PATH = "talend.store.path";
 
     // -------------------------------------------------------------------------
     // Representation properties
     // -------------------------------------------------------------------------
     /**
-     * Indicates the representation that should be associated to this
+     * Indicates the representation that should be associated with this
      * structure by default.
      * <p/>
      * Avro schema type level property for "type": "record".
@@ -116,7 +125,7 @@ public final class SchemaExternalConstants {
      * Optional. By default, the representation will be avro. Otherwise
      * use the {@link Representation} Enum.
      */
-    public static final String DEFAULT_REP_PROPERTY = "talend.default.rep";
+    public static final String DEFAULT_REP = "talend.default.rep";
 
     /**
      * An external representation. These are the various external formats


### PR DESCRIPTION
This is the first attempt at sharing some avro schema custom properties needed for TDM.  In the long term, TDM will require more custom properties than these but this should get us started for 6.3.0.

Rather than modifying the SchemaConstants class, I have created 2 new classes. It seems cleaner to have smaller, specialized, classes rather than a massive multipurpose one.