### PR TITLE
fix(TDI-38044): fix EnforcerCreator.java to use mapping by index for …

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/di/EnforcerCreator.java
+++ b/daikon/src/main/java/org/talend/daikon/di/EnforcerCreator.java
@@ -10,7 +10,10 @@ public final class EnforcerCreator {
 
     /**
      * Instantiates concrete class of {@link DiOutgoingSchemaEnforcer} according to incoming arguments
-     * 
+     * <code>byIndex</code> parameter is used to specify type of index mapper to use with
+     * {@link org.talend.daikon.di.DiOutgoingDynamicSchemaEnforcer}
+     * For non dynamic case by index is always used (in {@link org.talend.daikon.di.DiOutgoingSchemaEnforcer} )
+     *
      * @param designSchema design schema specified by user
      * @param byIndex schema fields mapper mode; true for by index mode; false is for by name mode
      * @return instance of {@link DiOutgoingSchemaEnforcer}
@@ -27,13 +30,7 @@ public final class EnforcerCreator {
             }
             enforcer = new DiOutgoingDynamicSchemaEnforcer(designSchema, indexMapper);
         } else {
-            IndexMapper indexMapper = null;
-            if (byIndex) {
-                indexMapper = new IndexMapperByIndex(designSchema);
-            } else {
-                indexMapper = new IndexMapperByName(designSchema);
-            }
-            enforcer = new DiOutgoingSchemaEnforcer(designSchema, indexMapper);
+            enforcer = new DiOutgoingSchemaEnforcer(designSchema, new IndexMapperByIndex(designSchema));
         }
 
         return enforcer;

--- a/daikon/src/main/java/org/talend/daikon/di/EnforcerCreator.java
+++ b/daikon/src/main/java/org/talend/daikon/di/EnforcerCreator.java
@@ -11,8 +11,8 @@ public final class EnforcerCreator {
     /**
      * Instantiates concrete class of {@link DiOutgoingSchemaEnforcer} according to incoming arguments
      * <code>byIndex</code> parameter is used to specify type of index mapper to use with
-     * {@link org.talend.daikon.di.DiOutgoingDynamicSchemaEnforcer}
-     * For non dynamic case by index is always used (in {@link org.talend.daikon.di.DiOutgoingSchemaEnforcer} )
+     * {@link org.talend.daikon.di.DiOutgoingDynamicSchemaEnforcer} For non dynamic case by index is always used (in
+     * {@link org.talend.daikon.di.DiOutgoingSchemaEnforcer} )
      *
      * @param designSchema design schema specified by user
      * @param byIndex schema fields mapper mode; true for by index mode; false is for by name mode

--- a/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
@@ -1,6 +1,7 @@
 package org.talend.daikon.di;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertThat;
 
 import java.math.BigDecimal;
@@ -236,4 +237,28 @@ public class DiOutgoingSchemaEnforcerTest {
         assertThat(transformedValue, equalTo((Object) expectedChar));
     }
 
+    /**
+     * Checks case when designSchema and runtimeSchema are different
+     */
+    @Test
+    public void testSetWrapped() throws Exception {
+        int[] expectedIndexMap = {0};
+
+        Schema designSchema = SchemaBuilder.builder().record("Record").fields()
+                .name("col0").type(AvroUtils._date()).noDefault()
+                .endRecord();
+
+        Schema runtimeSchema = SchemaBuilder.builder().record("Record").fields()
+                .name("field0").type().longType().noDefault()
+                .endRecord();
+
+        IndexedRecord indexedRecord = new GenericData.Record(runtimeSchema);
+        indexedRecord.put(0, 1467170137872L);
+
+        DiOutgoingSchemaEnforcer enforcer = EnforcerCreator
+                .createOutgoingEnforcer(designSchema, false);
+        enforcer.setWrapped(indexedRecord);
+        int[] actualIndexMap = enforcer.indexMap;
+        assertArrayEquals(expectedIndexMap, actualIndexMap);
+    }
 }

