### PR TITLE
style: end-of-line normaliaztion to lf for *.java files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-text eol=lf
+*.java text eol=lf


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
the configuration in the .gitattributes file is not taking effect on java files. this doesn't work on windows machine. and the build fails with a :
[ERROR] Failed to execute goal net.revelc.code.formatter:formatter-maven-plugin:1.6.0-SNAPSHOT:validate (default) on project daikon: File '...\daikon\src\main\java\org\talend\daikon\avro\AvroRegistry.java' format doesn't match!


**What is the new behavior?**
we added the *.java to the file to force line ending format on all environment and with no need for a local git configuration. 


**Does this PR introduce a breaking change?**
- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
For that to take effect on local files a *git rest --hard* is required after the pull of this modification