### PR TITLE
Add helper method to assertComponentIsRegistered.

### DIFF
--- a/daikon/src/test/java/org/talend/daikon/properties/test/AbstractPropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/test/AbstractPropertiesTest.java
@@ -68,8 +68,9 @@ public abstract class AbstractPropertiesTest {
      */
     public void assertComponentIsRegistered(Class<? extends Definition> requestClass, String definitionName,
             Class<? extends Definition> definitionClass) {
-        assertThat("Could not find the definition [" + definitionName + ", " + definitionClass + "]", getDefinitionRegistry()
-                .getDefinitionsMapByType(requestClass), hasEntry(is(definitionName), instanceOf(definitionClass)));
+        assertThat("Could not find the definition [" + definitionName + ", " + definitionClass + "]",
+                getDefinitionRegistry().getDefinitionsMapByType(requestClass),
+                hasEntry(is(definitionName), instanceOf(definitionClass)));
     }
 
 }

--- a/daikon/src/test/java/org/talend/daikon/properties/test/AbstractPropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/test/AbstractPropertiesTest.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
@@ -12,7 +12,11 @@
 // ============================================================================
 package org.talend.daikon.properties.test;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,8 +33,8 @@ public abstract class AbstractPropertiesTest {
     abstract public DefinitionRegistryService getDefinitionRegistry();
 
     /**
-     * checks that all properties created from all the definition in the registry have a proper i18n displayName and title.
-     * As well as checking for each Property and nested Properties.
+     * checks that all properties created from all the definition in the registry have a proper i18n displayName and
+     * title. As well as checking for each Property and nested Properties.
      */
     @Test
     public void testAlli18n() {
@@ -45,10 +49,27 @@ public abstract class AbstractPropertiesTest {
         PropertiesTestUtils.assertAllImagesAreSetup(getDefinitionRegistry(), errorCollector);
     }
 
+    /**
+     * @deprecated Use {@link #assertComponentIsRegistered(Class, String, Class)} with the expected class types.
+     */
     public void assertComponentIsRegistered(String definitionName) {
         Definition definition = getDefinitionRegistry().getDefinitionsMapByType(Definition.class).get(definitionName);
         assertNotNull("Could not find the definition [" + definitionName + "], please check the registered definitions",
                 definition);
+    }
+
+    /**
+     * Check that the set of Definitions that correspond to requestClass contain the value with the given definitionName
+     * and definitionClass.
+     * 
+     * @param requestClass The set of definitions to request by superclass.
+     * @param definitionName The name of the definition to request.
+     * @param definitionClass The expected type of class returned.
+     */
+    public void assertComponentIsRegistered(Class<? extends Definition> requestClass, String definitionName,
+            Class<? extends Definition> definitionClass) {
+        assertThat("Could not find the definition [" + definitionName + ", " + definitionClass + "]", getDefinitionRegistry()
+                .getDefinitionsMapByType(requestClass), hasEntry(is(definitionName), instanceOf(definitionClass)));
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The assertComponentIsRegistered just tests the name of the component.

**What is the new behavior?**

Deprecated the old assertComponentIsRegistered with a method that checks the requestClass and expected definition Class

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:

The deprecated method should be removed before 1.0!