### PR TITLE
fixed(TCOMP-402):fixed wrong artifact resolution with UrlClassLoader

### DIFF
--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -103,6 +103,12 @@
 			<version>0.0.1</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+		    <groupId>org.slf4j</groupId>
+		    <artifactId>slf4j-log4j12</artifactId>
+		    <version>1.7.21</version>
+		    <scope>test</scope>
+		</dependency>
 
 	</dependencies>
 	<build>

--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
@@ -31,6 +31,8 @@ import org.talend.daikon.sandbox.SandboxedInstance;
 
 public class RuntimeUtil {
 
+    static private final Logger LOG = LoggerFactory.getLogger(RuntimeUtil.class);
+
     public static final class MavenUrlStreamHandler extends URLStreamHandler {
 
         @Override
@@ -47,8 +49,6 @@ public class RuntimeUtil {
             return conn;
         }
     }
-
-    static final Logger LOG = LoggerFactory.getLogger(RuntimeUtil.class);
 
     static {
         // The mvn: protocol is always necessary for the methods in this class.

--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeUtil.java
@@ -19,12 +19,36 @@ import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.net.URLStreamHandlerFactory;
 
-import org.ops4j.pax.url.mvn.Handler;
+import org.ops4j.pax.url.mvn.MavenResolver;
+import org.ops4j.pax.url.mvn.MavenResolvers;
 import org.ops4j.pax.url.mvn.ServiceConstants;
+import org.ops4j.pax.url.mvn.internal.Connection;
+import org.ops4j.pax.url.mvn.internal.Parser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.talend.daikon.sandbox.SandboxInstanceFactory;
 import org.talend.daikon.sandbox.SandboxedInstance;
 
 public class RuntimeUtil {
+
+    public static final class MavenUrlStreamHandler extends URLStreamHandler {
+
+        @Override
+        public URLConnection openConnection(URL url) throws IOException {
+            // check for URL to not have library name instead of version see (TCOMP-402)
+            // unfortunately we need to use an pax mvn internal api (Parser).
+            if (new Parser(url.getPath()).getVersion().endsWith(".jar")) {
+                LOG.debug("Ignor this artifact : " + url.toString());
+                throw new IOException("Ignoring supposedly wrong URL :" + url.toString());
+            }
+            MavenResolver resolver = MavenResolvers.createMavenResolver(null, ServiceConstants.PID);
+            Connection conn = new Connection(url, resolver);
+            conn.setUseCaches(false);// to avoid concurent thread to have an IllegalStateException.
+            return conn;
+        }
+    }
+
+    static final Logger LOG = LoggerFactory.getLogger(RuntimeUtil.class);
 
     static {
         // The mvn: protocol is always necessary for the methods in this class.
@@ -51,15 +75,7 @@ public class RuntimeUtil {
                 @Override
                 public URLStreamHandler createURLStreamHandler(String protocol) {
                     if (ServiceConstants.PROTOCOL.equals(protocol)) {
-                        return new Handler() {
-
-                            @Override
-                            protected URLConnection openConnection(URL url) throws IOException {
-                                URLConnection conn = super.openConnection(url);
-                                conn.setUseCaches(false);// to avoid concurent thread to have an IllegalStateException.
-                                return conn;
-                            }
-                        };
+                        return new MavenUrlStreamHandler();
                     } else {
                         return null;
                     }
@@ -69,13 +85,12 @@ public class RuntimeUtil {
     }
 
     /**
-     * this will create a {@link SandboxedInstance} class based on the RuntimeInfo and using <code>parentClassLoader</code> if any
-     * is provided.
-     * If you want to cast the sandboxed instance to some existing classes you are strongly advised to use the Properties
-     * classloader used to determine the <code>runtimeInfo<code>.
-     * The sandboxed instance will be created in a new ClassLoader and isolated from the current JVM system properties. You must
-     * not forget to call {@link SandboxedInstance#close()} in order to release the classloader and remove the System properties
-     * isolation, please read carefully the {@link SandboxedInstance} javadoc.
+     * this will create a {@link SandboxedInstance} class based on the RuntimeInfo and using
+     * <code>parentClassLoader</code> if any is provided. If you want to cast the sandboxed instance to some existing
+     * classes you are strongly advised to use the Properties classloader used to determine the <code>runtimeInfo<code>.
+     * The sandboxed instance will be created in a new ClassLoader and isolated from the current JVM system properties.
+     * You must not forget to call {@link SandboxedInstance#close()} in order to release the classloader and remove the
+     * System properties isolation, please read carefully the {@link SandboxedInstance} javadoc.
      */
     public static SandboxedInstance createRuntimeClass(RuntimeInfo runtimeInfo, ClassLoader parentClassLoader) {
         return SandboxInstanceFactory.createSandboxedInstance(runtimeInfo, parentClassLoader, false);

--- a/daikon/src/test/java/org/talend/daikon/sandbox/SandboxInstanceFactoryTest.java
+++ b/daikon/src/test/java/org/talend/daikon/sandbox/SandboxInstanceFactoryTest.java
@@ -12,8 +12,14 @@
 // ============================================================================
 package org.talend.daikon.sandbox;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -29,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.daikon.runtime.RuntimeInfo;
 import org.talend.daikon.runtime.RuntimeUtil;
+import org.talend.daikon.runtime.RuntimeUtil.MavenUrlStreamHandler;
 import org.talend.daikon.sandbox.properties.ClassLoaderIsolatedSystemProperties;
 import org.talend.java.util.ClosableLRUMap;
 
@@ -350,6 +357,26 @@ public class SandboxInstanceFactoryTest {
         thread2.join();
         isol1.assertSuccess();
         isol2.assertSuccess();
+    }
+
+    @Test
+    public void testTCOMP402PreventResolutionIfVersionLooksLikeJar() throws MalformedURLException {
+        MavenUrlStreamHandler mavenUrlStreamHandler = new RuntimeUtil.MavenUrlStreamHandler();
+        try {
+            // should not throw IOException
+            mavenUrlStreamHandler.openConnection(new URL("mvn:org.talend.test/zeLib/0.0.1"));
+        } catch (IOException e) {
+            fail("IOException should not be thrown" + e.getMessage());
+        }
+
+        try {
+            // should throw IOException
+            mavenUrlStreamHandler.openConnection(new URL("mvn:org.talend.test/zeLib/somethig.jar"));
+            fail("The line above should throw an error");
+        } catch (IOException e) {
+            // expected
+        }
+
     }
 
     private void waitTrue(final AtomicBoolean valuetoWaitForTrue, String mess) {

--- a/daikon/src/test/resources/log4j.properties
+++ b/daikon/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+log4j.rootLogger=DEBUG, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+
+# Pattern to output the caller's file name and line number.
+log4j.appender.stdout.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
see TCOMP-402, when resolving jar classpath, the pax mvn resolver failed on wrong URLs


**What is the new behavior?**
those URL with versions ending with *.jar* are considered wrong URL.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