--- a/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/di/DiOutgoingSchemaEnforcerTest.java
@@ -89,8 +89,8 @@ public class DiOutgoingSchemaEnforcerTest {
     }
 
     /**
-     * Checks {@link DiOutgoingSchemaEnforcer#getSchema()} returns design schema, which was passed to constructor without
-     * any changes
+     * Checks {@link DiOutgoingSchemaEnforcer#getSchema()} returns design schema, which was passed to constructor
+     * without any changes
      */
     @Test
     public void testGetSchema() {
@@ -102,8 +102,8 @@ public class DiOutgoingSchemaEnforcerTest {
     }
 
     /**
-     * Checks {@link DiOutgoingSchemaEnforcer#get(int)} returns correct values retrieved from wrapped {@link IndexedRecord}
-     * in case design and runtime schema have same order of the fields
+     * Checks {@link DiOutgoingSchemaEnforcer#get(int)} returns correct values retrieved from wrapped
+     * {@link IndexedRecord} in case design and runtime schema have same order of the fields
      */
     @Test
     public void testGetByIndex() {
@@ -122,8 +122,8 @@ public class DiOutgoingSchemaEnforcerTest {
     }
 
     /**
-     * Checks {@link DiOutgoingSchemaEnforcer#get(int)} returns correct values retrieved from wrapped {@link IndexedRecord}
-     * in case design and runtime schema have different order of the fields
+     * Checks {@link DiOutgoingSchemaEnforcer#get(int)} returns correct values retrieved from wrapped
+     * {@link IndexedRecord} in case design and runtime schema have different order of the fields
      */
     @Test
     public void testGetByName() {
@@ -149,9 +149,8 @@ public class DiOutgoingSchemaEnforcerTest {
     }
 
     /**
-     * Checks {@link DiOutgoingSchemaEnforcer#get(int)} throws {@link IndexOutOfBoundsException} in case of incoming index less
-     * than 0
-     * or more than (designSchemaSize - 1)
+     * Checks {@link DiOutgoingSchemaEnforcer#get(int)} throws {@link IndexOutOfBoundsException} in case of incoming
+     * index less than 0 or more than (designSchemaSize - 1)
      */
     @Test(expected = IndexOutOfBoundsException.class)
     public void testGetOutOfBounds() {
@@ -202,8 +201,8 @@ public class DiOutgoingSchemaEnforcerTest {
     }
 
     /**
-     * Checks {@link DiOutgoingSchemaEnforcer#transformValue(Object, Field)} transforms {@link BigDecimal} value correctly
-     * using Java class
+     * Checks {@link DiOutgoingSchemaEnforcer#transformValue(Object, Field)} transforms {@link BigDecimal} value
+     * correctly using Java class
      */
     @Test
     public void testTransformValueToDecimal() {
@@ -220,8 +219,8 @@ public class DiOutgoingSchemaEnforcerTest {
     }
 
     /**
-     * Checks {@link DiOutgoingSchemaEnforcer#transformValue(Object, Field)} transforms {@link Character} value correctly
-     * using Java class
+     * Checks {@link DiOutgoingSchemaEnforcer#transformValue(Object, Field)} transforms {@link Character} value
+     * correctly using Java class
      */
     @Test
     public void testTransformValueToCharacter() {
@@ -242,21 +241,18 @@ public class DiOutgoingSchemaEnforcerTest {
      */
     @Test
     public void testSetWrapped() throws Exception {
-        int[] expectedIndexMap = {0};
+        int[] expectedIndexMap = { 0 };
 
-        Schema designSchema = SchemaBuilder.builder().record("Record").fields()
-                .name("col0").type(AvroUtils._date()).noDefault()
+        Schema designSchema = SchemaBuilder.builder().record("Record").fields().name("col0").type(AvroUtils._date()).noDefault()
                 .endRecord();
 
-        Schema runtimeSchema = SchemaBuilder.builder().record("Record").fields()
-                .name("field0").type().longType().noDefault()
+        Schema runtimeSchema = SchemaBuilder.builder().record("Record").fields().name("field0").type().longType().noDefault()
                 .endRecord();
 
         IndexedRecord indexedRecord = new GenericData.Record(runtimeSchema);
         indexedRecord.put(0, 1467170137872L);
 
-        DiOutgoingSchemaEnforcer enforcer = EnforcerCreator
-                .createOutgoingEnforcer(designSchema, false);
+        DiOutgoingSchemaEnforcer enforcer = EnforcerCreator.createOutgoingEnforcer(designSchema, false);
         enforcer.setWrapped(indexedRecord);
         int[] actualIndexMap = enforcer.indexMap;
         assertArrayEquals(expectedIndexMap, actualIndexMap);


### PR DESCRIPTION
…non-dynamic case

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

EnforcerCreator used mapping according incoming boolean byIndex param

**What is the new behavior?**

EnforcerCreator use mapping by index for non-dynamic case and according parameter for dynamic case

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
