### PR TITLE
[Fix] Update S3 client (1.11.18 -> 1.11.83)

### DIFF
--- a/daikon-content-service/s3-content-service/pom.xml
+++ b/daikon-content-service/s3-content-service/pom.xml
@@ -21,10 +21,16 @@
             <artifactId>spring-cloud-aws-context</artifactId>
             <version>1.1.3.RELEASE</version>
         </dependency>
+        <!-- Force usage of 1.11.83 to prevent SSL certificate check issues -->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
-            <version>1.11.18</version>
+            <version>1.11.83</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>1.11.83</version>
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ContentServiceConfiguration.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ContentServiceConfiguration.java
@@ -15,9 +15,9 @@ import org.talend.daikon.content.ContentServiceEnabled;
 import org.talend.daikon.content.ResourceResolver;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.EC2ContainerCredentialsProviderWrapper;
-import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
@@ -41,8 +41,8 @@ public class S3ContentServiceConfiguration implements ContentServiceEnabled {
         LOGGER.info("Using Token authentication");
         final String key = environment.getProperty("content-service.store.s3.accessKey");
         final String secret = environment.getProperty("content-service.store.s3.secretKey");
-        AWSCredentials awsCredentials = new BasicAWSCredentials(key, secret);
-        return builder.withCredentials(new StaticCredentialsProvider(awsCredentials));
+        final AWSCredentials awsCredentials = new BasicAWSCredentials(key, secret);
+        return builder.withCredentials(new AWSStaticCredentialsProvider(awsCredentials));
     }
 
     @Bean

--- a/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/AmazonS3TestWrapper.java
+++ b/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/AmazonS3TestWrapper.java
@@ -6,14 +6,15 @@ import java.net.URL;
 import java.util.Date;
 import java.util.List;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.AmazonWebServiceRequest;
-import com.amazonaws.HttpMethod;
+import com.amazonaws.*;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.S3ResponseMetadata;
 import com.amazonaws.services.s3.model.*;
