### PR TITLE
feat(Serialization): Propose a first implementation of ReferenceProperties.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/ReferenceProperties.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/ReferenceProperties.java
@@ -24,8 +24,8 @@ import org.talend.daikon.properties.property.Property;
  * A reference to another properties. This could be in one of the following states:
  * <li>Use this properties (no reference)</li>
  * <li>Reference a single instance of a given properties type in the enclosing scope, e.g. Job</li>
- * <li>Reference to a particular instance of a properties. In this case, the {@link #properties} will be
- * populated by the {@link org.talend.daikon.properties.presentation.Widget}.</li>
+ * <li>Reference to a particular instance of a properties. In this case, the {@link #properties} will be populated by
+ * the {@link org.talend.daikon.properties.presentation.Widget}.</li>
  *
  * IMPORTANT - when using {@code ComponentReferenceProperties} the property name in the enclosingProperties must be
  * {@code referencedComponent}.
@@ -45,8 +45,7 @@ public interface ReferenceProperties extends Properties {
     // Properties
     //
     public Property<ReferenceType> referenceType = newEnum("referenceType", ReferenceType.class);
-    
-    public Property<String> componentType = newProperty("componentType").setFlags(EnumSet.of(DESIGN_TIME_ONLY)); //$NON-NLS-1$
 
+    public Property<String> componentType = newProperty("componentType").setFlags(EnumSet.of(DESIGN_TIME_ONLY)); //$NON-NLS-1$
 
 }

--- a/daikon/src/main/java/org/talend/daikon/properties/ReferenceProperties.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/ReferenceProperties.java
@@ -1,0 +1,52 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2015 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.properties;
+
+import static org.talend.daikon.properties.property.Property.Flags.DESIGN_TIME_ONLY;
+import static org.talend.daikon.properties.property.PropertyFactory.newEnum;
+import static org.talend.daikon.properties.property.PropertyFactory.newProperty;
+
+import java.util.EnumSet;
+
+import org.talend.daikon.properties.property.Property;
+
+/**
+ * A reference to another properties. This could be in one of the following states:
+ * <li>Use this properties (no reference)</li>
+ * <li>Reference a single instance of a given properties type in the enclosing scope, e.g. Job</li>
+ * <li>Reference to a particular instance of a properties. In this case, the {@link #properties} will be
+ * populated by the {@link org.talend.daikon.properties.presentation.Widget}.</li>
+ *
+ * IMPORTANT - when using {@code ComponentReferenceProperties} the property name in the enclosingProperties must be
+ * {@code referencedComponent}.
+ *
+ * The {@link org.talend.daikon.properties.presentation.WidgetType#COMPONENT_REFERENCE} uses this class as its
+ * properties and the Widget will populate these values.
+ */
+public interface ReferenceProperties extends Properties {
+
+    public enum ReferenceType {
+        THIS_COMPONENT,
+        COMPONENT_TYPE,
+        COMPONENT_INSTANCE
+    }
+
+    //
+    // Properties
+    //
+    public Property<ReferenceType> referenceType = newEnum("referenceType", ReferenceType.class);
+    
+    public Property<String> componentType = newProperty("componentType").setFlags(EnumSet.of(DESIGN_TIME_ONLY)); //$NON-NLS-1$
+
+
+}

--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonDataGenerator.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonDataGenerator.java
@@ -1,12 +1,18 @@
 package org.talend.daikon.serialize.jsonschema;
 
-import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.*;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.dateFormatter;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.findClass;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getListInnerClassName;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getSubProperties;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getSubProperty;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.isListClass;
 
 import java.util.Date;
 import java.util.List;
 
 import org.apache.avro.Schema;
 import org.talend.daikon.properties.Properties;
+import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.property.Property;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -28,8 +34,10 @@ public class JsonDataGenerator {
         }
         List<Properties> propertiesList = getSubProperties(cProperties);
         for (Properties properties : propertiesList) {
-            String name = properties.getName();
-            rootNode.set(name, processTPropertiesData(properties));
+            if (!ReferenceProperties.class.isAssignableFrom(properties.getClass())) {
+                String name = properties.getName();
+                rootNode.set(name, processTPropertiesData(properties));
+            }
         }
         return rootNode;
     }
@@ -96,4 +104,5 @@ public class JsonDataGenerator {
             throw new RuntimeException("Do not support type " + type + " yet.");
         }
     }
+
 }

--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonPropertiesResolver.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonPropertiesResolver.java
@@ -1,6 +1,11 @@
 package org.talend.daikon.serialize.jsonschema;
 
-import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.*;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.dateFormatter;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.findClass;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getListInnerClassName;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getSubProperties;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getSubProperty;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.isListClass;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -11,6 +16,7 @@ import java.util.List;
 
 import org.apache.avro.Schema;
 import org.talend.daikon.properties.Properties;
