### PR TITLE
fix(migration):use latest json-io to improve missing field during migration

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/serialize/SerializerDeserializer.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/SerializerDeserializer.java
@@ -95,15 +95,7 @@ public class SerializerDeserializer {
             if (!DeserializeDeletedFieldHandler.class.isAssignableFrom(object.getClass())) {
                 return;
             }
-            Object deserialized = value;
-            if (value instanceof JsonObject) {
-                // convert the JsonObject to a real object
-                deserialized = new com.cedarsoftware.util.io.JsonReader().jsonObjectsToJava((JsonObject) value);
-                if (deserialized instanceof JsonObject) {
-                    deserialized = null;
-                }
-            }
-            Boolean migrated = ((DeserializeDeletedFieldHandler) object).deletedField(fieldName, deserialized);
+            Boolean migrated = ((DeserializeDeletedFieldHandler) object).deletedField(fieldName, value);
             if (migrated) {
                 migratedDeleted.set(true);
             }

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonio/PersistenceObjectForFieldRemoved.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonio/PersistenceObjectForFieldRemoved.java
@@ -1,0 +1,42 @@
+package org.talend.daikon.serialize.jsonio;
+
+import org.talend.daikon.serialize.DeserializeDeletedFieldHandler;
+
+public class PersistenceObjectForFieldRemoved implements DeserializeDeletedFieldHandler {
+
+    public static class InnerClass1 {
+
+        String inner1Str = "inner1Str";
+    }
+
+    public static class InnerClass2 {
+
+        String inner2Str = "inner2Str";
+
+        InnerClass1 in1inIn2;
+    }
+
+    String persObjStr = "persObjStrValue";
+
+    InnerClass1 in1 = new InnerClass1();
+
+    Object in2;// we don't use Inner2 to have an @type in the serialization
+
+    public boolean isdeletedFieldIn2_right_type;
+
+    public PersistenceObjectForFieldRemoved() {
+        InnerClass2 aIn2 = new InnerClass2();
+        aIn2.in1inIn2 = in1;
+        in2 = aIn2;
+    }
+
+    @Override
+    public boolean deletedField(String fieldName, Object value) {
+        boolean migrated = false;
+        if (fieldName.equals("in2Old")) {
+            isdeletedFieldIn2_right_type = (value != null && (value instanceof InnerClass2));
+            migrated = true;
+        }
+        return migrated;
+    }
+}

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonio/PersistenceObjectForFieldRemoved.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonio/PersistenceObjectForFieldRemoved.java
@@ -4,25 +4,25 @@ import org.talend.daikon.serialize.DeserializeDeletedFieldHandler;
 
 public class PersistenceObjectForFieldRemoved implements DeserializeDeletedFieldHandler {
 
+    public String persObjStr = "persObjStrValue";
+
+    public InnerClass1 in1 = new InnerClass1();
+
+    public Object in2;// we don't use Inner2 to have an @type in the serialization
+
+    public boolean isdeletedFieldIn2_right_type;
+
     public static class InnerClass1 {
 
-        String inner1Str = "inner1Str";
+        public String inner1Str = "inner1Str";
     }
 
     public static class InnerClass2 {
 
-        String inner2Str = "inner2Str";
+        public String inner2Str = "inner2Str";
 
-        InnerClass1 in1inIn2;
+        public InnerClass1 in1inIn2;
     }
-
-    String persObjStr = "persObjStrValue";
-
-    InnerClass1 in1 = new InnerClass1();
-
-    Object in2;// we don't use Inner2 to have an @type in the serialization
-
-    public boolean isdeletedFieldIn2_right_type;
 
     public PersistenceObjectForFieldRemoved() {
         InnerClass2 aIn2 = new InnerClass2();
@@ -33,7 +33,7 @@ public class PersistenceObjectForFieldRemoved implements DeserializeDeletedField
     @Override
     public boolean deletedField(String fieldName, Object value) {
         boolean migrated = false;
-        if (fieldName.equals("in2Old")) {
+        if ("in2Old".equals(fieldName)) {
             isdeletedFieldIn2_right_type = (value != null && (value instanceof InnerClass2));
             migrated = true;
         }

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonio/SerializeDeserializeTest.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonio/SerializeDeserializeTest.java
@@ -135,4 +135,18 @@ public class SerializeDeserializeTest {
         assertTrue(deser.object.inner.innerObject2.hasValuedDeleteInner3);
 
     }
+
+    @Test
+    public void testDeserializeMissingFieldTypedWithComplexTypeWithRef() {
+        String serTyped = "{\"@type\":\"org.talend.daikon.serialize.jsonio.PersistenceObjectForFieldRemoved\",\"persObjStr\":\"persObjStrValue\",\"in1\":{\"@id\":1,\"inner1Str\":\"inner1Str\"},\"in2Old\":{\"@type\":\"org.talend.daikon.serialize.jsonio.PersistenceObjectForFieldRemoved$InnerClass2\",\"inner2Str\":\"inner2Str\",\"in1inIn2\":{\"@ref\":1}},\"isdeletedFieldIn2_right_type\":false}";
+        // generate the above serialized string, but it is then manually altered to rename a field
+        // PersistenceObjectForFieldRemoved persistenceObjectForFieldRemoved = new PersistenceObjectForFieldRemoved();
+        // String ser = SerializerDeserializer.toSerializedPersistent(persistenceObjectForFieldRemoved);
+        // LOGGER.info(ser);
+
+        Deserialized<PersistenceObjectForFieldRemoved> deser = SerializerDeserializer.fromSerializedPersistent(serTyped,
+                PersistenceObjectForFieldRemoved.class);
+        assertTrue(deser.object.isdeletedFieldIn2_right_type);
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>com.cedarsoftware</groupId>
                 <artifactId>json-io</artifactId>
-                <version>4.5.0</version>
+                <version>4.9.9-TALEND</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
             <dependency>
                 <groupId>com.cedarsoftware</groupId>
                 <artifactId>json-io</artifactId>
+                 <!-- using a specific Talend artifact version until the next official release, the PR has been merge into master but not yet release. -->
                 <version>4.9.9-TALEND</version>
             </dependency>
         </dependencies>


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix

**What is the current behavior?** (You can also link to an open issue here)
when deserializing a field that is missing that was serialized with enough type information, the handler was notified with a null  value


**What is the new behavior?**
Now if the object can be deserialized, the handle gets the proper value. This is useful for field that where renamed.


**Does this PR introduce a breaking change?**

- [X] No


**Other information**:
This PR will require some Studio update for the new json-io version. So please merge this branch https://github.com/Talend/studio-se-master/tree/bugfix/json-io_migration_with_complex_types once this PR is merged.