+import com.amazonaws.services.s3.model.analytics.AnalyticsConfiguration;
+import com.amazonaws.services.s3.model.inventory.InventoryConfiguration;
+import com.amazonaws.services.s3.model.metrics.MetricsConfiguration;
+import com.amazonaws.services.s3.waiters.AmazonS3Waiters;
 
 class AmazonS3TestWrapper implements AmazonS3 {
 
@@ -165,11 +166,13 @@ class AmazonS3TestWrapper implements AmazonS3 {
         return delegate.createBucket(bucketName);
     }
 
+    @Deprecated
     @Override
     public Bucket createBucket(String bucketName, Region region) throws AmazonClientException, AmazonServiceException {
         return delegate.createBucket(bucketName, region);
     }
 
+    @Deprecated
     @Override
     public Bucket createBucket(String bucketName, String region) throws AmazonClientException, AmazonServiceException {
         return delegate.createBucket(bucketName, region);
@@ -268,6 +271,21 @@ class AmazonS3TestWrapper implements AmazonS3 {
     @Override
     public String getObjectAsString(String bucketName, String key) throws AmazonServiceException, AmazonClientException {
         return delegate.getObjectAsString(bucketName, key);
+    }
+
+    @Override
+    public GetObjectTaggingResult getObjectTagging(GetObjectTaggingRequest getObjectTaggingRequest) {
+        return delegate.getObjectTagging(getObjectTaggingRequest);
+    }
+
+    @Override
+    public SetObjectTaggingResult setObjectTagging(SetObjectTaggingRequest setObjectTaggingRequest) {
+        return delegate.setObjectTagging(setObjectTaggingRequest);
+    }
+
+    @Override
+    public DeleteObjectTaggingResult deleteObjectTagging(DeleteObjectTaggingRequest deleteObjectTaggingRequest) {
+        return delegate.deleteObjectTagging(deleteObjectTaggingRequest);
     }
 
     @Override
@@ -671,12 +689,129 @@ class AmazonS3TestWrapper implements AmazonS3 {
     }
 
     @Override
+    public DeleteBucketMetricsConfigurationResult deleteBucketMetricsConfiguration(String s, String s1) throws AmazonServiceException, SdkClientException {
+        return delegate.deleteBucketMetricsConfiguration(s, s1);
+    }
+
+    @Override
+    public DeleteBucketMetricsConfigurationResult deleteBucketMetricsConfiguration(DeleteBucketMetricsConfigurationRequest deleteBucketMetricsConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.deleteBucketMetricsConfiguration(deleteBucketMetricsConfigurationRequest);
+    }
+
+    @Override
+    public GetBucketMetricsConfigurationResult getBucketMetricsConfiguration(String s, String s1) throws AmazonServiceException, SdkClientException {
+        return delegate.getBucketMetricsConfiguration(s, s1);
+    }
+
+    @Override
+    public GetBucketMetricsConfigurationResult getBucketMetricsConfiguration(GetBucketMetricsConfigurationRequest getBucketMetricsConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.getBucketMetricsConfiguration(getBucketMetricsConfigurationRequest);
+    }
+
+    @Override
+    public SetBucketMetricsConfigurationResult setBucketMetricsConfiguration(String s, MetricsConfiguration metricsConfiguration) throws AmazonServiceException, SdkClientException {
+        return delegate.setBucketMetricsConfiguration(s, metricsConfiguration);
+    }
+
+    @Override
+    public SetBucketMetricsConfigurationResult setBucketMetricsConfiguration(SetBucketMetricsConfigurationRequest setBucketMetricsConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.setBucketMetricsConfiguration(setBucketMetricsConfigurationRequest);
+    }
+
+    @Override
+    public ListBucketMetricsConfigurationsResult listBucketMetricsConfigurations(ListBucketMetricsConfigurationsRequest listBucketMetricsConfigurationsRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.listBucketMetricsConfigurations(listBucketMetricsConfigurationsRequest);
+    }
+
+    @Override
+    public DeleteBucketAnalyticsConfigurationResult deleteBucketAnalyticsConfiguration(String s, String s1) throws AmazonServiceException, SdkClientException {
+        return delegate.deleteBucketAnalyticsConfiguration(s, s1);
+    }
+
+    @Override
+    public DeleteBucketAnalyticsConfigurationResult deleteBucketAnalyticsConfiguration(DeleteBucketAnalyticsConfigurationRequest deleteBucketAnalyticsConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.deleteBucketAnalyticsConfiguration(deleteBucketAnalyticsConfigurationRequest);
+    }
+
+    @Override
+    public GetBucketAnalyticsConfigurationResult getBucketAnalyticsConfiguration(String s, String s1) throws AmazonServiceException, SdkClientException {
+        return delegate.getBucketAnalyticsConfiguration(s, s1);
+    }
+
+    @Override
+    public GetBucketAnalyticsConfigurationResult getBucketAnalyticsConfiguration(GetBucketAnalyticsConfigurationRequest getBucketAnalyticsConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.getBucketAnalyticsConfiguration(getBucketAnalyticsConfigurationRequest);
+    }
+
+    @Override
+    public SetBucketAnalyticsConfigurationResult setBucketAnalyticsConfiguration(String s, AnalyticsConfiguration analyticsConfiguration) throws AmazonServiceException, SdkClientException {
+        return delegate.setBucketAnalyticsConfiguration(s, analyticsConfiguration);
+    }
+
+    @Override
+    public SetBucketAnalyticsConfigurationResult setBucketAnalyticsConfiguration(SetBucketAnalyticsConfigurationRequest setBucketAnalyticsConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.setBucketAnalyticsConfiguration(setBucketAnalyticsConfigurationRequest);
+    }
+
+    @Override
+    public ListBucketAnalyticsConfigurationsResult listBucketAnalyticsConfigurations(ListBucketAnalyticsConfigurationsRequest listBucketAnalyticsConfigurationsRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.listBucketAnalyticsConfigurations(listBucketAnalyticsConfigurationsRequest);
+    }
+
+    @Override
+    public DeleteBucketInventoryConfigurationResult deleteBucketInventoryConfiguration(String s, String s1) throws AmazonServiceException, SdkClientException {
+        return delegate.deleteBucketInventoryConfiguration(s, s1);
+    }
+
+    @Override
+    public DeleteBucketInventoryConfigurationResult deleteBucketInventoryConfiguration(DeleteBucketInventoryConfigurationRequest deleteBucketInventoryConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.deleteBucketInventoryConfiguration(deleteBucketInventoryConfigurationRequest);
+    }
+
+    @Override
+    public GetBucketInventoryConfigurationResult getBucketInventoryConfiguration(String s, String s1) throws AmazonServiceException, SdkClientException {
+        return delegate.getBucketInventoryConfiguration(s, s1);
+    }
+
+    @Override
+    public GetBucketInventoryConfigurationResult getBucketInventoryConfiguration(GetBucketInventoryConfigurationRequest getBucketInventoryConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.getBucketInventoryConfiguration(getBucketInventoryConfigurationRequest);
+    }
+
+    @Override
+    public SetBucketInventoryConfigurationResult setBucketInventoryConfiguration(String s, InventoryConfiguration inventoryConfiguration) throws AmazonServiceException, SdkClientException {
+        return delegate.setBucketInventoryConfiguration(s, inventoryConfiguration);
+    }
+
+    @Override
+    public SetBucketInventoryConfigurationResult setBucketInventoryConfiguration(SetBucketInventoryConfigurationRequest setBucketInventoryConfigurationRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.setBucketInventoryConfiguration(setBucketInventoryConfigurationRequest);
+    }
+
+    @Override
+    public ListBucketInventoryConfigurationsResult listBucketInventoryConfigurations(ListBucketInventoryConfigurationsRequest listBucketInventoryConfigurationsRequest) throws AmazonServiceException, SdkClientException {
+        return delegate.listBucketInventoryConfigurations(listBucketInventoryConfigurationsRequest);
+    }
+
+    @Override
     public Region getRegion() {
         return Region.EU_Ireland;
+    }
+
+    @Override
+    public String getRegionName() {
+        return delegate.getRegionName();
     }
 
     @Override
     public URL getUrl(String bucketName, String key) {
         return delegate.getUrl(bucketName, key);
     }
+
+    @Override
+    public AmazonS3Waiters waiters() {
+        return delegate.waiters();
+    }
+
+
 }


### PR DESCRIPTION
There is an issue in version 1.11.18 version of AWS clients. In the context of an EC2 instance, the SSL check for the AWS certificate was incorrectly handle, it was using **strict** host name validation where it should be using wildward validation.

In other words:

* "buket_name.s3.amazon.aws.com" does not validate certificate "*.s3.amazon.aws.com" in 1.11.18
* ... but does in 1.11.83.

Details:
* fix incorrect SSL policy (use of '*' in AWS issued SSL certificate).
* update code following minor API changes.
* remove usage of now deprecated class.
