### PR TITLE
Bugfix/6.3/tdi 37866 dynamic enforcer

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/di/DynamicIndexMapperByIndex.java
+++ b/daikon/src/main/java/org/talend/daikon/di/DynamicIndexMapperByIndex.java
@@ -43,8 +43,9 @@ class DynamicIndexMapperByIndex implements DynamicIndexMapper {
      */
     DynamicIndexMapperByIndex(Schema designSchema) {
         this.designSchemaSize = designSchema.getFields().size();
-        if (AvroUtils.isIncludeAllFields(designSchema)) {
-            dynamicFieldPosition = Integer.valueOf(designSchema.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION));
+        String dynamicFieldProperty = designSchema.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION);
+        if (AvroUtils.isIncludeAllFields(designSchema) && dynamicFieldProperty != null) {
+            dynamicFieldPosition = Integer.valueOf(dynamicFieldProperty);
         } else {
             throw new IllegalArgumentException("Design schema doesn't contain dynamic field");
         }

--- a/daikon/src/main/java/org/talend/daikon/di/DynamicIndexMapperByName.java
+++ b/daikon/src/main/java/org/talend/daikon/di/DynamicIndexMapperByName.java
@@ -54,8 +54,9 @@ class DynamicIndexMapperByName implements DynamicIndexMapper {
         this.designSchema = designSchema;
         this.designFields = designSchema.getFields();
         this.designSchemaSize = designFields.size();
-        if (AvroUtils.isIncludeAllFields(designSchema)) {
-            dynamicFieldPosition = Integer.valueOf(designSchema.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION));
+        String dynamicFieldProperty = designSchema.getProp(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION);
+        if (AvroUtils.isIncludeAllFields(designSchema) && dynamicFieldProperty != null) {
+            dynamicFieldPosition = Integer.valueOf(dynamicFieldProperty);
         } else {
             throw new IllegalArgumentException("Runtime schema doesn't contain dynamic field");
         }

--- a/daikon/src/main/java/org/talend/daikon/di/DynamicIndexMapperByName.java
+++ b/daikon/src/main/java/org/talend/daikon/di/DynamicIndexMapperByName.java
@@ -72,10 +72,8 @@ class DynamicIndexMapperByName implements DynamicIndexMapper {
     public int[] computeIndexMap(Schema runtimeSchema) {
         int[] indexMap = new int[designSchemaSize + 1];
 
+        indexMap[dynamicFieldPosition] = DYNAMIC;
         for (int i = 0; i < designSchemaSize; i++) {
-            if (i == dynamicFieldPosition) {
-                indexMap[dynamicFieldPosition] = DYNAMIC;
-            }
             Field designField = designFields.get(i);
             String fieldName = designField.name();
             Field runtimeField = runtimeSchema.getField(fieldName);

--- a/daikon/src/main/java/org/talend/daikon/di/DynamicIndexMapperByName.java
+++ b/daikon/src/main/java/org/talend/daikon/di/DynamicIndexMapperByName.java
@@ -58,7 +58,7 @@ class DynamicIndexMapperByName implements DynamicIndexMapper {
         if (AvroUtils.isIncludeAllFields(designSchema) && dynamicFieldProperty != null) {
             dynamicFieldPosition = Integer.valueOf(dynamicFieldProperty);
         } else {
-            throw new IllegalArgumentException("Runtime schema doesn't contain dynamic field");
+            throw new IllegalArgumentException("Design schema doesn't contain dynamic field");
         }
     }
 

--- a/daikon/src/test/java/org/talend/daikon/di/DynamicIndexMapperByIndexTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DynamicIndexMapperByIndexTest.java
@@ -13,8 +13,8 @@
 package org.talend.daikon.di;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertArrayEquals;
 
 import java.util.Arrays;
@@ -23,13 +23,77 @@ import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.talend.daikon.avro.SchemaConstants;
 
 /**
  * Unit-tests for {@link DynamicIndexMapperByIndex} class
  */
 public class DynamicIndexMapperByIndexTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * Checks {@link DynamicIndexMapperByIndex#DynamicIndexMapperByIndex(Schema)} throws {@link IllegalArgumentException}
+     * in case when incoming design schema doesn't contain dynamic field
+     * Case#1 INCLUDE_ALL_FIELDS is not present
+     */
+    @Test
+    public void testConstructorDynamicNotPresent1() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Design schema doesn't contain dynamic field");
+
+        Schema designSchemaWithoutIncludeAllFields = SchemaBuilder.builder().record("Record") //
+                .prop(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0").fields() //
+                .name("col1").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .name("col3").type().intType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByIndex indexMapper = new DynamicIndexMapperByIndex(designSchemaWithoutIncludeAllFields);
+    }
+
+    /**
+     * Checks {@link DynamicIndexMapperByIndex#DynamicIndexMapperByIndex(Schema)} throws {@link IllegalArgumentException}
+     * in case when incoming design schema doesn't contain dynamic field
+     * Case#2 TALEND6_DYNAMIC_COLUMN_POSITION is not present
+     */
+    @Test
+    public void testConstructorDynamicNotPresent2() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Design schema doesn't contain dynamic field");
+
+        Schema designSchemaWithoutDynamicColumnPosition = SchemaBuilder.builder().record("Record") //
+                .prop(SchemaConstants.INCLUDE_ALL_FIELDS, "true").fields() //
+                .name("col1").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .name("col3").type().intType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByIndex indexMapper = new DynamicIndexMapperByIndex(designSchemaWithoutDynamicColumnPosition);
+    }
+
+    /**
+     * Checks {@link DynamicIndexMapperByIndex#DynamicIndexMapperByIndex(Schema)} throws {@link IllegalArgumentException}
+     * in case when incoming design schema doesn't contain dynamic field
+     * Case#3 both TALEND6_DYNAMIC_COLUMN_POSITION and INCLUDE_ALL_FIELDS are not present
+     */
+    @Test
+    public void testConstructorDynamicNotPresent3() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Design schema doesn't contain dynamic field");
+
+        Schema designSchemaWithoutDynamic = SchemaBuilder.builder().record("Record").fields() //
+                .name("col1").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .name("col3").type().intType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByIndex indexMapper = new DynamicIndexMapperByIndex(designSchemaWithoutDynamic);
+    }
 
     /**
      * Checks {@link DynamicIndexMapperByIndex#computeIndexMap()} returns int array, which size equals n+1 and

--- a/daikon/src/test/java/org/talend/daikon/di/DynamicIndexMapperByNameTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DynamicIndexMapperByNameTest.java
@@ -90,6 +90,66 @@ public class DynamicIndexMapperByNameTest {
     }
     
     /**
+     * Checks {@link DynamicIndexMapperByName#computeIndexMap()} returns int array, which size equals n+1 and
+     * with values which equal indexes of corresponding fields in runtime schema, where n - number of fields in design schema
+     * and dynamic field position is in the middle
+     */
+    @Test
+    public void testComputeIndexMapMiddle() {
+        int[] expectedIndexMap = { 0, -1, 3, 4 };
+
+        Schema designSchema = SchemaBuilder.builder().record("Record") //
+                .prop(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "1").prop(SchemaConstants.INCLUDE_ALL_FIELDS, "true")
+                .fields() //
+                .name("col0").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .name("col3").type().intType().noDefault() //
+                .endRecord(); //
+
+        Schema runtimeSchema = SchemaBuilder.builder().record("Record").fields() //
+                .name("col0").type().intType().noDefault() //
+                .name("col1_1").type().intType().noDefault() //
+                .name("col1_2").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .name("col3").type().intType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByName indexMapper = new DynamicIndexMapperByName(designSchema);
+        int[] actualIndexMap = indexMapper.computeIndexMap(runtimeSchema);
+        assertArrayEquals(expectedIndexMap, actualIndexMap);
+    }
+
+    /**
+     * Checks {@link DynamicIndexMapperByName#computeIndexMap()} returns int array, which size equals n+1 and
+     * with values which equal indexes of corresponding fields in runtime schema, where n - number of fields in design schema
+     * and dynamic field position is in the end
+     */
+    @Test
+    public void testComputeIndexMapEnd() {
+        int[] expectedIndexMap = { 0, 1, 2, -1 };
+
+        Schema designSchema = SchemaBuilder.builder().record("Record") //
+                .prop(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "3").prop(SchemaConstants.INCLUDE_ALL_FIELDS, "true")
+                .fields() //
+                .name("col0").type().intType().noDefault() //
+                .name("col1").type().stringType().noDefault() //
+                .name("col2").type().intType().noDefault() //
+                .endRecord(); //
+
+        Schema runtimeSchema = SchemaBuilder.builder().record("Record").fields() //
+                .name("col0").type().intType().noDefault() //
+                .name("col1").type().intType().noDefault() //
+                .name("col2").type().intType().noDefault() //
+                .name("col3_1").type().stringType().noDefault() //
+                .name("col3_2").type().intType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByName indexMapper = new DynamicIndexMapperByName(designSchema);
+        int[] actualIndexMap = indexMapper.computeIndexMap(runtimeSchema);
+        assertArrayEquals(expectedIndexMap, actualIndexMap);
+    }
+    
+    /**
      * Checks {@link DynamicIndexMapperByName#computeIndexMap()} in case when design schema has only 1 dynamic field
      * and no more other fields. Method should return int array, which size is 1 and the only element = -1
      * Test-case related to https://jira.talendforge.org/browse/TDI-37866

--- a/daikon/src/test/java/org/talend/daikon/di/DynamicIndexMapperByNameTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DynamicIndexMapperByNameTest.java
@@ -88,6 +88,31 @@ public class DynamicIndexMapperByNameTest {
         int[] actualIndexMap = indexMapper.computeIndexMap(runtimeSchema);
         assertArrayEquals(expectedIndexMap, actualIndexMap);
     }
+    
+    /**
+     * Checks {@link DynamicIndexMapperByName#computeIndexMap()} in case when design schema has only 1 dynamic field
+     * and no more other fields. Method should return int array, which size is 1 and the only element = -1
+     * Test-case related to https://jira.talendforge.org/browse/TDI-37866
+     */
+    @Test
+    public void testComputeIndexMapOnlyDynamic() {
+        int[] expectedIndexMap = { -1 };
+
+        Schema designSchema = SchemaBuilder.builder().record("Record") //
+                .prop(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0") //
+                .prop(SchemaConstants.INCLUDE_ALL_FIELDS, "true").fields() //
+                .endRecord(); //
+
+        Schema runtimeSchema = SchemaBuilder.builder().record("Record").fields() //
+                .name("col0").type().intType().noDefault() //
+                .name("col1").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByName indexMapper = new DynamicIndexMapperByName(designSchema);
+        int[] actualIndexMap = indexMapper.computeIndexMap(runtimeSchema);
+        assertArrayEquals(expectedIndexMap, actualIndexMap);
+    }
 
     /**
      * Checks {@link DynamicIndexMapperByName#DynamicIndexMapperByName(Schema, Schema)} throws {@link IllegalArgumentException}

--- a/daikon/src/test/java/org/talend/daikon/di/DynamicIndexMapperByNameTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DynamicIndexMapperByNameTest.java
@@ -21,13 +21,77 @@ import java.util.List;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.hamcrest.collection.IsIterableContainingInOrder;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.talend.daikon.avro.SchemaConstants;
 
 /**
  * Unit-tests for {@link DynamicIndexMapperByName} class
  */
 public class DynamicIndexMapperByNameTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    /**
+     * Checks {@link DynamicIndexMapperByName#DynamicIndexMapperByName(Schema)} throws {@link IllegalArgumentException}
+     * in case when incoming design schema doesn't contain dynamic field
+     * Case#1 INCLUDE_ALL_FIELDS is not present
+     */
+    @Test
+    public void testConstructorDynamicNotPresent1() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Design schema doesn't contain dynamic field");
+
+        Schema designSchemaWithoutIncludeAllFields = SchemaBuilder.builder().record("Record") //
+                .prop(DiSchemaConstants.TALEND6_DYNAMIC_COLUMN_POSITION, "0").fields() //
+                .name("col1").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .name("col3").type().intType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByName indexMapper = new DynamicIndexMapperByName(designSchemaWithoutIncludeAllFields);
+    }
+
+    /**
+     * Checks {@link DynamicIndexMapperByName#DynamicIndexMapperByName(Schema)} throws {@link IllegalArgumentException}
+     * in case when incoming design schema doesn't contain dynamic field
+     * Case#2 TALEND6_DYNAMIC_COLUMN_POSITION is not present
+     */
+    @Test
+    public void testConstructorDynamicNotPresent2() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Design schema doesn't contain dynamic field");
+
+        Schema designSchemaWithoutDynamicColumnPosition = SchemaBuilder.builder().record("Record") //
+                .prop(SchemaConstants.INCLUDE_ALL_FIELDS, "true").fields() //
+                .name("col1").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .name("col3").type().intType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByName indexMapper = new DynamicIndexMapperByName(designSchemaWithoutDynamicColumnPosition);
+    }
+
+    /**
+     * Checks {@link DynamicIndexMapperByName#DynamicIndexMapperByName(Schema)} throws {@link IllegalArgumentException}
+     * in case when incoming design schema doesn't contain dynamic field
+     * Case#3 both TALEND6_DYNAMIC_COLUMN_POSITION and INCLUDE_ALL_FIELDS are not present
+     */
+    @Test
+    public void testConstructorDynamicNotPresent3() {
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Design schema doesn't contain dynamic field");
+
+        Schema designSchemaWithoutDynamic = SchemaBuilder.builder().record("Record").fields() //
+                .name("col1").type().intType().noDefault() //
+                .name("col2").type().stringType().noDefault() //
+                .name("col3").type().intType().noDefault() //
+                .endRecord(); //
+
+        DynamicIndexMapperByName indexMapper = new DynamicIndexMapperByName(designSchemaWithoutDynamic);
+    }
 
     /**
      * Checks {@link DynamicIndexMapperByName#computeIndexMap()} returns int array, which size equals n+1 and
@@ -88,7 +152,7 @@ public class DynamicIndexMapperByNameTest {
         int[] actualIndexMap = indexMapper.computeIndexMap(runtimeSchema);
         assertArrayEquals(expectedIndexMap, actualIndexMap);
     }
-    
+
     /**
      * Checks {@link DynamicIndexMapperByName#computeIndexMap()} returns int array, which size equals n+1 and
      * with values which equal indexes of corresponding fields in runtime schema, where n - number of fields in design schema
@@ -148,7 +212,7 @@ public class DynamicIndexMapperByNameTest {
         int[] actualIndexMap = indexMapper.computeIndexMap(runtimeSchema);
         assertArrayEquals(expectedIndexMap, actualIndexMap);
     }
-    
+
     /**
      * Checks {@link DynamicIndexMapperByName#computeIndexMap()} in case when design schema has only 1 dynamic field
      * and no more other fields. Method should return int array, which size is 1 and the only element = -1


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

There is an error in DynamicIndexMapperByName#computeIndexMap()

It computes indexMap incorrectly when design schema contains only dynamic field

**What is the new behavior?**

Fixed above bug

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

Related to https://jira.talendforge.org/browse/TDI-37866
