### PR TITLE
fix(TCOMP-395): removed JVM caching for mvn URL connections

### DIFF
--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -94,10 +95,28 @@
 			<version>2.2.15</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<!-- this is actually excluded from the test class path cause it is being 
+				loaded dynamically by the tests -->
+			<groupId>org.talend.test</groupId>
+			<artifactId>zeLib</artifactId>
+			<version>0.0.1</version>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+			     <!-- this removes the test lib cause is it being loaded dynamically during the tests -->
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<classpathDependencyExcludes>
+						<classpathDependencyExcludes>org.talend.test:zeLib</classpathDependencyExcludes>
+					</classpathDependencyExcludes>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>

--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
@@ -12,15 +12,17 @@
 // ============================================================================
 package org.talend.daikon.runtime;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
 import org.ops4j.pax.url.mvn.Handler;
 import org.ops4j.pax.url.mvn.ServiceConstants;
 import org.talend.daikon.sandbox.SandboxInstanceFactory;
 import org.talend.daikon.sandbox.SandboxedInstance;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLStreamHandler;
-import java.net.URLStreamHandlerFactory;
 
 public class RuntimeUtil {
 
@@ -42,7 +44,15 @@ public class RuntimeUtil {
                 @Override
                 public URLStreamHandler createURLStreamHandler(String protocol) {
                     if (ServiceConstants.PROTOCOL.equals(protocol)) {
-                        return new Handler();
+                        return new Handler() {
+
+                            @Override
+                            protected URLConnection openConnection(URL url) throws IOException {
+                                URLConnection conn = super.openConnection(url);
+                                conn.setUseCaches(false);// to avoid concurent thread to have an IllegalStateException.
+                                return conn;
+                            }
+                        };
                     } else {
                         return null;
                     }

--- a/daikon/src/test/java/org/talend/daikon/sandbox/SandboxInstanceFactoryTest.java
+++ b/daikon/src/test/java/org/talend/daikon/sandbox/SandboxInstanceFactoryTest.java
@@ -14,19 +14,117 @@ package org.talend.daikon.sandbox;
 
 import static org.junit.Assert.*;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.talend.daikon.runtime.RuntimeUtil;
 
 public class SandboxInstanceFactoryTest {
+
+    static final Logger LOG = LoggerFactory.getLogger(SandboxInstanceFactoryTest.class);
+
+    private class Runnable1 implements Runnable {
+
+        private final AtomicBoolean firstSandBCreated;
+
+        private final AtomicBoolean secondSandBCreated;
+
+        private final AtomicBoolean firstSandBClosed;
+
+        private boolean success;
+
+        private Runnable1(AtomicBoolean firstSandBCreated, AtomicBoolean secondSandBCreated, AtomicBoolean firstSandBClosed) {
+            this.firstSandBCreated = firstSandBCreated;
+            this.secondSandBCreated = secondSandBCreated;
+            this.firstSandBClosed = firstSandBClosed;
+        }
+
+        @Override
+        public void run() {
+            URL libUrl;
+            try {
+                libUrl = new URL("mvn:org.talend.test/zeLib/0.0.1");
+                try (SandboxedInstance sandboxedInstance = SandboxInstanceFactory.createSandboxedInstance(TEST_CLASS_NAME,
+                        Collections.singletonList(libUrl), null, false)) {
+                    this.firstSandBCreated.set(true);
+                    Object obj = sandboxedInstance.getInstance();
+                    waitTrue(this.secondSandBCreated, "secondSandBCreated");
+                    success = true;
+                } finally {
+                    this.firstSandBClosed.set(true);
+                }
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void assertSuccess() {
+            assertTrue(success);
+        }
+
+    }
+
+    private class Runnable2 implements Runnable {
+
+        private final AtomicBoolean secondSandBCreated;
+
+        private final AtomicBoolean firstSandBClosed;
+
+        private final AtomicBoolean firstSandBCreated;
+
+        private boolean success;
+
+        private Runnable2(AtomicBoolean secondSandBCreated, AtomicBoolean firstSandBClosed, AtomicBoolean firstSandBCreated) {
+            this.secondSandBCreated = secondSandBCreated;
+            this.firstSandBClosed = firstSandBClosed;
+            this.firstSandBCreated = firstSandBCreated;
+        }
+
+        @Override
+        public void run() {
+            // wait the first sandbox is created
+            waitTrue(this.firstSandBCreated, "firstSandBCreated");
+            URL libUrl;
+            try {
+                libUrl = new URL("mvn:org.talend.test/zeLib/0.0.1");
+                try (SandboxedInstance sandboxedInstance = SandboxInstanceFactory.createSandboxedInstance(TEST_CLASS_NAME,
+                        Collections.singletonList(libUrl), null, false)) {
+                    Object obj = sandboxedInstance.getInstance();
+                    this.secondSandBCreated.set(true);
+                    waitTrue(this.firstSandBClosed, "firstSandBClosed");
+                    // the next line will throw an IllegalStateException if classloader caches jars.
+                    obj.getClass().getClassLoader().loadClass("foo");
+                } catch (ClassNotFoundException e) {
+                    // expected
+                    success = true;
+                }
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void assertSuccess() {
+            assertTrue(success);
+        }
+    }
 
     private static final String TEST_CLASS_NAME = "org.talend.test.MyClass1";
 
     private Properties previous;
+
+    @BeforeClass
+    static public void setupMvnHandler() {
+        RuntimeUtil.registerMavenUrlHandler();
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -87,4 +185,34 @@ public class SandboxInstanceFactoryTest {
 
         }
     }
+
+    @Test
+    public void test2ThreadCallSameRuntimeWithDifferentClassLoaders() throws InterruptedException {
+        final AtomicBoolean firstSandBCreated = new AtomicBoolean(false);
+        final AtomicBoolean secondSandBCreated = new AtomicBoolean(false);
+        final AtomicBoolean firstSandBClosed = new AtomicBoolean(false);
+        Runnable1 runnable1 = new Runnable1(firstSandBCreated, secondSandBCreated, firstSandBClosed);
+        Runnable2 runnable2 = new Runnable2(secondSandBCreated, firstSandBClosed, firstSandBCreated);
+        Thread thread1 = new Thread(runnable1);
+        Thread thread2 = new Thread(runnable2);
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+        runnable1.assertSuccess();
+        runnable2.assertSuccess();
+    }
+
+    private void waitTrue(final AtomicBoolean valuetoWaitForTrue, String mess) {
+        LOG.debug("waiting for " + mess);
+        while (!valuetoWaitForTrue.get()) {
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException e) {
+                LOG.error("", e);
+            }
+        }
+        LOG.debug(mess + " set to true.");
+    }
+
 }

--- a/daikon/src/test/java/org/talend/daikon/sandbox/SandboxedInstanceTest.java
+++ b/daikon/src/test/java/org/talend/daikon/sandbox/SandboxedInstanceTest.java
@@ -21,10 +21,15 @@ import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.talend.daikon.sandbox.properties.ClassLoaderIsolatedSystemProperties;
 
 public class SandboxedInstanceTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     private static final String TEST_CLASS_NAME = "org.talend.test.MyClass1";
 
@@ -117,8 +122,9 @@ public class SandboxedInstanceTest {
         } finally {
             sandboxedInstance.close();
         }
-        // check that null is returned once the close is called.
-        assertNull(sandboxedInstance.getInstance());
+        // check that an exception is thrown once the close is called.
+        thrown.expect(IllegalStateException.class);
+        sandboxedInstance.getInstance();
     }
 
     public Object createNewInstanceWithNewClassLoader()


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
when a sandboxed classloader in created by 2 threads and using the same jars, and one is closed before the second tries to load some classes, an IllegalStateException occurs.


**What is the new behavior?**
The JVM caching for URL connection has been removed to avoid this behavior.
I have also cleaned the way the sandboxed is closed (not related to this PR but necessary)


**Does this PR introduce a breaking change?**

- [x] No
