### PR TITLE
bug: prevent NullPointerException when parsing an empty Schema 

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonPropertiesResolver.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonPropertiesResolver.java
@@ -10,6 +10,7 @@ import java.util.Date;
 import java.util.List;
 
 import org.apache.avro.Schema;
+import org.apache.commons.lang3.StringUtils;
 import org.talend.daikon.properties.Properties;
 import org.talend.daikon.properties.ReferenceProperties;
 import org.talend.daikon.properties.property.Property;
@@ -70,7 +71,11 @@ public class JsonPropertiesResolver {
         } else if (Boolean.class.equals(type)) {
             return dataNode.booleanValue();
         } else if (Schema.class.equals(type)) {
-            return new Schema.Parser().parse(dataNode.textValue());
+            if (StringUtils.isNotBlank(dataNode.textValue())) {
+                return new Schema.Parser().parse(dataNode.textValue());
+            } else {
+                return null;
+            }
         } else if (type.isEnum()) {
             return Enum.valueOf(type, dataNode.textValue());
         } else if (Date.class.equals(type)) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
When parsing dataset properties with an empty Schema (e.g. JDBC dataset schema in dataprep), there a NullPointerException is triggered.


**What is the new behavior?**
No exception is thrown.


**Does this PR introduce a breaking change?**
- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**: