### PR TITLE
fix (TDI-37709) : remove jodatime in daikon bundle to fix comp build

### DIFF
--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -24,11 +24,6 @@
 	</properties>
 	<dependencies>
 		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.8.2</version>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
 			<version>${avro.version}</version>
@@ -98,6 +93,12 @@
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>2.2.15</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+			<version>2.8.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -95,12 +95,6 @@
 			<version>2.2.15</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.8.2</version>
-			<scope>test</scope>
-		</dependency>
 
 	</dependencies>
 	<build>

--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -27,6 +27,7 @@
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>2.8.2</version>
+            <optional>true</optional>			
 		</dependency>
 		<dependency>
 			<groupId>org.apache.avro</groupId>
@@ -181,8 +182,8 @@
 								<DynamicImport-Package>*</DynamicImport-Package>
 								<Service-Component>*</Service-Component>
 								<Embed-Transitive>true</Embed-Transitive>
-								<Embed-Dependency>*;artifactId=paranamer|snappy-java|commons-compress|xz;inline=true</Embed-Dependency>
-								<Import-Package>com.cedarsoftware.*;resolution:=optional,com.fasterxml.*;resolution:=optional,org.apache.*;resolution:=optional,*</Import-Package>
+								<Embed-Dependency>*;artifactId=paranamer|snappy-java|commons-compress|xz|joda-time;inline=false</Embed-Dependency>
+								<Import-Package>!org.joda.convert,com.cedarsoftware.*;resolution:=optional,com.fasterxml.*;resolution:=optional,org.apache.*;resolution:=optional,*</Import-Package>
 							</instructions>
 						</configuration>
 					</execution>

--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -27,7 +27,6 @@
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time</artifactId>
 			<version>2.8.2</version>
-            <optional>true</optional>			
 		</dependency>
 		<dependency>
 			<groupId>org.apache.avro</groupId>
@@ -182,8 +181,8 @@
 								<DynamicImport-Package>*</DynamicImport-Package>
 								<Service-Component>*</Service-Component>
 								<Embed-Transitive>true</Embed-Transitive>
-								<Embed-Dependency>*;artifactId=paranamer|snappy-java|commons-compress|xz|joda-time;inline=false</Embed-Dependency>
-								<Import-Package>!org.joda.convert,com.cedarsoftware.*;resolution:=optional,com.fasterxml.*;resolution:=optional,org.apache.*;resolution:=optional,*</Import-Package>
+								<Embed-Dependency>*;artifactId=paranamer|snappy-java|commons-compress|xz;inline=true</Embed-Dependency>
+								<Import-Package>com.cedarsoftware.*;resolution:=optional,com.fasterxml.*;resolution:=optional,org.apache.*;resolution:=optional,*</Import-Package>
 							</instructions>
 						</configuration>
 					</execution>

--- a/daikon/src/main/java/org/talend/daikon/di/DiOutgoingSchemaEnforcer.java
+++ b/daikon/src/main/java/org/talend/daikon/di/DiOutgoingSchemaEnforcer.java
@@ -15,6 +15,7 @@ package org.talend.daikon.di;
 import static org.talend.daikon.di.DiSchemaConstants.TALEND6_COLUMN_TALEND_TYPE;
 
 import java.math.BigDecimal;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -22,7 +23,6 @@ import org.apache.avro.LogicalType;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
-import org.apache.avro.data.TimeConversions;
 import org.apache.avro.generic.IndexedRecord;
 import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.SchemaConstants;
@@ -126,12 +126,6 @@ public class DiOutgoingSchemaEnforcer implements IndexedRecord {
      */
     private boolean firstRecordProcessed = false;
 
-    private TimeConversions.DateConversion dateConversion = new TimeConversions.DateConversion();
-
-    private TimeConversions.TimeConversion timeConversion = new TimeConversions.TimeConversion();
-
-    private TimeConversions.TimestampConversion timestampConversion = new TimeConversions.TimestampConversion();
-
     /**
      * Constructor sets design schema and {@link IndexMapper} instance
      *
@@ -211,11 +205,14 @@ public class DiOutgoingSchemaEnforcer implements IndexedRecord {
         LogicalType logicalType = nonnull.getLogicalType();
         if (logicalType != null) {
             if (logicalType == LogicalTypes.date()) {
-                return dateConversion.fromInt((Integer) value, nonnull, logicalType).toDate();
+                Calendar c = Calendar.getInstance();
+                c.setTimeInMillis(0L);
+                c.add(Calendar.DATE, (Integer) value);
+                return c.getTime();
             } else if (logicalType == LogicalTypes.timeMillis()) {
                 return value;
             } else if (logicalType == LogicalTypes.timestampMillis()) {
-                return timestampConversion.fromLong((Long) value, nonnull, logicalType).toDate();
+                return new Date((Long) value);
             }
         }
 

--- a/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
@@ -43,7 +43,7 @@ public class DiOutgoingSchemaEnforcerTest {
     /**
      * 1000 days after 1970-01-01, equal to 1972-09-27.
      */
-    private static Date DATE_COMPARE = new Date(1000 * 60 * 60 * 24 * 1000L);
+    private static Date DATE_COMPARE = new Date(NUM_DAYS * 60 * 60 * 24 * 1000L);
 
     /**
      * Creates runtime schema, design schema and record, which is used as test arguments

--- a/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
@@ -3,18 +3,14 @@ package org.talend.daikon.di;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 
-import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.util.Date;
 
-import org.apache.avro.LogicalType;
-import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
-import org.joda.time.LocalDate;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.talend.daikon.avro.AvroUtils;
@@ -44,7 +40,10 @@ public class DiOutgoingSchemaEnforcerTest {
 
     private static int NUM_DAYS = 1000;
 
-    private static Date DATE_COMPARE = new LocalDate(1970, 1, 1).plusDays(1000).toDate();
+    /**
+     * 1000 days after 1970-01-01, equal to 1972-09-27.
+     */
+    private static Date DATE_COMPARE = new Date(1000 * 60 * 60 * 24 * 1000L);
 
     /**
      * Creates runtime schema, design schema and record, which is used as test arguments


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Build / CI related changes

**What is the current behavior?** (You can also link to an open issue here)
daikon bundle expects joda-time package to be provided by another bundle. this break *components* build.


**What is the new behavior?**
I have embedded joda-time in the bundle. I did not exported it cause it is used by DI specific classes that are supposed to be moved to the Studio. 
I have made the maven dependencies optional to not impact other projects relying on daikon because all of them will never use the di classes.


**Does this PR introduce a breaking change?**
- [x] No
