### PR TITLE
TDKN-86: Fix use of static HTTP port in configuration.

### DIFF
--- a/daikon-service/service-common/src/test/java/org/talend/daikon/RandomServerPortFinder.java
+++ b/daikon-service/service-common/src/test/java/org/talend/daikon/RandomServerPortFinder.java
@@ -1,0 +1,57 @@
+package org.talend.daikon;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.ServerList;
+
+/**
+ * Unit tests run on a random port so can't be set in configuration. This configuration allows to create a server list
+ * using the "local.server.port" environment variable.
+ */
+@Configuration
+public class RandomServerPortFinder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RandomServerPortFinder.class);
+
+    @Autowired
+    private Environment environment;
+
+    @Bean
+    public ServerList<Server> serverList() {
+        return new ServerList<Server>() {
+
+            @Override
+            public List<Server> getInitialListOfServers() {
+                return Collections.emptyList();
+            }
+
+            @Override
+            public List<Server> getUpdatedListOfServers() {
+                return getServers();
+            }
+
+            private List<Server> getServers() {
+                final String serverPortProperty = environment.getProperty("local.server.port");
+                List<Server> serverList;
+                if (serverPortProperty != null) {
+                    serverList = Collections.singletonList(new Server("127.0.0.1", Integer.parseInt(serverPortProperty)));
+                    LOGGER.info("Configure server list to: {}", serverList);
+                } else {
+                    serverList = Collections.emptyList();
+                    LOGGER.warn("No server currently available.");
+                }
+                return serverList;
+            }
+        };
+    }
+
+}

--- a/daikon-service/service-common/src/test/resources/application.properties
+++ b/daikon-service/service-common/src/test/resources/application.properties
@@ -1,2 +1,1 @@
-server.port=8989
-TestService.ribbon.listOfServers=127.0.0.1:8989
+server.port=0


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?**
https://jira.talendforge.org/browse/TDKN-86 Unit tests in service-common module run on a static port, making them unstable in case of concurrent builds on same machine.

**What is the new behavior?**
Unit tests now use a random port (based on Spring's random port finder).

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**:

* Unit test now run on random HTTP port.
* Add configuration to dynamically build the available server list using the random port number.