### PR TITLE
Add a base class for IndexedRecord implementations that are Comparable.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/avro/converter/CachedIndexedRecordConverterBase.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/converter/CachedIndexedRecordConverterBase.java
@@ -1,16 +1,14 @@
 package org.talend.daikon.avro.converter;
 
+import java.lang.reflect.Array;
+import java.util.Arrays;
+
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.IndexedRecord;
-import org.apache.avro.reflect.ReflectData;
-import org.apache.avro.specific.SpecificData;
 import org.talend.daikon.avro.AvroUtils;
 import org.talend.daikon.avro.container.ContainerReaderByIndex;
 import org.talend.daikon.avro.container.ContainerWriterByIndex;
-
-import java.lang.reflect.Array;
-import java.util.Arrays;
 
 /**
  * This abstract base class provides an implementation of an {@link IndexedRecordConverter} that caches the maximum
@@ -213,7 +211,7 @@ public abstract class CachedIndexedRecordConverterBase<ContainerDataSpecT, Field
      * An Adapter that maps the given {@link GettableT} to have the appearance of an Avro {@link IndexedRecord}. This
      * relies heavily on the cached and unchanging information stored in the factory.
      */
-    private class IndexedRecordAdapterWithCache implements IndexedRecord, Comparable<IndexedRecord> {
+    private class IndexedRecordAdapterWithCache extends ComparableIndexedRecordBase {
 
         /** The wrapped data. */
         public GettableT gettable;
@@ -254,31 +252,8 @@ public abstract class CachedIndexedRecordConverterBase<ContainerDataSpecT, Field
         }
 
         @Override
-        public int hashCode() {
-            // Base the hash code only on the schema.
-            return SpecificData.get().hashCode(this, getSchema());
-        }
-
-        @Override
-        public boolean equals(Object that) {
-            if (that == this) {
-                return true; // identical object
-            }
-            if (!(that instanceof IndexedRecord)) {
-                return false; // not a record
-            }
-            return compareTo((IndexedRecord) that) == 0;
-        }
-
-        @Override
         public String toString() {
             return gettable.toString();
         }
-
-        @Override
-        public int compareTo(IndexedRecord that) {
-            return ReflectData.get().compare(this, that, getSchema());
-        }
-
     }
 }

--- a/daikon/src/main/java/org/talend/daikon/avro/converter/ComparableIndexedRecordBase.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/converter/ComparableIndexedRecordBase.java
@@ -30,7 +30,7 @@ public abstract class ComparableIndexedRecordBase implements IndexedRecord, Comp
         IndexedRecord that = (IndexedRecord) o;
         if (!this.getSchema().equals(that.getSchema()))
             return false;
-        // TODO(rskraba): there should be an better/faster compare for Avro!
+        // TODO(rskraba): there should be an better&faster compare for Avro!
         return GenericData.get().compare(this, that, getSchema()) == 0;
     }
 

--- a/daikon/src/main/java/org/talend/daikon/avro/converter/ComparableIndexedRecordBase.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/converter/ComparableIndexedRecordBase.java
@@ -1,0 +1,51 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.avro.converter;
+
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.IndexedRecord;
+
+/**
+ * A base for {@link IndexedRecord} implementations that respect the Java {@link Object} contracts for {@link #equals},
+ * {@link #hashCode} and {@link #compareTo}.
+ */
+public abstract class ComparableIndexedRecordBase implements IndexedRecord, Comparable<IndexedRecord> {
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof IndexedRecord))
+            return false;
+        IndexedRecord that = (IndexedRecord) o;
+        if (!this.getSchema().equals(that.getSchema()))
+            return false;
+        // TODO(rskraba): there should be an better/faster compare for Avro!
+        return GenericData.get().compare(this, that, getSchema()) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return GenericData.get().hashCode(this, getSchema());
+    }
+
+    @Override
+    public int compareTo(IndexedRecord that) {
+        return GenericData.get().compare(this, that, getSchema());
+    }
+
+    @Override
+    public String toString() {
+        return GenericData.get().toString(this);
+    }
+}

--- a/daikon/src/main/java/org/talend/daikon/avro/converter/SingleColumnIndexedRecordConverter.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/converter/SingleColumnIndexedRecordConverter.java
@@ -14,7 +14,6 @@ package org.talend.daikon.avro.converter;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.IndexedRecord;
 
 /**
@@ -105,7 +104,7 @@ public class SingleColumnIndexedRecordConverter<DatumT>
      * 
      * @param <T> The primitive type to wrap.
      */
-    public static class PrimitiveAsIndexedRecordAdapter<T> implements IndexedRecord, Comparable<IndexedRecord> {
+    public static class PrimitiveAsIndexedRecordAdapter<T> extends ComparableIndexedRecordBase {
 
         private final T mValue;
 
@@ -130,34 +129,5 @@ public class SingleColumnIndexedRecordConverter<DatumT>
         public void put(int i, Object v) {
             throw new UnmodifiableAdapterException();
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this)
-                return true;
-            if (!(o instanceof IndexedRecord))
-                return false;
-            IndexedRecord that = (IndexedRecord) o;
-            if (!this.getSchema().equals(that.getSchema()))
-                return false;
-            // TODO(rskraba): there should be an better/faster compare for Avro!
-            return GenericData.get().compare(this, that, getSchema()) == 0;
-        }
-
-        @Override
-        public int hashCode() {
-            return GenericData.get().hashCode(this, getSchema());
-        }
-
-        @Override
-        public int compareTo(IndexedRecord that) {
-            return GenericData.get().compare(this, that, getSchema());
-        }
-
-        @Override
-        public String toString() {
-            return GenericData.get().toString(this);
-        }
-
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Currently, some IndexedRecord wrappers (adapting a technology-specific object) don't need to implement `compareTo` and can use the default behaviour for `equals()` and `hashCode()`

**What is the new behavior?**

In a big data environment, however, it is important that two IndexedRecords that have identical content according to Avro correctly implement `equals()` and `hashCode()`.

Since Avro provides a standard mechanism to do this, this PR adds a base class to automatically provide coherent `equals()`, `hashCode()` and `compareTo()` methods.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ..


**Other information**:
