### PR TITLE
feat (test) : add a test base class for defintions and properties i18n

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/definition/I18nDefinition.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/I18nDefinition.java
@@ -1,0 +1,43 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.definition;
+
+import org.talend.daikon.NamedThing;
+import org.talend.daikon.SimpleNamedThing;
+
+/**
+ * Base class for all definitions that require some standard way of setting their title and displayName.<br>
+ * for displayName you shall provide a properties file with the key <b>definition.XXX.displayName</b> where XXX is the value
+ * returned by {@link NamedThing#getName()}<br>
+ * for title you shall provide a properties file with the key <b>definition.XXX.title</b> where XXX is the value returned by
+ * {@link NamedThing#getName()}<br>
+ */
+public class I18nDefinition extends SimpleNamedThing {
+
+    public static final String DEFINITION_I18N_PREFIX = "definition.";
+
+    public I18nDefinition(String name) {
+        super(name);
+    }
+
+    @Override
+    public String getDisplayName() {
+        return getName() != null ? getI18nMessage(DEFINITION_I18N_PREFIX + getName() + I18N_DISPLAY_NAME_SUFFIX) : "";
+    }
+
+    @Override
+    public String getTitle() {
+        return getName() != null ? getI18nMessage(DEFINITION_I18N_PREFIX + getName() + I18N_TITLE_NAME_SUFFIX) : "";
+    }
+
+}

--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
@@ -601,7 +601,7 @@ public class PropertiesImpl extends TranslatableImpl implements Properties, AnyP
 
     @Override
     public String getDisplayName() {
-        return getName() != null ? getI18nMessage("properties." + getName() + ".displayName") : "";
+        return getName() != null ? getI18nMessage("properties." + getName() + I18N_DISPLAY_NAME_SUFFIX) : "";
     }
 
     @Override

--- a/daikon/src/test/java/org/talend/daikon/properties/TestAbstractPropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/TestAbstractPropertiesTest.java
@@ -1,0 +1,53 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.properties;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.talend.daikon.definition.Definition;
+import org.talend.daikon.definition.service.DefinitionRegistryService;
+import org.talend.daikon.properties.test.AbstractPropertiesTest;
+import org.talend.daikon.properties.testproperties.TestProperties;
+
+public class TestAbstractPropertiesTest {
+
+    @Test
+    public void test() {
+        AbstractPropertiesTest propertiesTest = new AbstractPropertiesTest() {
+
+            @Override
+            public DefinitionRegistryService getDefinitionRegistry() {
+                DefinitionRegistryService defRegServ = mock(DefinitionRegistryService.class);
+                Definition repDef = when(mock(Definition.class).getName()).thenReturn("NAME").getMock();
+                when(repDef.getPropertiesClass()).thenReturn(TestProperties.class);
+                when(defRegServ.getDefinitionsMapByType(Definition.class)).thenReturn(Collections.singletonMap("NAME", repDef));
+                return defRegServ;
+            }
+        };
+        // check for an existing definition
+        propertiesTest.assertComponentIsRegistered("NAME");
+        // check for a non existing def
+        try {
+            propertiesTest.assertComponentIsRegistered("XXX");
+            fail("assertiong should have failed in the above line");
+        } catch (AssertionError ae) {
+            // this is ok if we have an error
+        }
+
+    }
+
+}

