### PR TITLE
feat(fileIO): cache SandboxedInstance.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeInfo.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeInfo.java
@@ -28,4 +28,22 @@ public interface RuntimeInfo {
     List<URL> getMavenUrlDependencies();
 
     String getRuntimeClassName();
+
+    /**
+     * Override the default equals() computation to be compatible with cache system on {@link RuntimeControllerImpl}
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * Override the default toString() computation to be compatible with cache system on {@link RuntimeControllerImpl}
+     */
+    @Override
+    String toString();
+
+    /**
+     * Override the default hashCode() computation to be compatible with cache system on {@link RuntimeControllerImpl}
+     */
+    @Override
+    public int hashCode();
 }

--- a/daikon/src/test/java/org/talend/daikon/sandbox/SandboxedInstanceTest.java
+++ b/daikon/src/test/java/org/talend/daikon/sandbox/SandboxedInstanceTest.java
@@ -12,7 +12,12 @@
 // ============================================================================
 package org.talend.daikon.sandbox;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -100,6 +105,7 @@ public class SandboxedInstanceTest {
         URLClassLoader urlClassLoader = URLClassLoader
                 .newInstance(Collections.singleton(this.getClass().getResource("zeLib-0.0.1.jar")).toArray(new URL[1]));
         SandboxedInstance sandboxedInstance = new SandboxedInstance(TEST_CLASS_NAME, false, urlClassLoader);
+        Object instance = null;
         try {
             assertNull(sandboxedInstance.isolatedThread);
             assertNull(sandboxedInstance.previousContextClassLoader);
@@ -107,7 +113,7 @@ public class SandboxedInstanceTest {
             ClassLoader previousClassLoader = Thread.currentThread().getContextClassLoader();
             assertNotEquals(urlClassLoader, previousClassLoader);
             assertFalse(ClassLoaderIsolatedSystemProperties.getInstance().isIsolated(urlClassLoader));
-            Object instance = sandboxedInstance.getInstance();
+            instance = sandboxedInstance.getInstance();
             assertTrue(ClassLoaderIsolatedSystemProperties.getInstance().isIsolated(urlClassLoader));
             assertNotNull(instance);
             assertEquals(Thread.currentThread(), sandboxedInstance.isolatedThread);
@@ -118,7 +124,7 @@ public class SandboxedInstanceTest {
             sandboxedInstance.close();
         }
         // check that null is returned once the close is called.
-        assertNull(sandboxedInstance.getInstance());
+        assertEquals(instance, sandboxedInstance.getInstance());
     }
 
     public Object createNewInstanceWithNewClassLoader()


### PR DESCRIPTION
Caching this object will allow the process to not compute it multiple time,
it will dramatically improve the computation time, since the class loading is
now done once by object type.

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, a SandboxedInstance is created for each time there is a rest call. This create a delay of 1 seconds during the class loading and 2 second for the instantiation of a beam pipeline.

**What is the new behavior?**
Reusing existing SandboxedInstance allow us to highly improve this computation time (aka: transform it to 0 second)


**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: 
A `sandboxedInstance` will now still keep its `instance` element alive, even after a clean.


**Other information**:
