### PR TITLE
fix (TDI-37525): add missing when DiOutgoingSchemaEnforcer transform from Avro-compatible to  Talend-compatible types

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/di/DiOutgoingSchemaEnforcer.java
+++ b/daikon/src/main/java/org/talend/daikon/di/DiOutgoingSchemaEnforcer.java
@@ -12,7 +12,12 @@
 // ============================================================================
 package org.talend.daikon.di;
 
-import java.util.*;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
@@ -194,6 +199,10 @@ public class DiOutgoingSchemaEnforcer implements IndexedRecord, DiSchemaConstant
             return value instanceof Date ? value : new Date((Long) value);
         } else if ("id_Byte".equals(talendType)) { //$NON-NLS-1$
             return value instanceof Number ? ((Number) value).byteValue() : Byte.parseByte(String.valueOf(value));
+        } else if ("id_Character".equals(talendType) || "java.lang.Character".equals(javaClass)) {
+            return value instanceof Character ? value : ((String) value).charAt(0);
+        } else if ("id_BigDecimal".equals(talendType) || "java.math.BigDecimal".equals(javaClass)) {
+            return value instanceof BigDecimal ? value : new BigDecimal(String.valueOf(value));
         }
         return value;
     }

--- a/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
@@ -5,8 +5,10 @@ import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
+import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Map;
 
@@ -433,5 +435,63 @@ public class DiOutgoingSchemaEnforcerTest {
 
         assertThat(enforcer.get(0), instanceOf(Date.class));
         assertThat(enforcer.get(0), is((Object) currentDate));
+    }
+
+    @Test
+    public void testValueConversionToDecimal() {
+        // The expected schema after enforcement.
+        Schema talend6Schema = SchemaBuilder.builder().record("Record").fields() //
+                .name("TestBigDecimal").type(AvroUtils._decimal()).noDefault() //
+                .endRecord();
+
+        // The enforcer to test.
+        DiOutgoingSchemaEnforcer enforcer = new DiOutgoingSchemaEnforcer(talend6Schema, false);
+
+        // Use this factory to create a one-column indexed record.
+        SingleColumnIndexedRecordConverter<String> factory = new SingleColumnIndexedRecordConverter<>(String.class,
+                AvroUtils._decimal());
+        // Test not null value
+        IndexedRecord testData = factory.convertToAvro("10.20");
+
+        enforcer.setWrapped(testData);
+
+        assertThat(enforcer.get(0), instanceOf(BigDecimal.class));
+        assertThat(enforcer.get(0), is((Object) new BigDecimal("10.20")));
+
+        // Test null value
+        testData = factory.convertToAvro(null);
+
+        enforcer.setWrapped(testData);
+        assertNull(enforcer.get(0));
+
+    }
+
+    @Test
+    public void testValueConversionToCharacter() {
+        // The expected schema after enforcement.
+        Schema talend6Schema = SchemaBuilder.builder().record("Record").fields() //
+                .name("TestBigCharacter").type(AvroUtils._character()).noDefault() //
+                .endRecord();
+
+        // The enforcer to test.
+        DiOutgoingSchemaEnforcer enforcer = new DiOutgoingSchemaEnforcer(talend6Schema, false);
+
+        // Use this factory to create a one-column indexed record.
+        SingleColumnIndexedRecordConverter<String> factory = new SingleColumnIndexedRecordConverter<>(String.class,
+                AvroUtils._character());
+        // Test not null value
+        IndexedRecord testData = factory.convertToAvro("A");
+
+        enforcer.setWrapped(testData);
+
+        assertThat(enforcer.get(0), instanceOf(Character.class));
+        assertThat(enforcer.get(0), is((Object) 'A'));
+
+        // Test null value
+        testData = factory.convertToAvro(null);
+
+        enforcer.setWrapped(testData);
+        assertNull(enforcer.get(0));
+
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit message follows Talend standard
- [x] Tests for the changes have been added (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

Because of BigDecimal and Character type save String type value in avro.
But in the DiOutgoingSchemaEnforcer  transform from Avro-compatible to  Talend-compatible types
We miss those 2 type convert.


**What is the new behavior?**

Add above missing

**Does this PR introduce a breaking change?**

- [x] No