### PR TITLE
feat(fileIO): cache SandboxedClassLoader.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeInfo.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeInfo.java
@@ -28,4 +28,22 @@ public interface RuntimeInfo {
     List<URL> getMavenUrlDependencies();
 
     String getRuntimeClassName();
+
+    /**
+     * Override the default equals() computation to be compatible with cache system on {@link RuntimeControllerImpl}
+     */
+    @Override
+    boolean equals(Object obj);
+
+    /**
+     * Override the default toString() computation to be compatible with cache system on {@link RuntimeControllerImpl}
+     */
+    @Override
+    String toString();
+
+    /**
+     * Override the default hashCode() computation to be compatible with cache system on {@link RuntimeControllerImpl}
+     */
+    @Override
+    public int hashCode();
 }

--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
@@ -78,14 +78,12 @@ public class RuntimeUtil {
      * isolation, please read carefully the {@link SandboxedInstance} javadoc.
      */
     public static SandboxedInstance createRuntimeClass(RuntimeInfo runtimeInfo, ClassLoader parentClassLoader) {
-        return SandboxInstanceFactory.createSandboxedInstance(runtimeInfo.getRuntimeClassName(),
-                runtimeInfo.getMavenUrlDependencies(), parentClassLoader, false);
+        return SandboxInstanceFactory.createSandboxedInstance(runtimeInfo, parentClassLoader, false);
     }
 
     public static SandboxedInstance createRuntimeClassWithCurrentJVMProperties(RuntimeInfo runtimeInfo,
             ClassLoader parentClassLoader) {
-        return SandboxInstanceFactory.createSandboxedInstance(runtimeInfo.getRuntimeClassName(),
-                runtimeInfo.getMavenUrlDependencies(), parentClassLoader, true);
+        return SandboxInstanceFactory.createSandboxedInstance(runtimeInfo, parentClassLoader, true);
     }
 
 }

--- a/daikon/src/main/java/org/talend/daikon/sandbox/SandboxInstanceFactory.java
+++ b/daikon/src/main/java/org/talend/daikon/sandbox/SandboxInstanceFactory.java
@@ -30,6 +30,7 @@ public class SandboxInstanceFactory {
 
     /**
      * TODO: Add context variable to allow the user to configure the maximum size of the cache.
+     * Maybe using a CacheBuilder.
      */
     private static Map<RuntimeInfo, ClassLoader> classLoaderCache = new ClosableLRUMap<>(3, 10);
 

--- a/daikon/src/main/java/org/talend/daikon/sandbox/SandboxInstanceFactory.java
+++ b/daikon/src/main/java/org/talend/daikon/sandbox/SandboxInstanceFactory.java
@@ -61,7 +61,7 @@ public class SandboxInstanceFactory {
     public static SandboxedInstance createSandboxedInstance(RuntimeInfo runtimeInfo, ClassLoader parentClassLoader,
             boolean useCurrentJvmProperties) {
         if (runtimeInfo.getRuntimeClassName() == null) {
-            throw new IllegalArgumentException("classToInstanciate should not be null");
+            throw new IllegalArgumentException("classToInstantiate should not be null");
         }
 
         if (classLoaderCache.containsKey(runtimeInfo) && classLoaderCache.get(runtimeInfo) != null) {

--- a/daikon/src/main/java/org/talend/daikon/sandbox/SandboxedInstance.java
+++ b/daikon/src/main/java/org/talend/daikon/sandbox/SandboxedInstance.java
@@ -68,7 +68,6 @@ public class SandboxedInstance implements AutoCloseable {
         if (isolatedThread != null) {
             isolatedThread.setContextClassLoader(previousContextClassLoader);
         } // else getInstance was not called so no need to reset context classloader.
-        ClassLoaderIsolatedSystemProperties.getInstance().stopIsolateClassLoader(sandboxClassLoader);
         sandboxClassLoader = null;
         previousContextClassLoader = null;
         isolatedThread = null;

--- a/daikon/src/main/java/org/talend/daikon/sandbox/SandboxedInstance.java
+++ b/daikon/src/main/java/org/talend/daikon/sandbox/SandboxedInstance.java
@@ -69,13 +69,6 @@ public class SandboxedInstance implements AutoCloseable {
             isolatedThread.setContextClassLoader(previousContextClassLoader);
         } // else getInstance was not called so no need to reset context classloader.
         ClassLoaderIsolatedSystemProperties.getInstance().stopIsolateClassLoader(sandboxClassLoader);
-        if (sandboxClassLoader instanceof AutoCloseable) {
-            try {
-                ((AutoCloseable) sandboxClassLoader).close();
-            } catch (Exception e) {
-                new TalendRuntimeException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
-            }
-        }
         sandboxClassLoader = null;
         previousContextClassLoader = null;
         isolatedThread = null;
@@ -119,4 +112,7 @@ public class SandboxedInstance implements AutoCloseable {
         return this.instance;
     }
 
+    public ClassLoader getSandboxClassLoader() {
+        return sandboxClassLoader;
+    }
 }

--- a/daikon/src/main/java/org/talend/java/util/ClosableLRUMap.java
+++ b/daikon/src/main/java/org/talend/java/util/ClosableLRUMap.java
@@ -1,0 +1,70 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.java.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.talend.daikon.exception.TalendRuntimeException;
+import org.talend.daikon.exception.error.CommonErrorCodes;
+
+public class ClosableLRUMap<K, V> extends LinkedHashMap<K, V> {
+
+    protected final int _maxEntries;
+
+    @Override
+    protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+        boolean removeOldest = size() > _maxEntries;
+        if (removeOldest) {
+            if (eldest.getValue() instanceof AutoCloseable) {
+                try {
+                    ((AutoCloseable) eldest.getValue()).close();
+                } catch (Exception e) {
+                    new TalendRuntimeException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
+                }
+            }
+        }
+        return removeOldest;
+    }
+
+    public ClosableLRUMap(int initialEntries, int maxEntries) {
+        super(initialEntries, 0.8f, true);
+        _maxEntries = maxEntries;
+    }
+
+    @Override
+    public V remove(Object key) {
+        V value = get(key);
+        if (value instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) value).close();
+            } catch (Exception e) {
+                new TalendRuntimeException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
+            }
+        }
+        return super.remove(key);
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+        if (value instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) value).close();
+            } catch (Exception e) {
+                new TalendRuntimeException(CommonErrorCodes.UNEXPECTED_EXCEPTION, e);
+            }
+        }
+        return super.remove(key, value);
+    }
+
+}