+import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.property.Property;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -28,7 +34,9 @@ public class JsonPropertiesResolver {
         }
         List<Properties> propertiesList = getSubProperties(cProperties);
         for (Properties properties : propertiesList) {
-            resolveJson((ObjectNode) jsonData.get(properties.getName()), cProperties.getProperties(properties.getName()));
+            if (!ReferenceProperties.class.isAssignableFrom(properties.getClass())) {
+                resolveJson((ObjectNode) jsonData.get(properties.getName()), cProperties.getProperties(properties.getName()));
+            }
         }
         return cProperties;
     }

--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGenerator.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGenerator.java
@@ -1,14 +1,18 @@
 package org.talend.daikon.serialize.jsonschema;
 
-import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.*;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getListInnerClassName;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getSubProperties;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getSubProperty;
+import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.isListClass;
 
 import java.util.Date;
 import java.util.List;
 
 import org.talend.daikon.NamedThing;
 import org.talend.daikon.properties.Properties;
-import org.talend.daikon.properties.property.EnumProperty;
+import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.property.EnumListProperty;
+import org.talend.daikon.properties.property.EnumProperty;
 import org.talend.daikon.properties.property.Property;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
@@ -41,7 +45,12 @@ public class JsonSchemaGenerator {
         List<Properties> propertiesList = getSubProperties(cProperties);
         for (Properties properties : propertiesList) {
             String name = properties.getName();
-            ((ObjectNode) schema.get(JsonSchemaConstants.TAG_PROPERTIES)).set(name, processTProperties(properties));
+            if (ReferenceProperties.class.isAssignableFrom(properties.getClass())) {
+                ((ObjectNode) schema.get(JsonSchemaConstants.TAG_PROPERTIES)).put(name,
+                        ((ReferenceProperties)properties).componentType.getValue());
+            } else {
+                ((ObjectNode) schema.get(JsonSchemaConstants.TAG_PROPERTIES)).set(name, processTProperties(properties));
+            }
         }
         return schema;
     }

--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGenerator.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGenerator.java
@@ -47,7 +47,7 @@ public class JsonSchemaGenerator {
             String name = properties.getName();
             if (ReferenceProperties.class.isAssignableFrom(properties.getClass())) {
                 ((ObjectNode) schema.get(JsonSchemaConstants.TAG_PROPERTIES)).put(name,
-                        ((ReferenceProperties)properties).componentType.getValue());
+                        ((ReferenceProperties) properties).componentType.getValue());
             } else {
                 ((ObjectNode) schema.get(JsonSchemaConstants.TAG_PROPERTIES)).set(name, processTProperties(properties));
             }

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/FullExampleProperties.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/FullExampleProperties.java
@@ -1,7 +1,14 @@
 package org.talend.daikon.serialize.jsonschema;
 
 import static org.talend.daikon.properties.presentation.Widget.widget;
-import static org.talend.daikon.properties.property.PropertyFactory.*;
+import static org.talend.daikon.properties.property.PropertyFactory.newBoolean;
+import static org.talend.daikon.properties.property.PropertyFactory.newDate;
+import static org.talend.daikon.properties.property.PropertyFactory.newEnum;
+import static org.talend.daikon.properties.property.PropertyFactory.newEnumList;
+import static org.talend.daikon.properties.property.PropertyFactory.newInteger;
+import static org.talend.daikon.properties.property.PropertyFactory.newProperty;
+import static org.talend.daikon.properties.property.PropertyFactory.newSchema;
+import static org.talend.daikon.properties.property.PropertyFactory.newString;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -17,8 +24,8 @@ import org.talend.daikon.properties.ValidationResult;
 import org.talend.daikon.properties.ValidationResult.Result;
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.presentation.Widget;
-import org.talend.daikon.properties.property.EnumProperty;
 import org.talend.daikon.properties.property.EnumListProperty;
