### PR TITLE
fix: When setting up mvn URL handlers, use maven.repo.local

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
@@ -36,6 +36,13 @@ public class RuntimeUtil {
         try {
             new URL("mvn:foo/bar");
         } catch (MalformedURLException e) {
+
+            // handles mvn local repository
+            String mvnLocalRepo = System.getProperty("maven.repo.local");
+            if (mvnLocalRepo != null) {
+                System.setProperty("org.ops4j.pax.url.mvn.localRepository", mvnLocalRepo);
+            }
+
             // If the URL above failed, the mvn protocol needs to be installed.
             URL.setURLStreamHandlerFactory(new URLStreamHandlerFactory() {
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)



**What is the new behavior?**

If the maven.local.repo is set, it will override the org.ops4j.pax.url.mvn.localRepository.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

This change is mainly necessary during builds and tests, but it is also logical that if a user has set the maven.local.repo system property to use it during pax resolution of mvn URLs.