--- a/daikon/src/test/java/org/talend/daikon/sandbox/SandboxedInstanceTest.java
+++ b/daikon/src/test/java/org/talend/daikon/sandbox/SandboxedInstanceTest.java
@@ -66,7 +66,7 @@ public class SandboxedInstanceTest {
         assertTrue(ClassLoaderIsolatedSystemProperties.getInstance().isIsolated(instance.getClass().getClassLoader()));
         sandboxedInstance.close();
         assertEquals(previousClassLoader, Thread.currentThread().getContextClassLoader());
-        assertFalse(ClassLoaderIsolatedSystemProperties.getInstance().isIsolated(instance.getClass().getClassLoader()));
+        assertTrue(ClassLoaderIsolatedSystemProperties.getInstance().isIsolated(instance.getClass().getClassLoader()));
     }
 
     /**

--- a/daikon/src/test/java/org/talend/daikon/sandbox/properties/ClassLoaderIsolatedSystemPropertiesStaticInitTest.java
+++ b/daikon/src/test/java/org/talend/daikon/sandbox/properties/ClassLoaderIsolatedSystemPropertiesStaticInitTest.java
@@ -15,13 +15,16 @@ package org.talend.daikon.sandbox.properties;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.net.URL;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.talend.daikon.runtime.RuntimeInfo;
 import org.talend.daikon.sandbox.SandboxInstanceFactory;
 
 public class ClassLoaderIsolatedSystemPropertiesStaticInitTest {
@@ -29,6 +32,25 @@ public class ClassLoaderIsolatedSystemPropertiesStaticInitTest {
     public static final int TEST_TIMES = 5;
 
     private Properties previous;
+
+    private class TestRuntime implements RuntimeInfo {
+
+        private String name;
+
+        public TestRuntime(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String getRuntimeClassName() {
+            return name;
+        }
+
+        @Override
+        public List<URL> getMavenUrlDependencies() {
+            return Collections.EMPTY_LIST;
+        }
+    }
 
     @Before
     public void setUp() throws Exception {
@@ -46,7 +68,7 @@ public class ClassLoaderIsolatedSystemPropertiesStaticInitTest {
     public void testSetupJVMIsolationProperties() {
         assertFalse(System.getProperties() instanceof ClassLoaderIsolatedSystemProperties);
         // just do the call to have the static initializer called
-        SandboxInstanceFactory.createSandboxedInstance(this.getClass().getCanonicalName(), Collections.EMPTY_LIST,
+        SandboxInstanceFactory.createSandboxedInstance(new TestRuntime(this.getClass().getCanonicalName()),
                 this.getClass().getClassLoader(), true);
         assertTrue(System.getProperties() instanceof ClassLoaderIsolatedSystemProperties);
     }

--- a/daikon/src/test/java/org/talend/java/util/ClosableLRUMapTest.java
+++ b/daikon/src/test/java/org/talend/java/util/ClosableLRUMapTest.java
@@ -1,0 +1,98 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.java.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class ClosableLRUMapTest {
+
+    private class ClosableItem implements AutoCloseable {
+
+        private boolean isClosed = false;
+
+        @Override
+        public void close() throws IOException {
+            isClosed = true;
+        }
+
+        public boolean isClosed() {
+            return isClosed;
+        }
+    }
+
+    @Test
+    public void testInsert() {
+        ClosableItem closable1 = new ClosableItem();
+        ClosableItem closable2 = new ClosableItem();
+        ClosableItem closable3 = new ClosableItem();
+        ClosableItem closable4 = new ClosableItem();
+        ClosableItem closable5 = new ClosableItem();
+        ClosableLRUMap<String, ClosableItem> map = new ClosableLRUMap<>(1, 3);
+        map.put("closable1", closable1);
+        assertFalse(closable1.isClosed);
+        map.put("closable2", closable2);
+        assertFalse(closable1.isClosed);
+        assertFalse(closable2.isClosed);
+        map.put("closable3", closable3);
+        assertFalse(closable1.isClosed);
+        assertFalse(closable2.isClosed);
+        assertFalse(closable3.isClosed);
+
+        // add to many element => close the oldest
+        map.put("closable4", closable4);
+        assertTrue(closable1.isClosed);
+        assertFalse(closable2.isClosed);
+        assertFalse(closable3.isClosed);
+        assertFalse(closable4.isClosed);
+
+        // add an existing element => no change
+        map.put("closable4", closable4);
+        assertTrue(closable1.isClosed);
+        assertFalse(closable2.isClosed);
+        assertFalse(closable3.isClosed);
+        assertFalse(closable4.isClosed);
+
+        // add to many element => close the oldest
+        map.put("closable5", closable5);
+        assertTrue(closable1.isClosed);
+        assertTrue(closable2.isClosed);
+        assertFalse(closable3.isClosed);
+        assertFalse(closable4.isClosed);
+        assertFalse(closable5.isClosed);
+    }
+
+    @Test
+    public void testDelete() {
+        ClosableItem closable1 = new ClosableItem();
+        ClosableLRUMap<String, ClosableItem> map = new ClosableLRUMap<>(1, 3);
+        map.put("closable1", closable1);
+        assertFalse(closable1.isClosed);
+        map.remove("closable1");
+        assertTrue(closable1.isClosed);
+    }
+
+    @Test
+    public void testDelete2() {
+        ClosableItem closable1 = new ClosableItem();
+        ClosableLRUMap<String, ClosableItem> map = new ClosableLRUMap<>(1, 3);
+        map.put("closable1", closable1);
+        assertFalse(closable1.isClosed);
+        map.remove("closable1", closable1);
+        assertTrue(closable1.isClosed);
+    }
+}

--- a/daikon/src/test/java/org/talend/java/util/ClosableLRUMapTest.java
+++ b/daikon/src/test/java/org/talend/java/util/ClosableLRUMapTest.java
@@ -12,8 +12,7 @@
 // ============================================================================
 package org.talend.java.util;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 
@@ -52,21 +51,18 @@ public class ClosableLRUMapTest {
         assertFalse(closable1.isClosed);
         assertFalse(closable2.isClosed);
         assertFalse(closable3.isClosed);
-
         // add to many element => close the oldest
         map.put("closable4", closable4);
         assertTrue(closable1.isClosed);
         assertFalse(closable2.isClosed);
         assertFalse(closable3.isClosed);
         assertFalse(closable4.isClosed);
-
         // add an existing element => no change
         map.put("closable4", closable4);
         assertTrue(closable1.isClosed);
         assertFalse(closable2.isClosed);
         assertFalse(closable3.isClosed);
         assertFalse(closable4.isClosed);
-
         // add to many element => close the oldest
         map.put("closable5", closable5);
         assertTrue(closable1.isClosed);
@@ -94,5 +90,28 @@ public class ClosableLRUMapTest {
         assertFalse(closable1.isClosed);
         map.remove("closable1", closable1);
         assertTrue(closable1.isClosed);
+    }
+
+    @Test
+    public void testClear() {
+        ClosableItem closable1 = new ClosableItem();
+        ClosableItem closable2 = new ClosableItem();
+        ClosableItem closable3 = new ClosableItem();
+        ClosableItem closable4 = new ClosableItem();
+        ClosableLRUMap<String, ClosableItem> map = new ClosableLRUMap<>(1, 3);
+        map.put("closable1", closable1);
+        map.put("closable2", closable2);
+        map.put("closable3", closable3);
+        // add to many element => close the oldest
+        map.put("closable4", closable4);
+        assertTrue(closable1.isClosed);
+        assertFalse(closable2.isClosed);
+        assertFalse(closable3.isClosed);
+        assertFalse(closable4.isClosed);
+        map.clear();
+        assertTrue(closable1.isClosed);
+        assertTrue(closable2.isClosed);
+        assertTrue(closable3.isClosed);
+        assertTrue(closable4.isClosed);
     }
 }


### PR DESCRIPTION
Caching this the SandboxedClassLoader allow us to gain computation time on the
classloading after its first intanTiation.
Adding a ClosableLRUMap algorithm to clear automatically the cache if there
is too many ClassLoader instanciated at the same time.

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
Currently, a SandboxedClassLoader is created for each time there is a rest call. This create a delay of 1 seconds during the class loading and 2 second for the instantiation of a beam pipeline.


**What is the new behavior?**
Reusing existing SandboxedClassLoader allow us to highly improve this computation time (aka: reduce it to 0 second)


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