+import org.talend.daikon.properties.property.EnumProperty;
 import org.talend.daikon.properties.property.Property;
 
 /**

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/JsonDataGeneratorTest.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/JsonDataGeneratorTest.java
@@ -1,6 +1,6 @@
 package org.talend.daikon.serialize.jsonschema;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -43,6 +43,14 @@ public class JsonDataGeneratorTest {
                 .asList(new FullExampleProperties.TableProperties.ColEnum[] { FullExampleProperties.TableProperties.ColEnum.FOO,
                         FullExampleProperties.TableProperties.ColEnum.BAR, FullExampleProperties.TableProperties.ColEnum.FOO }));
         properties.tableProp.colListString.setValue(Arrays.asList(new String[] { "a", "b", "c" }));
+        return properties;
+    }
+
+    static public ReferenceExampleProperties createASetupReferenceExampleProperties() throws ParseException {
+        ReferenceExampleProperties properties = new ReferenceExampleProperties("refexample");
+        properties.init();
+        properties.parentProp.setValue("testParentValue");
+        properties.reference.childProp.setValue("testChildValue");
         return properties;
     }
 

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/JsonSchemaUtilTest.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/JsonSchemaUtilTest.java
@@ -1,13 +1,17 @@
 package org.talend.daikon.serialize.jsonschema;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URISyntaxException;
 import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.junit.Test;
+import org.talend.daikon.properties.Properties;
+import org.talend.daikon.serialize.jsonschema.ReferenceExampleProperties.TestReferenceProperties;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -43,9 +47,39 @@ public class JsonSchemaUtilTest {
         assertEquals(fep, deserFep);
     }
 
+    @Test
+    public void testSerializeUnserializeWithReferenceProperties() throws ParseException, JsonProcessingException, IOException {
+        // create a json string of a setup properties
+        ReferenceExampleProperties referenceProperties = JsonDataGeneratorTest.createASetupReferenceExampleProperties();
+        String parentJson = JsonSchemaUtil.toJson(referenceProperties);
+        String childJson = JsonSchemaUtil.toJson(referenceProperties.reference);
+
+        // re-create the Properties from the json data of the json string
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode jsonNode = mapper.readTree(parentJson);
+        JsonNode jsonData = jsonNode.get(JsonSchemaUtil.TAG_JSON_DATA);
+        ReferenceExampleProperties deserParentJson = JsonSchemaUtil.fromJson(jsonData.toString(),
+                (ReferenceExampleProperties) new ReferenceExampleProperties("refexample").init());
+
+        jsonNode = mapper.readTree(childJson);
+        jsonData = jsonNode.get(JsonSchemaUtil.TAG_JSON_DATA);
+        TestReferenceProperties deserChildJson = JsonSchemaUtil.fromJson(jsonData.toString(),
+                (TestReferenceProperties) new ReferenceExampleProperties.TestReferenceProperties("reference").init());
+
+        // merge everything to the parent
+        Map<String, Properties> propertiesMap = new HashMap<>();
+        propertiesMap.put("ReferenceExample", deserParentJson);
+        propertiesMap.put("TestReference", deserChildJson);
+        JsonSchemaUtil.resolveReferenceProperties(propertiesMap);
+
+        // compare the parent with the initial object
+        assertEquals(referenceProperties, deserParentJson);
+    }
+
     public static String readJson(String path) throws URISyntaxException, IOException {
         java.net.URL url = JsonSchemaUtilTest.class.getResource(path);
         java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
         return new String(java.nio.file.Files.readAllBytes(resPath), "UTF8").trim();
     }
+
 }

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/ReferenceExampleProperties.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/ReferenceExampleProperties.java
@@ -1,0 +1,33 @@
+package org.talend.daikon.serialize.jsonschema;
+
+import static org.talend.daikon.properties.property.PropertyFactory.newString;
+
+import org.talend.daikon.properties.PropertiesImpl;
+import org.talend.daikon.properties.ReferenceProperties;
+import org.talend.daikon.properties.ReferenceProperties.ReferenceType;
+import org.talend.daikon.properties.property.Property;
+
+public class ReferenceExampleProperties extends PropertiesImpl {
+
+
+    public Property<String> parentProp = newString("parentProp", "initialparentValue");
+    public TestReferenceProperties reference = new TestReferenceProperties("reference");
+
+
+    public ReferenceExampleProperties(String name) {
+        super(name);
+        reference.componentType.setValue("TestReference");
+        reference.referenceType.setValue(ReferenceType.COMPONENT_TYPE);
+    }
+    
+    public static class TestReferenceProperties extends PropertiesImpl implements ReferenceProperties {
+
+        public Property<String> childProp = newString("childProp", "initialChildValue");
+        
+        public TestReferenceProperties(String name) {
+            super(name);
+        }
+
+    }
+
+}

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/ReferenceExampleProperties.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/ReferenceExampleProperties.java
@@ -9,21 +9,20 @@ import org.talend.daikon.properties.property.Property;
 
 public class ReferenceExampleProperties extends PropertiesImpl {
 
-
     public Property<String> parentProp = newString("parentProp", "initialparentValue");
-    public TestReferenceProperties reference = new TestReferenceProperties("reference");
 
+    public TestReferenceProperties reference = new TestReferenceProperties("reference");
 
     public ReferenceExampleProperties(String name) {
         super(name);
         reference.componentType.setValue("TestReference");
         reference.referenceType.setValue(ReferenceType.COMPONENT_TYPE);
     }
-    
+
     public static class TestReferenceProperties extends PropertiesImpl implements ReferenceProperties {
 
         public Property<String> childProp = newString("childProp", "initialChildValue");
-        
+
         public TestReferenceProperties(String name) {
             super(name);
         }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**



**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
First implementation of the reference properties.
A properties should not serialize its referenceProperties, but you will get the
type of the referenced properties instead.
The deserialization will not crash if a referenced properties is missing.
When you have deserialized all your object your can call the method
"JsonSchemaUtil.resolveReferenceProperties" to rebuild the complete object.
These method are going to be use to serialize and deserialize the Datasets
and the Datastores.