### PR TITLE
TCOMP-313: Add "setVisible" method on Widget.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/presentation/Form.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/presentation/Form.java
@@ -246,6 +246,15 @@ public class Form extends SimpleNamedThing implements ToStringIndent {
     }
 
     /**
+     * Change the visibility status of all of the {@code Form}'s widgets.
+     */
+    public void setVisible(boolean hidden) {
+        for (Widget w : getWidgets()) {
+            w.setVisible(hidden);
+        }
+    }
+
+    /**
      * Return widget name from its contents
      */
     private String getWidgetContentName(Widget widget) {
@@ -273,9 +282,9 @@ public class Form extends SimpleNamedThing implements ToStringIndent {
     }
 
     /**
-     * Return the {@link Widget} with the specified name.
+     * Return the {@link Widget} of a NamedThing.
      */
-    public Widget getWidget(Property<?> child) {
+    public Widget getWidget(NamedThing child) {
         return widgetMap.get(child.getName());
     }
 

--- a/daikon/src/main/java/org/talend/daikon/properties/presentation/Form.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/presentation/Form.java
@@ -248,9 +248,9 @@ public class Form extends SimpleNamedThing implements ToStringIndent {
     /**
      * Change the visibility status of all of the {@code Form}'s widgets.
      */
-    public void setVisible(boolean hidden) {
+    public void setVisible(boolean visible) {
         for (Widget w : getWidgets()) {
-            w.setVisible(hidden);
+            w.setVisible(visible);
         }
     }
 

--- a/daikon/src/main/java/org/talend/daikon/properties/presentation/Widget.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/presentation/Widget.java
@@ -289,6 +289,13 @@ public class Widget implements ToStringIndent {
         return hidden;
     }
 
+    /**
+     * return if the current Widget is visible or not.
+     */
+    public boolean isVisible() {
+        return !hidden;
+    }
+
     public String getWidgetType() {
         return widgetType;
     }

--- a/daikon/src/main/java/org/talend/daikon/properties/presentation/Widget.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/presentation/Widget.java
@@ -250,6 +250,41 @@ public class Widget implements ToStringIndent {
         return this;
     }
 
+    /**
+     * Set or reset this as hidden and mark the underlying {@link Property} or {@link Form} as hidden or not.
+     */
+    public Widget setHidden(Property<Boolean> hidden) {
+        return setHidden(hidden.getValue());
+    }
+
+    /**
+     * Set or reset this as hidden and mark the underlying {@link Property} or {@link Form} as hidden or not.
+     */
+    public Widget setHidden() {
+        return setHidden(true);
+    }
+
+    /**
+     * Set or reset this as visible and mark the underlying {@link Property} or {@link Form} as visible or not.
+     */
+    public Widget setVisible(boolean visible) {
+        return setHidden(!visible);
+    }
+
+    /**
+     * Set or reset this as visible and mark the underlying {@link Property} or {@link Form} as visible or not.
+     */
+    public Widget setVisible(Property<Boolean> visible) {
+        return setHidden(!visible.getValue());
+    }
+
+    /**
+     * Set or reset this as visible and mark the underlying {@link Property} or {@link Form} as visible or not.
+     */
+    public Widget setVisible() {
+        return setVisible(true);
+    }
+
     public boolean isHidden() {
         return hidden;
     }

--- a/daikon/src/test/java/org/talend/daikon/properties/PropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/PropertiesTest.java
@@ -191,10 +191,12 @@ public class PropertiesTest {
     public void testCopyValuesRefreshLayout() {
         TestProperties props = (TestProperties) new TestProperties("props").init();
         assertFalse(props.nestedProps.getForm(Form.MAIN).getWidget(props.nestedProps.anotherProp.getName()).isHidden());
+        assertTrue(props.nestedProps.getForm(Form.MAIN).getWidget(props.nestedProps.anotherProp.getName()).isVisible());
         TestProperties props2 = (TestProperties) new TestProperties("props2").init();
         props2.nestedProps.booleanProp.setValue(true);
         props.copyValuesFrom(props2);
         assertTrue(props.nestedProps.getForm(Form.MAIN).getWidget(props.nestedProps.anotherProp.getName()).isHidden());
+        assertFalse(props.nestedProps.getForm(Form.MAIN).getWidget(props.nestedProps.anotherProp.getName()).isVisible());
     }
 
     @Test

--- a/daikon/src/test/java/org/talend/daikon/properties/PropertyTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/PropertyTest.java
@@ -15,14 +15,11 @@ package org.talend.daikon.properties;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.talend.daikon.properties.property.PropertyFactory.newProperty;
 
 import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.junit.Test;
@@ -115,6 +112,24 @@ public class PropertyTest {
         widget.setHidden(true);
         assertTrue(element.isFlag(Property.Flags.HIDDEN));
         widget.setHidden(false);
+        assertFalse(element.isFlag(Property.Flags.HIDDEN));
+        widget.setHidden();
+        assertTrue(element.isFlag(Property.Flags.HIDDEN));
+    }
+
+    @Test
+    public void testVisibleForProperties() {
+        Property<String> element = newProperty("element");
+        assertFalse(element.isFlag(Property.Flags.HIDDEN));
+        Widget widget = new Widget(element);
+        assertFalse(element.isFlag(Property.Flags.HIDDEN));
+        widget.setVisible(false);
+        assertTrue(element.isFlag(Property.Flags.HIDDEN));
+        widget.setVisible(true);
+        assertFalse(element.isFlag(Property.Flags.HIDDEN));
+        widget.setVisible(false);
+        assertTrue(element.isFlag(Property.Flags.HIDDEN));
+        widget.setVisible();
         assertFalse(element.isFlag(Property.Flags.HIDDEN));
     }
 

--- a/daikon/src/test/java/org/talend/daikon/properties/presentation/FormTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/presentation/FormTest.java
@@ -75,7 +75,7 @@ public class FormTest {
     }
 
     @Test
-    public void testSetVisible() {
+    public void testSetHidden() {
         Form form = new Form(new PropertiesImpl("bar") { //$NON-NLS-1$
         }, "foo"); //$NON-NLS-1$
         form.addRow(widget(newString("w1")));
@@ -95,7 +95,7 @@ public class FormTest {
     }
 
     @Test
-    public void testSetVisibleForNestedForms() {
+    public void testSetHiddenForNestedForms() {
         Form form = new Form(new PropertiesImpl("bar") { //$NON-NLS-1$
         }, "foo"); //$NON-NLS-1$
         Form nestedForm = new Form(new PropertiesImpl("foo") { //$NON-NLS-1$
@@ -109,6 +109,45 @@ public class FormTest {
         assertTrue(form.getWidget("w1").isHidden());
         assertTrue(nestedForm.getWidget("w3").isHidden());
         form.setHidden(false);
+        assertFalse(form.getWidget("w1").isHidden());
+        assertFalse(nestedForm.getWidget("w3").isHidden());
+    }
+
+    @Test
+    public void testSetVisible() {
+        Form form = new Form(new PropertiesImpl("bar") { //$NON-NLS-1$
+        }, "foo"); //$NON-NLS-1$
+        form.addRow(widget(newString("w1")));
+        form.addRow(widget(newString("w2")));
+        form.addRow(widget(newString("w3")));
+        assertFalse(form.getWidget("w1").isHidden());
+        assertFalse(form.getWidget("w2").isHidden());
+        assertFalse(form.getWidget("w3").isHidden());
+        form.setVisible(false);
+        assertTrue(form.getWidget("w1").isHidden());
+        assertTrue(form.getWidget("w2").isHidden());
+        assertTrue(form.getWidget("w3").isHidden());
+        form.setVisible(true);
+        assertFalse(form.getWidget("w1").isHidden());
+        assertFalse(form.getWidget("w2").isHidden());
+        assertFalse(form.getWidget("w3").isHidden());
+    }
+
+    @Test
+    public void testSetVisibleForNestedForms() {
+        Form form = new Form(new PropertiesImpl("bar") { //$NON-NLS-1$
+        }, "foo"); //$NON-NLS-1$
+        Form nestedForm = new Form(new PropertiesImpl("foo") { //$NON-NLS-1$
+        }, "bar"); //$NON-NLS-1$
+        form.addRow(widget(newString("w1")));
+        form.addRow(widget(nestedForm));
+        nestedForm.addRow(widget(newString("w3")));
+        assertFalse(form.getWidget("w1").isHidden());
+        assertFalse(nestedForm.getWidget("w3").isHidden());
+        form.setVisible(false);
+        assertTrue(form.getWidget("w1").isHidden());
+        assertTrue(nestedForm.getWidget("w3").isHidden());
+        form.setVisible(true);
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(nestedForm.getWidget("w3").isHidden());
     }

--- a/daikon/src/test/java/org/talend/daikon/properties/presentation/FormTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/presentation/FormTest.java
@@ -84,14 +84,23 @@ public class FormTest {
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(form.getWidget("w2").isHidden());
         assertFalse(form.getWidget("w3").isHidden());
+        assertTrue(form.getWidget("w1").isVisible());
+        assertTrue(form.getWidget("w2").isVisible());
+        assertTrue(form.getWidget("w3").isVisible());
         form.setHidden(true);
         assertTrue(form.getWidget("w1").isHidden());
         assertTrue(form.getWidget("w2").isHidden());
         assertTrue(form.getWidget("w3").isHidden());
+        assertFalse(form.getWidget("w1").isVisible());
+        assertFalse(form.getWidget("w2").isVisible());
+        assertFalse(form.getWidget("w3").isVisible());
         form.setHidden(false);
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(form.getWidget("w2").isHidden());
         assertFalse(form.getWidget("w3").isHidden());
+        assertTrue(form.getWidget("w1").isVisible());
+        assertTrue(form.getWidget("w2").isVisible());
+        assertTrue(form.getWidget("w3").isVisible());
     }
 
     @Test
@@ -105,12 +114,18 @@ public class FormTest {
         nestedForm.addRow(widget(newString("w3")));
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(nestedForm.getWidget("w3").isHidden());
+        assertTrue(form.getWidget("w1").isVisible());
+        assertTrue(nestedForm.getWidget("w3").isVisible());
         form.setHidden(true);
         assertTrue(form.getWidget("w1").isHidden());
         assertTrue(nestedForm.getWidget("w3").isHidden());
+        assertFalse(form.getWidget("w1").isVisible());
+        assertFalse(nestedForm.getWidget("w3").isVisible());
         form.setHidden(false);
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(nestedForm.getWidget("w3").isHidden());
+        assertTrue(form.getWidget("w1").isVisible());
+        assertTrue(nestedForm.getWidget("w3").isVisible());
     }
 
     @Test
@@ -123,14 +138,23 @@ public class FormTest {
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(form.getWidget("w2").isHidden());
         assertFalse(form.getWidget("w3").isHidden());
+        assertTrue(form.getWidget("w1").isVisible());
+        assertTrue(form.getWidget("w2").isVisible());
+        assertTrue(form.getWidget("w3").isVisible());
         form.setVisible(false);
         assertTrue(form.getWidget("w1").isHidden());
         assertTrue(form.getWidget("w2").isHidden());
         assertTrue(form.getWidget("w3").isHidden());
+        assertFalse(form.getWidget("w1").isVisible());
+        assertFalse(form.getWidget("w2").isVisible());
+        assertFalse(form.getWidget("w3").isVisible());
         form.setVisible(true);
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(form.getWidget("w2").isHidden());
         assertFalse(form.getWidget("w3").isHidden());
+        assertTrue(form.getWidget("w1").isVisible());
+        assertTrue(form.getWidget("w2").isVisible());
+        assertTrue(form.getWidget("w3").isVisible());
     }
 
     @Test
@@ -144,12 +168,18 @@ public class FormTest {
         nestedForm.addRow(widget(newString("w3")));
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(nestedForm.getWidget("w3").isHidden());
+        assertTrue(form.getWidget("w1").isVisible());
+        assertTrue(nestedForm.getWidget("w3").isVisible());
         form.setVisible(false);
         assertTrue(form.getWidget("w1").isHidden());
         assertTrue(nestedForm.getWidget("w3").isHidden());
+        assertFalse(form.getWidget("w1").isVisible());
+        assertFalse(nestedForm.getWidget("w3").isVisible());
         form.setVisible(true);
         assertFalse(form.getWidget("w1").isHidden());
         assertFalse(nestedForm.getWidget("w3").isHidden());
+        assertTrue(form.getWidget("w1").isVisible());
+        assertTrue(nestedForm.getWidget("w3").isVisible());
     }
 
 }


### PR DESCRIPTION
Add a couple of method into widget to improve the usability of the "refreshLayout" method.
The list of the added method is:
```
public Widget setHidden(Property<Boolean> hidden)
public Widget setHidden()
public Widget setVisible(boolean visible)
public Widget setVisible(Property<Boolean> visible)
public Widget setVisible()
```
It will change the code from:
```
if (useOtherConnection) {
    form.getWidget(useDataSource).setHidden(true);
    form.getWidget(dataSource).setHidden(true);
} else {
    form.getWidget(useDataSource).setHidden(false);
    form.getWidget(dataSource).setHidden(!useDataSource.getValue());
}

```
into:
```
if (useOtherConnection) {
    form.getWidget(useDataSource).setHidden();
    form.getWidget(dataSource).setHidden();
} else {
    form.getWidget(useDataSource).setVisible();
    form.getWidget(dataSource).setVisible(useDataSource);
}
```

This PR also contains small improvement in the Form class, adding a "setVisible" method and extending the "getWidget" method to any NamedThing.