### PR TITLE
feat(i18n):made definition title equals to displayName if no title is pr…

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/definition/I18nDefinition.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/I18nDefinition.java
@@ -36,7 +36,7 @@ public class I18nDefinition extends SimpleNamedThing {
     }
 
     /**
-     * return the I18N title matching the <b>definition.<name>.title<b> key in the associaated .properties message where <name> is
+     * return the I18N title matching the <b>definition.[name].title</b> key in the associated .properties message where [name] is
      * the value returned by {@link I18nDefinition#getName()}.
      * If no I18N was found then the {@link #getDisplayName()} is used is any is provided.
      */

--- a/daikon/src/main/java/org/talend/daikon/definition/I18nDefinition.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/I18nDefinition.java
@@ -35,9 +35,21 @@ public class I18nDefinition extends SimpleNamedThing {
         return getName() != null ? getI18nMessage(DEFINITION_I18N_PREFIX + getName() + I18N_DISPLAY_NAME_SUFFIX) : "";
     }
 
+    /**
+     * return the I18N title matching the <b>definition.<name>.title<b> key in the associaated .properties message where <name> is
+     * the value returned by {@link I18nDefinition#getName()}.
+     * If no I18N was found then the {@link #getDisplayName()} is used is any is provided.
+     */
     @Override
     public String getTitle() {
-        return getName() != null ? getI18nMessage(DEFINITION_I18N_PREFIX + getName() + I18N_TITLE_NAME_SUFFIX) : "";
+        String title = getName() != null ? getI18nMessage(DEFINITION_I18N_PREFIX + getName() + I18N_TITLE_NAME_SUFFIX) : "";
+        if ("".equals(title) || title.startsWith(DEFINITION_I18N_PREFIX)) {
+            String displayName = getDisplayName();
+            if (!"".equals(displayName) && !displayName.startsWith(DEFINITION_I18N_PREFIX)) {
+                title = displayName;
+            } // else title is what was computed before.
+        } // else title is provided so use it.
+        return title;
     }
 
 }

--- a/daikon/src/test/java/org/talend/daikon/definition/I18nDefinitionTest.java
+++ b/daikon/src/test/java/org/talend/daikon/definition/I18nDefinitionTest.java
@@ -1,0 +1,46 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.definition;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Test;
+
+public class I18nDefinitionTest {
+
+    @Test
+    public void testGetTitle() {
+
+        // check getTitle with proper i18n
+        I18nDefinition i18nDefinition = getMockI18nDef();
+        when(i18nDefinition.getI18nMessage("definition.foo.title")).thenReturn("ZeTitle");
+        assertEquals("ZeTitle", i18nDefinition.getTitle());
+
+        // check getTitle with no i18n but one available for displayname
+        i18nDefinition = getMockI18nDef();
+        when(i18nDefinition.getI18nMessage("definition.foo.displayName")).thenReturn("ZedisplayName");
+        assertEquals("ZedisplayName", i18nDefinition.getTitle());
+
+        // check getTitle with no i18n and no i18n for display name
+        i18nDefinition = getMockI18nDef();
+        assertEquals("definition.foo.title", i18nDefinition.getTitle());
+    }
+
+    private I18nDefinition getMockI18nDef() {
+        I18nDefinition i18nDefinition = spy(new I18nDefinition(""));
+        when(i18nDefinition.getName()).thenReturn("foo");
+        return i18nDefinition;
+    }
+
+}


### PR DESCRIPTION
…ovided

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
definition title is always required even if it is the same as the displayName


**What is the new behavior?**
title is not required anymore and the displayName will be used if not provided.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


this is related to a request in the PR : https://github.com/Talend/components/pull/339