--- a/daikon/src/test/java/org/talend/daikon/properties/TestPropertiesTestUtils.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/TestPropertiesTestUtils.java
@@ -1,0 +1,137 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.properties;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.talend.daikon.definition.Definition;
+import org.talend.daikon.definition.service.DefinitionRegistryService;
+import org.talend.daikon.i18n.I18nMessages;
+import org.talend.daikon.properties.test.PropertiesTestUtils;
+import org.talend.daikon.properties.testproperties.TestProperties;
+
+public class TestPropertiesTestUtils {
+
+    private class ADefinition implements Definition {
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return null;
+        }
+
+        @Override
+        public String getTitle() {
+            return null;
+        }
+
+        @Override
+        public void setI18nMessageFormatter(I18nMessages i18nMessages) {
+
+        }
+
+        @Override
+        public String getI18nMessage(String key, Object... arguments) {
+            return null;
+        }
+
+        @Override
+        public Class getPropertiesClass() {
+            return null;
+        }
+
+        @Override
+        public String getImagePath() {
+            return null;
+        }
+    }
+
+    @Test
+    public void testAssertAlli18nAreSetup() {
+        DefinitionRegistryService defRegServ = mock(DefinitionRegistryService.class);
+        Definition repDef = when(mock(Definition.class).getName()).thenReturn("NAME").getMock();
+        when(repDef.getPropertiesClass()).thenReturn(TestProperties.class);
+        when(defRegServ.getDefinitionsMapByType(Definition.class)).thenReturn(Collections.singletonMap("NAME", repDef));
+
+        ErrorCollector errorCollector = spy(new ErrorCollector());
+        // check when everything is fine
+        when(repDef.getDisplayName()).thenReturn("foo");
+        when(repDef.getTitle()).thenReturn("bar");
+
+        PropertiesTestUtils.assertAlli18nAreSetup(defRegServ, errorCollector);
+
+        verify(errorCollector, times(0)).addError(any(Throwable.class));
+
+        // check when displayName and title is missing
+        errorCollector = spy(new ErrorCollector());
+        when(repDef.getDisplayName()).thenReturn(Definition.I18N_DISPLAY_NAME_SUFFIX);
+        when(repDef.getTitle()).thenReturn(Definition.I18N_TITLE_NAME_SUFFIX);
+
+        PropertiesTestUtils.assertAlli18nAreSetup(defRegServ, errorCollector);
+
+        verify(errorCollector, times(2)).addError(any(Throwable.class));
+
+        // check when displayName and title are null
+        errorCollector = spy(new ErrorCollector());
+        when(repDef.getDisplayName()).thenReturn(null);
+        when(repDef.getTitle()).thenReturn(null);
+
+        PropertiesTestUtils.assertAlli18nAreSetup(defRegServ, errorCollector);
+
+        verify(errorCollector, times(2)).addError(any(Throwable.class));
+
+    }
+
+    @Test
+    public void testAssertAllImagesAreSetup() {
+        // create a registry with one definition
+        DefinitionRegistryService defRegServ = mock(DefinitionRegistryService.class);
+        Definition repDef = when(mock(ADefinition.class).getName()).thenReturn("NAME").getMock();
+        when(repDef.getPropertiesClass()).thenReturn(TestProperties.class);
+        when(defRegServ.getDefinitionsMapByType(Definition.class)).thenReturn(Collections.singletonMap("NAME", repDef));
+
+        // check when everything is fine
+        ErrorCollector errorCollector = spy(new ErrorCollector());
+        when(repDef.getImagePath()).thenReturn("/org/talend/daikon/properties/messages.properties");
+
+        PropertiesTestUtils.assertAllImagesAreSetup(defRegServ, errorCollector);
+
+        verify(errorCollector, times(0)).addError(any(Throwable.class));
+
+        // check when path is missing
+        errorCollector = spy(new ErrorCollector());
+        when(repDef.getImagePath()).thenReturn(null);
+
+        PropertiesTestUtils.assertAllImagesAreSetup(defRegServ, errorCollector);
+
+        verify(errorCollector, times(1)).addError(any(Throwable.class));
+
+        // check when path is wrong
+        errorCollector = spy(new ErrorCollector());
+        when(repDef.getImagePath()).thenReturn("foo");
+
+        PropertiesTestUtils.assertAllImagesAreSetup(defRegServ, errorCollector);
+
+        verify(errorCollector, times(1)).addError(any(Throwable.class));
+    }
+
+}

--- a/daikon/src/test/java/org/talend/daikon/properties/test/AbstractPropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/test/AbstractPropertiesTest.java
@@ -1,0 +1,54 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.properties.test;
+
+import static org.junit.Assert.*;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.talend.daikon.definition.Definition;
+import org.talend.daikon.definition.service.DefinitionRegistryService;
+
+public abstract class AbstractPropertiesTest {
+
+    // for benchmarking the apis, one suggestion is to use http://openjdk.java.net/projects/code-tools/jmh/.
+    @Rule
+    public ErrorCollector errorCollector = new ErrorCollector();
+
+    abstract public DefinitionRegistryService getDefinitionRegistry();
+
+    /**
+     * checks that all properties created from all the definition in the registry have a proper i18n displayName and title.
+     * As well as checking for each Property and nested Properties.
+     */
+    @Test
+    public void testAlli18n() {
+        PropertiesTestUtils.assertAlli18nAreSetup(getDefinitionRegistry(), errorCollector);
+    }
+
+    /**
+     * checks that all definitions provide an image path to an existing image.
+     */
+    @Test
+    public void testAllImages() {
+        PropertiesTestUtils.assertAllImagesAreSetup(getDefinitionRegistry(), errorCollector);
+    }
+
+    public void assertComponentIsRegistered(String definitionName) {
+        Definition definition = getDefinitionRegistry().getDefinitionsMapByType(Definition.class).get(definitionName);
+        assertNotNull("Could not find the definition [" + definitionName + "], please check the registered definitions",
+                definition);
+    }
+
+}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Other... Please describe: adding test base classes.

**What is the current behavior?** (You can also link to an open issue here)
No test helper class exists to check on i18n and images for all definition kind. Only the one for the Components exists in the repo *components*


**What is the new behavior?**
Add an Class *AbstractPropertiesTest* that can be extended to check that all i18n is properly setup.
A new *I18nDefinition* class is proposed to setup standard keys for i18n if the definitions.


**Does this PR introduce a breaking change?**

- [x] No

**Other information**:
see the related PR in *components* ( https://github.com/Talend/components/pull/339 )
