### PR TITLE
TCOMP-313: Add a the possibility for the Form to retrieve a Widget directly  from a Property.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/presentation/Form.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/presentation/Form.java
@@ -273,6 +273,13 @@ public class Form extends SimpleNamedThing implements ToStringIndent {
     }
 
     /**
+     * Return the {@link Widget} with the specified name.
+     */
+    public Widget getWidget(Property<?> child) {
+        return widgetMap.get(child.getName());
+    }
+
+    /**
      * Uses the class name to get a {@link Widget}.
      *
      * @param childClass the Class of the desired {@link Properties} to get.

--- a/daikon/src/test/java/org/talend/daikon/properties/presentation/FormTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/presentation/FormTest.java
@@ -12,12 +12,15 @@
 // ============================================================================
 package org.talend.daikon.properties.presentation;
 
-import static org.junit.Assert.*;
-import static org.talend.daikon.properties.presentation.Widget.*;
-import static org.talend.daikon.properties.property.PropertyFactory.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.talend.daikon.properties.presentation.Widget.widget;
+import static org.talend.daikon.properties.property.PropertyFactory.newString;
 
 import org.junit.Test;
 import org.talend.daikon.properties.PropertiesImpl;
+import org.talend.daikon.properties.property.Property;
 
 public class FormTest {
 
@@ -45,6 +48,30 @@ public class FormTest {
         form.setSubtitle(subTitle);
         assertEquals("Ze Form Title", form.getTitle());
         assertEquals(subTitle, form.getSubtitle());
+    }
+
+    @Test
+    public void testGetWidget() {
+        Property<String> w1 = newString("w1");
+        Property<String> w2 = newString("w2");
+        Property<String> w3 = newString("w3");
+        Form form = new Form(new PropertiesImpl("bar") { //$NON-NLS-1$
+        }, "foo"); //$NON-NLS-1$
+        form.addRow(widget(w1));
+        form.addRow(widget(w2));
+        form.addRow(widget(w3));
+
+        assertEquals(w1, form.getWidget("w1").getContent());
+        assertEquals(w2, form.getWidget("w2").getContent());
+        assertEquals(w3, form.getWidget("w3").getContent());
+
+        assertEquals(w1, form.getWidget(w1.getName()).getContent());
+        assertEquals(w2, form.getWidget(w2.getName()).getContent());
+        assertEquals(w3, form.getWidget(w3.getName()).getContent());
+
+        assertEquals(w1, form.getWidget(w1).getContent());
+        assertEquals(w2, form.getWidget(w2).getContent());
+        assertEquals(w3, form.getWidget(w3).getContent());
     }
 
     @Test


### PR DESCRIPTION
This pull request will help the readability of the "refreshLayout" part of a componentProperty.
It will change the code from:
```
if (useOtherConnection) {
    form.getWidget(useDataSource.getName()).setHidden(true);
    form.getWidget(dataSource.getName()).setHidden(true);
} else {
    form.getWidget(useDataSource.getName()).setHidden(false);
    form.getWidget(dataSource.getName()).setHidden(!useDataSource.getValue());
}
```
to:
```
if (useOtherConnection) {
    form.getWidget(useDataSource).setHidden(true);
    form.getWidget(dataSource).setHidden(true);
} else {
    form.getWidget(useDataSource).setHidden(false);
    form.getWidget(dataSource).setHidden(!useDataSource.getValue());
}

```