### PR TITLE
chore(spring-mongo):add plugin repo for maven plugin resolution

### DIFF
--- a/daikon-spring/daikon-spring-mongo/pom.xml
+++ b/daikon-spring/daikon-spring-mongo/pom.xml
@@ -60,7 +60,12 @@
             <url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
         </repository>
     </distributionManagement>
-	
+    <pluginRepositories>
+        <pluginRepository>
+            <id>com.springsource.repository.bundles.release</id>
+            <url>http://repository.springsource.com/maven/bundles/release</url>
+        </pluginRepository>
+    </pluginRepositories>	
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
build failed for *spring-mongo* module on a new machine cause the maven plugin could not be dowloaded


**What is the new behavior?**
added the right maven plugin repo to download the missing plugin


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
