### PR TITLE
feature (TCOMP-336) : add an Defintion interface and Def registry ser…

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/definition/Definition.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/Definition.java
@@ -1,0 +1,39 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.definition;
+
+import org.talend.daikon.NamedThing;
+import org.talend.daikon.properties.Properties;
+
+/**
+ * provide named and image definition for any entity, mainly classes that are associated with {@link Properties}
+ * all definitions {@link #getName()} must return a unique value within a single jvm
+ */
+public interface Definition extends NamedThing {
+
+    /**
+     * A path relative to the current instance, ideally is should just be the name of the png image if
+     * placed in the same resource folder as the implementing class. The service api requesting an icon
+     * will use the following code:
+     * 
+     * <pre>
+     * {@code
+     *    this.getClass().getResourceAsStream(getImagePath())
+     * }
+     * </pre>
+     * 
+     * @see {@link java.lang.Class#getResourceAsStream(String)}
+     * @return the path to the image resource or null if an image is not required.
+     */
+    String getImagePath();
+}

--- a/daikon/src/main/java/org/talend/daikon/definition/service/DefinitionRegistryService.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/service/DefinitionRegistryService.java
@@ -18,13 +18,13 @@ import java.util.Map;
 import org.talend.daikon.definition.Definition;
 
 /**
- * The service should handle {@link Definition} and garanties that onyl one instance is registered with on unique name (
+ * The service should handle {@link Definition} and guarantees that only one instance is registered with a unique name (
  * {@link Definition.getName()}
  */
 public interface DefinitionRegistryService {
 
     /**
-     * Get the map of all {@link Definition} that implement a specific interface using thier name as the map key.
+     * Get the map of all {@link Definition} that implement a specific interface using the name as the map key.
      *
      * @param An interface or subclass of {@link Definition}.
      * @return All {@link Definition} that were registered in the framework and that implement that interface or an empty map.

--- a/daikon/src/main/java/org/talend/daikon/definition/service/DefinitionRegistryService.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/service/DefinitionRegistryService.java
@@ -1,0 +1,43 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.definition.service;
+
+import java.io.InputStream;
+import java.util.Map;
+
+import org.talend.daikon.definition.Definition;
+
+/**
+ * The service should handle {@link Definition} and garanties that onyl one instance is registered with on unique name (
+ * {@link Definition.getName()}
+ */
+public interface DefinitionRegistryService {
+
+    /**
+     * Get the map of all {@link Definition} that implement a specific interface using thier name as the map key.
+     *
+     * @param An interface or subclass of {@link Definition}.
+     * @return All {@link Definition} that were registered in the framework and that implement that interface or an empty map.
+     */
+    <T extends Definition> Map<String, T> getDefinitionsMapByType(Class<T> cls);
+
+    /**
+     * Return the image related to the given definition
+     * 
+     * @param definitionName, name of the defintion to get the image for
+     * @return the image stream or null if none was provided or an error occurred
+     * @exception ComponentException thrown if the definitionName is not registered in the service
+     */
+    InputStream getImage(String definitionName);
+
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Feature

**What is the current behavior?** (You can also link to an open issue here)
lack of definition for getting access to properties and lack of registry service for definitions


**What is the new behavior?**
A new definition interface has been created and a new service registry interface  for getting access to definitions.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Other information**:
We may also move the registry implementation in daikon.
and don't look at the branch name, it is an error.