### PR TITLE
feat(TCOMP-481): Clean up image path API for definitions.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/definition/Definition.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/Definition.java
@@ -16,8 +16,14 @@ import org.talend.daikon.NamedThing;
 import org.talend.daikon.properties.Properties;
 
 /**
- * Provides information about a Properties, such as an associated name and image and a factory to create an instance.
- * All definitions {@link #getName()} must return a unique value within a single jvm
+ * Provide information about a {@link Properties} that can be queried before having an instance.
+ * 
+ * This is used to associate extra data with the properties, notably images and internationalized text, and acts as a
+ * factory to create new instances.
+ *
+ * Subinterfaces can be used to logically group {@link Definition} that provide similar business logic.
+ *
+ * All definitions {@link #getName()} must be unique within a single jvm.
  */
 public interface Definition<P extends Properties> extends NamedThing {
 
@@ -39,6 +45,40 @@ public interface Definition<P extends Properties> extends NamedThing {
      * 
      * @see {@link java.lang.Class#getResourceAsStream(String)}
      * @return the path to the image resource or null if an image is not required.
+     * @deprecated use the {@link #getImagePath(DefinitionImageType)}
      */
+    @Deprecated
     String getImagePath();
+
+    /**
+     * A resource path to the current package corresponding to an image. The service api requesting an image resource
+     * will use the following code:
+     *
+     * <pre>
+     * {@code
+     *    this.getClass().getResourceAsStream(getImagePath())
+     * }
+     * </pre>
+     *
+     * @param type The type of image resource to fetch.
+     * @return the path to the image resource, or null if an image type is not available or required for the definition.
+     * @see {@link java.lang.Class#getResourceAsStream(String)}
+     */
+    String getImagePath(DefinitionImageType type);
+
+    /**
+     * An icon key can optionally be used to "override" the icon resource associated with the definition by an icon
+     * provided and styled by the specific product.
+     *
+     * If this is present, it will be the preferred source for the icon for the definition. If this is null or the icon
+     * key is unrecognized, the product will fall back on one of the images defined by
+     * {@link #getImagePath(DefinitionImageType)}.
+     *
+     * The list of standard icons is available at the {@code Talend/ui} repository and reusable contributions are
+     * welcome.
+     *
+     * @return the path to the image resource, or null if an image type is not available or required for the definition.
+     * @see <a href="https://github.com/Talend/ui/tree/master/packages/icons/src/svg">Available icons</a>
+     */
+    String getIconKey();
 }

--- a/daikon/src/main/java/org/talend/daikon/definition/Definition.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/Definition.java
@@ -56,7 +56,7 @@ public interface Definition<P extends Properties> extends NamedThing {
      *
      * <pre>
      * {@code
-     *    this.getClass().getResourceAsStream(getImagePath())
+     *    this.getClass().getResourceAsStream(getImagePath(DefinitionImageType.SVG_ICON))
      * }
      * </pre>
      *

--- a/daikon/src/main/java/org/talend/daikon/definition/DefinitionImageType.java
+++ b/daikon/src/main/java/org/talend/daikon/definition/DefinitionImageType.java
@@ -1,0 +1,30 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.definition;
+
+/**
+ * Image resource types that a {@link Definition} can support.
+ *
+ * This is used by {@link Definition#getImagePath(DefinitionImageType)} and the component service to provide image
+ * resources. Not all {@link Definition} need to support all image types.
+ */
+public enum DefinitionImageType {
+    /** A rescalable SVG icon to represent the definition. */
+    SVG_ICON,
+    /** A 32x32 PNG icon to represent the definition. */
+    PALETTE_ICON_32X32,
+    /** A 16x16 PNG icon to represent the definition. */
+    TREE_ICON_16X16,
+    /** A PNG banner used for the definition. */
+    WIZARD_BANNER_75X66
+}

--- a/daikon/src/main/java/org/talend/daikon/exception/TalendRuntimeException.java
+++ b/daikon/src/main/java/org/talend/daikon/exception/TalendRuntimeException.java
@@ -114,7 +114,7 @@ public class TalendRuntimeException extends RuntimeException {
     /**
      * Called when something unexpected happens.
      * 
-     * @param cause the unexpected exception.
+     * @param message the unexpected exception.
      * @deprecated cause the IDEs do not know this throws an exception please use {@link #createUnexpectedException(String)}
      */
     @Deprecated

--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeInfo.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeInfo.java
@@ -31,7 +31,7 @@ import java.util.List;
 public interface RuntimeInfo {
 
     /**
-     * list all the dependencies required for this component to be executed at runtime
+     * list all the dependencies required for this component to be executed at runtime.
      * 
      * @return a set of maven uri following the pax-maven uri scheme @see <a
      * href="https://ops4j1.jira.com/wiki/display/paxurl/Mvn+Protocol">https://ops4j1.jira.com/wiki/display/paxurl/

--- a/daikon/src/main/java/org/talend/daikon/runtime/RuntimeInfo.java
+++ b/daikon/src/main/java/org/talend/daikon/runtime/RuntimeInfo.java
@@ -15,35 +15,32 @@ package org.talend.daikon.runtime;
 import java.net.URL;
 import java.util.List;
 
+/**
+ * Encapsulates an implementation of business logic that can be used at runtime.
+ *
+ * This is usually created by a {@link org.talend.daikon.definition.Definition} and configured by giving a
+ * {@link org.talend.daikon.properties.Properties}. The type of the definition defines the requirements that the
+ * business logic is required to implement.
+ *
+ * In order to cache reusable resources associated with a runtime, the{@link #equals(Object)}, {@link #hashCode()} and
+ * {@link #toString()} methods should be implemented so that a RuntimeInfo instance can be used as a key.
+ *
+ * @see org.talend.daikon.sandbox.SandboxedInstance for a mechanism to automatically create an instance using a
+ * dedicated classloader that includes the dependencies.
+ */
 public interface RuntimeInfo {
 
     /**
-     * list all the depencencies required for this component to be executed at runtime
+     * list all the dependencies required for this component to be executed at runtime
      * 
-     * @param componentName name of the component to get the dependencies of.
-     * @return a set of maven uri following the pax-maven uri scheme @see
-     * <a href="https://ops4j1.jira.com/wiki/display/paxurl/Mvn+Protocol">https://ops4j1.jira.com/wiki/display/paxurl/
+     * @return a set of maven uri following the pax-maven uri scheme @see <a
+     * href="https://ops4j1.jira.com/wiki/display/paxurl/Mvn+Protocol">https://ops4j1.jira.com/wiki/display/paxurl/
      * Mvn+Protocol</a>
      */
     List<URL> getMavenUrlDependencies();
 
+    /**
+     * @return the name of the class to be instantiated to implement the business logic.
+     */
     String getRuntimeClassName();
-
-    /**
-     * Override the default equals() computation to be compatible with cache system on {@link RuntimeControllerImpl}
-     */
-    @Override
-    boolean equals(Object obj);
-
-    /**
-     * Override the default toString() computation to be compatible with cache system on {@link RuntimeControllerImpl}
-     */
-    @Override
-    String toString();
-
-    /**
-     * Override the default hashCode() computation to be compatible with cache system on {@link RuntimeControllerImpl}
-     */
-    @Override
-    public int hashCode();
 }

--- a/daikon/src/test/java/org/talend/daikon/properties/TestPropertiesTestUtils.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/TestPropertiesTestUtils.java
@@ -12,14 +12,19 @@
 // ============================================================================
 package org.talend.daikon.properties;
 
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.talend.daikon.definition.Definition;
+import org.talend.daikon.definition.DefinitionImageType;
 import org.talend.daikon.definition.service.DefinitionRegistryService;
 import org.talend.daikon.i18n.I18nMessages;
 import org.talend.daikon.properties.test.PropertiesTestUtils;
@@ -63,6 +68,16 @@ public class TestPropertiesTestUtils {
         public String getImagePath() {
             return null;
         }
+
+        @Override
+        public String getImagePath(DefinitionImageType type) {
+            return null;
+        }
+
+        @Override
+        public String getIconKey() {
+            return null;
+        }
     }
 
     @Test
@@ -98,11 +113,10 @@ public class TestPropertiesTestUtils {
         PropertiesTestUtils.assertAlli18nAreSetup(defRegServ, errorCollector);
 
         verify(errorCollector, times(2)).addError(any(Throwable.class));
-
     }
 
     @Test
-    public void testAssertAllImagesAreSetup() {
+    public void testAssertAnIconIsSetup() {
         // create a registry with one definition
         DefinitionRegistryService defRegServ = mock(DefinitionRegistryService.class);
         Definition repDef = when(mock(ADefinition.class).getName()).thenReturn("NAME").getMock();
@@ -110,27 +124,60 @@ public class TestPropertiesTestUtils {
         when(defRegServ.getDefinitionsMapByType(Definition.class)).thenReturn(Collections.singletonMap("NAME", repDef));
 
         // check when everything is fine
+
+        // There is a PNG icon available.
         ErrorCollector errorCollector = spy(new ErrorCollector());
-        when(repDef.getImagePath()).thenReturn("/org/talend/daikon/properties/messages.properties");
+        when(repDef.getImagePath(DefinitionImageType.PALETTE_ICON_32X32))
+                .thenReturn("/org/talend/daikon/properties/messages.properties");
+        when(repDef.getImagePath(DefinitionImageType.SVG_ICON)).thenReturn(null);
+        when(repDef.getIconKey()).thenReturn(null);
 
-        PropertiesTestUtils.assertAllImagesAreSetup(defRegServ, errorCollector);
-
+        PropertiesTestUtils.assertAnIconIsSetup(defRegServ, errorCollector);
         verify(errorCollector, times(0)).addError(any(Throwable.class));
 
-        // check when path is missing
+        // There is an SVG icon available.
         errorCollector = spy(new ErrorCollector());
-        when(repDef.getImagePath()).thenReturn(null);
+        when(repDef.getImagePath(DefinitionImageType.PALETTE_ICON_32X32)).thenReturn(null);
+        when(repDef.getImagePath(DefinitionImageType.SVG_ICON)).thenReturn("/org/talend/daikon/properties/messages.properties");
+        when(repDef.getIconKey()).thenReturn(null);
 
-        PropertiesTestUtils.assertAllImagesAreSetup(defRegServ, errorCollector);
+        PropertiesTestUtils.assertAnIconIsSetup(defRegServ, errorCollector);
+        verify(errorCollector, times(0)).addError(any(Throwable.class));
 
+        // There is an iconKey available.
+        errorCollector = spy(new ErrorCollector());
+        when(repDef.getImagePath(DefinitionImageType.PALETTE_ICON_32X32)).thenReturn(null);
+        when(repDef.getImagePath(DefinitionImageType.SVG_ICON)).thenReturn(null);
+        when(repDef.getIconKey()).thenReturn("icon-key");
+
+        PropertiesTestUtils.assertAnIconIsSetup(defRegServ, errorCollector);
+        verify(errorCollector, times(0)).addError(any(Throwable.class));
+
+        // check when no icon information is present
+        errorCollector = spy(new ErrorCollector());
+        when(repDef.getImagePath(DefinitionImageType.PALETTE_ICON_32X32)).thenReturn(null);
+        when(repDef.getImagePath(DefinitionImageType.SVG_ICON)).thenReturn(null);
+        when(repDef.getIconKey()).thenReturn(null);
+
+        PropertiesTestUtils.assertAnIconIsSetup(defRegServ, errorCollector);
         verify(errorCollector, times(1)).addError(any(Throwable.class));
 
-        // check when path is wrong
+        // There is a PNG icon available, but the path is wrong
         errorCollector = spy(new ErrorCollector());
-        when(repDef.getImagePath()).thenReturn("foo");
+        when(repDef.getImagePath(DefinitionImageType.PALETTE_ICON_32X32)).thenReturn("foo");
+        when(repDef.getImagePath(DefinitionImageType.SVG_ICON)).thenReturn(null);
+        when(repDef.getIconKey()).thenReturn(null);
 
-        PropertiesTestUtils.assertAllImagesAreSetup(defRegServ, errorCollector);
+        PropertiesTestUtils.assertAnIconIsSetup(defRegServ, errorCollector);
+        verify(errorCollector, times(1)).addError(any(Throwable.class));
 
+        // There is an SVG icon available.
+        errorCollector = spy(new ErrorCollector());
+        when(repDef.getImagePath(DefinitionImageType.PALETTE_ICON_32X32)).thenReturn(null);
+        when(repDef.getImagePath(DefinitionImageType.SVG_ICON)).thenReturn("foo");
+        when(repDef.getIconKey()).thenReturn(null);
+
+        PropertiesTestUtils.assertAnIconIsSetup(defRegServ, errorCollector);
         verify(errorCollector, times(1)).addError(any(Throwable.class));
     }
 

--- a/daikon/src/test/java/org/talend/daikon/properties/TestPropertiesTestUtils.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/TestPropertiesTestUtils.java
@@ -12,6 +12,8 @@
 // ============================================================================
 package org.talend.daikon.properties;
 
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -89,6 +91,7 @@ public class TestPropertiesTestUtils {
 
         ErrorCollector errorCollector = spy(new ErrorCollector());
         // check when everything is fine
+        assertThat(repDef, notNullValue());
         when(repDef.getDisplayName()).thenReturn("foo");
         when(repDef.getTitle()).thenReturn("bar");
 
@@ -124,6 +127,7 @@ public class TestPropertiesTestUtils {
         when(defRegServ.getDefinitionsMapByType(Definition.class)).thenReturn(Collections.singletonMap("NAME", repDef));
 
         // check when everything is fine
+        assertThat(repDef, notNullValue());
 
         // There is a PNG icon available.
         ErrorCollector errorCollector = spy(new ErrorCollector());

--- a/daikon/src/test/java/org/talend/daikon/properties/test/AbstractPropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/test/AbstractPropertiesTest.java
@@ -46,7 +46,7 @@ public abstract class AbstractPropertiesTest {
      */
     @Test
     public void testAllImages() {
-        PropertiesTestUtils.assertAllImagesAreSetup(getDefinitionRegistry(), errorCollector);
+        PropertiesTestUtils.assertAnIconIsSetup(getDefinitionRegistry(), errorCollector);
     }
 
     /**

--- a/daikon/src/test/java/org/talend/daikon/properties/test/PropertiesTestUtils.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/test/PropertiesTestUtils.java
@@ -115,9 +115,9 @@ public class PropertiesTestUtils {
         Collection<Definition> allDefs = defRegistry.getDefinitionsMapByType(Definition.class).values();
         for (Definition def : allDefs) {
             Class propertiesClass = def.getPropertiesClass();
-            if (propertiesClass == null) {// log it but do not consider it as a error caus tComp Wizard ses it with
-                                              // null(this is
-                                          // bad)
+            if (propertiesClass == null) {
+                // log it but do not consider it as a error because
+                // tComp Wizard ses it with null (this is bad)
                 LOGGER.error("Properties class for definition [" + def.getName() + "] should never be null.");
                 continue;
             }

--- a/daikon/src/test/java/org/talend/daikon/properties/test/PropertiesTestUtils.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/test/PropertiesTestUtils.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.daikon.NamedThing;
 import org.talend.daikon.definition.Definition;
+import org.talend.daikon.definition.DefinitionImageType;
 import org.talend.daikon.definition.service.DefinitionRegistryService;
 import org.talend.daikon.properties.AnyPropertyVisitor;
 import org.talend.daikon.properties.Properties;
@@ -106,16 +107,17 @@ public class PropertiesTestUtils {
     /**
      * check all properties of a component for i18n, check form i18n, check ComponentProperties title is i18n
      * 
-     * @param componentService where to get all the components
-     * @param errorCollector used to collect all errors at once. @see
-     *            <a href="http://junit.org/apidocs/org/junit/rules/ErrorCollector.html">ErrorCollector</a>
+     * @param defRegistry where to get all the definitions
+     * @param errorCollector used to collect all errors at once. @see <a
+     * href="http://junit.org/apidocs/org/junit/rules/ErrorCollector.html">ErrorCollector</a>
      */
     static public void assertAlli18nAreSetup(DefinitionRegistryService defRegistry, ErrorCollector errorCollector) {
         Collection<Definition> allDefs = defRegistry.getDefinitionsMapByType(Definition.class).values();
         for (Definition def : allDefs) {
             Class propertiesClass = def.getPropertiesClass();
-            if (propertiesClass == null) {// log it but do not consider it as a error caus tComp Wizard ses it with null(this is
-                                              // bad)
+            if (propertiesClass == null) {// log it but do not consider it as a error caus tComp Wizard ses it with
+                                              // null(this is
+                                          // bad)
                 LOGGER.error("Properties class for definition [" + def.getName() + "] should never be null.");
                 continue;
             }
@@ -142,25 +144,41 @@ public class PropertiesTestUtils {
     }
 
     /**
-     * check that all Components and Wizards have theirs images properly set.
+     * Check that all Components and Wizards have at least one icon image set.
      * 
-     * @param componentService service to get the components to be checked.
+     * @param defRegistry service to get the components to be checked.
      */
-    public static void assertAllImagesAreSetup(DefinitionRegistryService defRegistry, ErrorCollector errorCollector) {
+    public static void assertAnIconIsSetup(DefinitionRegistryService defRegistry, ErrorCollector errorCollector) {
         Collection<Definition> allDefs = defRegistry.getDefinitionsMapByType(Definition.class).values();
         for (Definition def : allDefs) {
-            String imagePath = def.getImagePath();
-            errorCollector.checkThat("the definition [" + def.getName() + "] must return an image path.", imagePath,
-                    notNullValue());
-            if (imagePath != null) {// check that the image resource exists
-                InputStream resourceAsStream = def.getClass().getResourceAsStream(imagePath);
+            String pngImagePath = def.getImagePath(DefinitionImageType.PALETTE_ICON_32X32);
+            String svgImagePath = def.getImagePath(DefinitionImageType.SVG_ICON);
+            String iconKey = def.getIconKey();
+            // At least one of the icon resources must be present.
+            if (pngImagePath == null && svgImagePath == null && iconKey == null) {
+                errorCollector
+                        .addError(new Throwable("the definition [" + def.getName() + "] must have at least one icon resource."));
+            }
+            if (pngImagePath != null) {// check that the image resource exists
+                InputStream resourceAsStream = def.getClass().getResourceAsStream(pngImagePath);
                 errorCollector
                         .checkThat(
-                                "Failed to find the image for path [" + imagePath + "] for the definition [" + def.getName()
+                                "Failed to find the image for path [" + pngImagePath + "] for the definition [" + def.getName()
                                         + "].\nIt should be located at ["
-                                        + def.getClass().getPackage().getName().replace('.', '/') + "/" + imagePath + "]",
+                                        + def.getClass().getPackage().getName().replace('.', '/') + "/" + pngImagePath + "]",
                                 resourceAsStream, notNullValue());
             }
+            if (svgImagePath != null) {// check that the image resource exists
+                InputStream resourceAsStream = def.getClass().getResourceAsStream(svgImagePath);
+                errorCollector
+                        .checkThat(
+                                "Failed to find the image for path [" + svgImagePath + "] for the definition [" + def.getName()
+                                        + "].\nIt should be located at ["
+                                        + def.getClass().getPackage().getName().replace('.', '/') + "/" + svgImagePath + "]",
+                                resourceAsStream, notNullValue());
+            }
+            // There is no test for iconKey -- the product is responsible for obtaining the icon corresponding to this
+            // value.
         }
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [X] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The Definition class only offers a mechanism to get the image path (probably an icon).

**What is the new behavior?**

The Definition class only offers a mechanism to get the image path for different resource types, as well as an icon key.

**Does this PR introduce a breaking change?**

- [X] Yes
- [ ] No

**If this PR contains a breaking change, please describe the impact and migration path for existing applications**: ...

All existing definitions need to add the new methods for image resource discovery.  

This can be done for all components in a backwards compatible manner in AbstractComponentDefinition, which needs to be prepared for the components repository.  

**Other information**:

Please do not merge this change until the other PR is prepared, but comments are appreciated!