### PR TITLE
fix (TDI-37525): add missing type mapping when DiIncomingSchemaEnforcer initialize dynamic column

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/di/DiIncomingSchemaEnforcer.java
+++ b/daikon/src/main/java/org/talend/daikon/di/DiIncomingSchemaEnforcer.java
@@ -12,6 +12,7 @@
 // ============================================================================
 package org.talend.daikon.di;
 
+import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -25,8 +26,8 @@ import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
-import org.talend.daikon.avro.SchemaConstants;
 import org.talend.daikon.avro.AvroUtils;
+import org.talend.daikon.avro.SchemaConstants;
 
 /**
  * <b>You should almost certainly not be using this class.</b>
@@ -120,6 +121,16 @@ public class DiIncomingSchemaEnforcer implements DiSchemaConstants {
             fieldSchema = Schema.create(Schema.Type.DOUBLE);
         } else if ("id_Float".equals(type)) {
             fieldSchema = Schema.create(Schema.Type.FLOAT);
+        } else if ("id_Byte".equals(type)) {
+            fieldSchema = AvroUtils._byte();
+        } else if ("id_Short".equals(type)) {
+            fieldSchema = AvroUtils._short();
+        } else if ("id_BigDecimal".equals(type)) {
+            fieldSchema = AvroUtils._decimal();
+        } else if ("id_Date".equals(type)) {
+            fieldSchema = AvroUtils._date();
+        } else {
+            throw new UnsupportedOperationException("Unrecognized type " + type);
         }
 
         if (isNullable) {
@@ -237,6 +248,14 @@ public class DiIncomingSchemaEnforcer implements DiSchemaConstants {
                 } catch (ParseException e) {
                     throw new RuntimeException(e);
                 }
+            }
+        }
+
+        if ("id_BigDecimal".equals(talendType) || "java.math.BigDecimal".equals(javaClass)) {
+            if (v instanceof BigDecimal) {
+                datum = v;
+            } else if (v instanceof String) {
+                datum = new BigDecimal((String) v);
             }
         }
 

--- a/daikon/src/main/java/org/talend/daikon/di/DiIncomingSchemaEnforcer.java
+++ b/daikon/src/main/java/org/talend/daikon/di/DiIncomingSchemaEnforcer.java
@@ -125,6 +125,8 @@ public class DiIncomingSchemaEnforcer implements DiSchemaConstants {
             fieldSchema = AvroUtils._byte();
         } else if ("id_Short".equals(type)) {
             fieldSchema = AvroUtils._short();
+        } else if ("id_Character".equals(type)) {
+            fieldSchema = AvroUtils._character();
         } else if ("id_BigDecimal".equals(type)) {
             fieldSchema = AvroUtils._decimal();
         } else if ("id_Date".equals(type)) {
@@ -136,7 +138,12 @@ public class DiIncomingSchemaEnforcer implements DiSchemaConstants {
         if (isNullable) {
             fieldSchema = SchemaBuilder.nullable().type(fieldSchema);
         }
-        fieldsFromDynamicColumns.add(new Schema.Field(name, fieldSchema, description, (Object) null));
+        Schema.Field field = new Schema.Field(name, fieldSchema, description, (Object) null);
+        // Set pattern for date type
+        if ("id_Date".equals(type) && format != null) {
+            field.addProp(SchemaConstants.TALEND_COLUMN_PATTERN, format);
+        }
+        fieldsFromDynamicColumns.add(field);
     }
 
     /**
@@ -218,7 +225,7 @@ public class DiIncomingSchemaEnforcer implements DiSchemaConstants {
 
         // TODO(rskraba): This is pretty rough -- fix with a general type conversion strategy.
         String talendType = f.getProp(DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE);
-        String javaClass = f.schema().getProp(SchemaConstants.JAVA_CLASS_FLAG);
+        String javaClass = fieldSchema.getProp(SchemaConstants.JAVA_CLASS_FLAG);
         if ("id_Date".equals(talendType) || "java.util.Date".equals(javaClass)) {
             if (v instanceof Date) {
                 datum = v;

--- a/daikon/src/test/java/org/talend/daikon/di/DiIncomingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DiIncomingSchemaEnforcerTest.java
@@ -19,6 +19,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.talend.daikon.avro.AvroUtils;
+import org.talend.daikon.avro.SchemaConstants;
 
 /**
  * Unit tests for {DiIncomingSchemaEnforcer}.
@@ -242,7 +243,10 @@ public class DiIncomingSchemaEnforcerTest {
                 .endRecord();
         talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
         talend6Schema = AvroUtils.setProperty(talend6Schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0");
+        talend6Schema = AvroUtils.setProperty(talend6Schema, DiSchemaConstants.TALEND6_COLUMN_PATTERN,
+                "yyyy-MM-dd'T'HH:mm:ss'000Z'");
 
+        // 1) Test all type which supported in dynamic
         DiIncomingSchemaEnforcer enforcer = new DiIncomingSchemaEnforcer(talend6Schema);
 
         // The enforcer isn't usable yet.
@@ -257,9 +261,11 @@ public class DiIncomingSchemaEnforcerTest {
         enforcer.initDynamicColumn("Test_Double", null, "id_Double", null, 0, 0, 0, null, null, false, false, null, null);
         enforcer.initDynamicColumn("Test_Float", null, "id_Float", null, 0, 0, 0, null, null, false, false, null, null);
         enforcer.initDynamicColumn("Test_BigDecimal", null, "id_BigDecimal", null, 0, 0, 0, null, null, false, false, null, null);
-        enforcer.initDynamicColumn("Test_Date", null, "id_Date", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Date", null, "id_Date", null, 0, 0, 0, "yyyy-MM-dd'T'HH:mm:ss'000Z'", null, false, false,
+                null, null);
         enforcer.initDynamicColumn("Test_Byte", null, "id_Byte", null, 0, 0, 0, null, null, false, false, null, null);
         enforcer.initDynamicColumn("Test_Short", null, "id_Short", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Character", null, "id_Character", null, 0, 0, 0, null, null, false, true, null, null);
         try {
             // Throw an exception rather than put schema null to avoid NPE
             enforcer.initDynamicColumn("Test_Unsupported", null, "id_Unsupported", null, 0, 0, 0, null, null, false, false, null,
@@ -286,6 +292,9 @@ public class DiIncomingSchemaEnforcerTest {
         enforcer.put(7, new Date(1234567891011L));
         enforcer.put(8, Byte.parseByte("20"));
         enforcer.put(9, Short.parseShort("2016"));
+        enforcer.put(10, 'A');
+        assertThat(enforcer.getRuntimeSchema().getFields().get(7).getProp(SchemaConstants.TALEND_COLUMN_PATTERN),
+                is((Object) "yyyy-MM-dd'T'HH:mm:ss'000Z'"));
 
         IndexedRecord adapted = enforcer.createIndexedRecord();
 
@@ -299,5 +308,36 @@ public class DiIncomingSchemaEnforcerTest {
         assertThat(adapted.get(7), is((Object) new Date(1234567891011L)));
         assertThat(adapted.get(8), is((Object) 20));
         assertThat(adapted.get(9), is((Object) 2016));
+        assertThat(adapted.get(10), is((Object) "A"));
+
+        // To date with specified pattern "yyyy-MM-dd'T'HH:mm:ss'000Z'"
+        enforcer.put(7, "2009-02-13T23:31:31.000Z");
+        adapted = enforcer.createIndexedRecord();
+        assertThat(adapted.get(7), is((Object) new Date(1234567891000L)));
+
+        // 2) Test BigDecimal and Date when nullable is true
+        enforcer = new DiIncomingSchemaEnforcer(talend6Schema);
+        assertThat(enforcer.getDesignSchema(), is(talend6Schema));
+        assertThat(enforcer.needsInitDynamicColumns(), is(true));
+        assertThat(enforcer.getRuntimeSchema(), nullValue());
+        enforcer.initDynamicColumn("Test_BigDecimal", null, "id_BigDecimal", null, 0, 0, 0, null, null, false, true, null, null);
+        enforcer.initDynamicColumn("Test_Date", null, "id_Date", null, 0, 0, 0, "yyyy-MM-dd'T'HH:mm:ss'000Z'", null, false, true,
+                null, null);
+        assertThat(enforcer.needsInitDynamicColumns(), is(true));
+        enforcer.initDynamicColumnsFinished();
+        assertThat(enforcer.needsInitDynamicColumns(), is(false));
+
+        // Check the run-time schema was created.
+        assertThat(enforcer.getDesignSchema(), is(talend6Schema));
+        assertThat(enforcer.getRuntimeSchema(), not(nullValue()));
+
+        enforcer.put(0, new BigDecimal("630.1020"));
+        enforcer.put(1, new Date(1234567891011L));
+        assertThat(enforcer.getRuntimeSchema().getFields().get(1).getProp(SchemaConstants.TALEND_COLUMN_PATTERN),
+                is((Object) "yyyy-MM-dd'T'HH:mm:ss'000Z'"));
+
+        adapted = enforcer.createIndexedRecord();
+        assertThat(adapted.get(0), is((Object) new BigDecimal("630.1020")));
+        assertThat(adapted.get(1), is((Object) new Date(1234567891011L)));
     }
 }

--- a/daikon/src/test/java/org/talend/daikon/di/DiIncomingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DiIncomingSchemaEnforcerTest.java
@@ -5,7 +5,9 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
+import java.math.BigDecimal;
 import java.util.Date;
 
 import org.apache.avro.Schema;
@@ -233,4 +235,69 @@ public class DiIncomingSchemaEnforcerTest {
         assertThat(adapted.get(0), is((Object) new Date(1234567891000L)));
     }
 
+    @Test
+    public void testDynamicColumnALLSupportedType() {
+        Schema talend6Schema = SchemaBuilder.builder().record("Record").fields() //
+                .name("valid").type().booleanType().noDefault() //
+                .endRecord();
+        talend6Schema = AvroUtils.setIncludeAllFields(talend6Schema, true);
+        talend6Schema = AvroUtils.setProperty(talend6Schema, DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0");
+
+        DiIncomingSchemaEnforcer enforcer = new DiIncomingSchemaEnforcer(talend6Schema);
+
+        // The enforcer isn't usable yet.
+        assertThat(enforcer.getDesignSchema(), is(talend6Schema));
+        assertThat(enforcer.needsInitDynamicColumns(), is(true));
+        assertThat(enforcer.getRuntimeSchema(), nullValue());
+
+        enforcer.initDynamicColumn("Test_String", null, "id_String", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Boolean", null, "id_Boolean", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Integer", null, "id_Integer", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Long", null, "id_Long", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Double", null, "id_Double", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Float", null, "id_Float", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_BigDecimal", null, "id_BigDecimal", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Date", null, "id_Date", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Byte", null, "id_Byte", null, 0, 0, 0, null, null, false, false, null, null);
+        enforcer.initDynamicColumn("Test_Short", null, "id_Short", null, 0, 0, 0, null, null, false, false, null, null);
+        try {
+            // Throw an exception rather than put schema null to avoid NPE
+            enforcer.initDynamicColumn("Test_Unsupported", null, "id_Unsupported", null, 0, 0, 0, null, null, false, false, null,
+                    null);
+            fail("Expect to get unsupported type exception!");
+        } catch (UnsupportedOperationException e) {
+        }
+        assertThat(enforcer.needsInitDynamicColumns(), is(true));
+        enforcer.initDynamicColumnsFinished();
+        assertThat(enforcer.needsInitDynamicColumns(), is(false));
+
+        // Check the run-time schema was created.
+        assertThat(enforcer.getDesignSchema(), is(talend6Schema));
+        assertThat(enforcer.getRuntimeSchema(), not(nullValue()));
+
+        // Put values into the enforcer and get them as an IndexedRecord.
+        enforcer.put(0, "string value");
+        enforcer.put(1, true);
+        enforcer.put(2, 100);
+        enforcer.put(3, 1234567891011L);
+        enforcer.put(4, 2.15);
+        enforcer.put(5, 3.6f);
+        enforcer.put(6, new BigDecimal("630.1020"));
+        enforcer.put(7, new Date(1234567891011L));
+        enforcer.put(8, Byte.parseByte("20"));
+        enforcer.put(9, Short.parseShort("2016"));
+
+        IndexedRecord adapted = enforcer.createIndexedRecord();
+
+        assertThat(adapted.get(0), is((Object) "string value"));
+        assertThat(adapted.get(1), is((Object) true));
+        assertThat(adapted.get(2), is((Object) 100));
+        assertThat(adapted.get(3), is((Object) 1234567891011L));
+        assertThat(adapted.get(4), is((Object) 2.15));
+        assertThat(adapted.get(5), is((Object) 3.6f));
+        assertThat(adapted.get(6), is((Object) new BigDecimal("630.1020")));
+        assertThat(adapted.get(7), is((Object) new Date(1234567891011L)));
+        assertThat(adapted.get(8), is((Object) 20));
+        assertThat(adapted.get(9), is((Object) 2016));
+    }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

1. When DiIncomingSchemaEnforcer.initDynamicColumn(...) take all of the parameters from the dynamic metadata and adapt it to a field for the runtime Schema. The mapping miss some type like:
id_Byte/id_Short/id_BigDecimal/id_Date/id_Character
2. When pass unsupported type, the field schema would put null.This would caused NPE problem


**What is the new behavior?**

Add above missing and throw a UnsupportedOperationException for unsupported type

**Does this PR introduce a breaking change?**

- [x] No