### PR TITLE
[feature] Multi tenancy support for S3

### DIFF
--- a/daikon-content-service/content-service-common/src/test/java/org/talend/daikon/content/DeletableResourceTest.java
+++ b/daikon-content-service/content-service-common/src/test/java/org/talend/daikon/content/DeletableResourceTest.java
@@ -1,9 +1,6 @@
 package org.talend.daikon.content;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -15,7 +12,7 @@ import org.junit.Test;
 
 public abstract class DeletableResourceTest extends DeletableLoaderResourceTests {
 
-    private static final String LOCATION = "file.txt";
+    protected static final String LOCATION = "file.txt";
 
     protected DeletableResource resource;
 

--- a/daikon-content-service/s3-content-service/README.md
+++ b/daikon-content-service/s3-content-service/README.md
@@ -36,7 +36,7 @@ public class MyComponent {
 
 ## Additional S3 configuration
 
-### Authentication modes
+### S3 client creation
 By default, AWS S3 client will authenticate using running EC2 instance credentials. Default behavior is same as:
 
 ```properties
@@ -51,6 +51,13 @@ content-service.store.s3.accessKey=<access_key>
 content-service.store.s3.secretKey=<secret_key>
 ```
 
+You may also use custom mode:
+ 
+```properties
+content-service.store.s3.authentication=CUSTOM
+```
+In this case, a bean of type `org.talend.daikon.content.s3.provider.AmazonS3Provider` is required in class path.
+
 ### Region
 
 When code runs in an EC2 context, AWS region is automatically detected. You may still specify/enforce it using an optional property.
@@ -58,3 +65,12 @@ When code runs in an EC2 context, AWS region is automatically detected. You may 
 ```properties
 content-service.store.s3.region=eu-west-1
 ```
+
+### Multi tenancy
+
+You can also enable multi tenancy for S3 (defaults to `false`):
+```properties
+multi-tenancy.s3.active=true
+```
+
+In this case you are required to provide an implementation of `org.talend.daikon.content.s3.provider.S3BucketProvider` that provide the current bucket name.

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/IncorrectS3ConfigurationAnalyzer.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/IncorrectS3ConfigurationAnalyzer.java
@@ -1,0 +1,29 @@
+package org.talend.daikon.content.s3;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.springframework.boot.diagnostics.FailureAnalysis;
+import org.springframework.boot.diagnostics.FailureAnalyzer;
+
+/**
+ * Allow S3 code to plug into Spring Boot's startup failure analysis.
+ */
+public class IncorrectS3ConfigurationAnalyzer implements FailureAnalyzer {
+
+    public IncorrectS3ConfigurationAnalyzer() {
+        // For Spring initialization.
+    }
+
+    @Override
+    public FailureAnalysis analyze(Throwable failure) {
+        final Throwable[] throwables = ExceptionUtils.getThrowables(failure);
+        for (Throwable throwable : throwables) {
+            if (throwable instanceof S3ContentServiceConfiguration.InvalidConfiguration) {
+                final S3ContentServiceConfiguration.InvalidConfiguration issue = (S3ContentServiceConfiguration.InvalidConfiguration) throwable;
+                return new FailureAnalysis("Incorrect S3 configuration: " + issue.getMessage(), //
+                        "Add a bean of class " + issue.getMissingBeanClass().getName(), //
+                        failure);
+            }
+        }
+        return null;
+    }
+}

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/IncorrectS3ConfigurationAnalyzer.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/IncorrectS3ConfigurationAnalyzer.java
@@ -9,10 +9,6 @@ import org.springframework.boot.diagnostics.FailureAnalyzer;
  */
 public class IncorrectS3ConfigurationAnalyzer implements FailureAnalyzer {
 
-    public IncorrectS3ConfigurationAnalyzer() {
-        // For Spring initialization.
-    }
-
     @Override
     public FailureAnalysis analyze(Throwable failure) {
         final Throwable[] throwables = ExceptionUtils.getThrowables(failure);

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/LocationUtils.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/LocationUtils.java
@@ -12,7 +12,6 @@ class LocationUtils {
         // nothing to do
     }
 
-
     /**
      * Strips off the first '/' (if more characters than just a '/') to have proper tree structure in S3 bucket.
      * 

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -9,6 +9,7 @@ import org.springframework.core.io.WritableResource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.talend.daikon.content.AbstractResourceResolver;
 import org.talend.daikon.content.DeletableResource;
+import org.talend.daikon.content.s3.provider.S3BucketProvider;
 
 import com.amazonaws.services.s3.AmazonS3;
 
@@ -16,9 +17,9 @@ class S3ResourceResolver extends AbstractResourceResolver {
 
     private final AmazonS3 amazonS3;
 
-    private final String bucket;
+    private final S3BucketProvider bucket;
 
-    S3ResourceResolver(ResourcePatternResolver delegate, AmazonS3 amazonS3, String bucket) {
+    S3ResourceResolver(ResourcePatternResolver delegate, AmazonS3 amazonS3, S3BucketProvider bucket) {
         super(delegate);
         this.amazonS3 = amazonS3;
         this.bucket = bucket;
@@ -26,7 +27,7 @@ class S3ResourceResolver extends AbstractResourceResolver {
 
     @Override
     public DeletableResource[] getResources(String locationPattern) throws IOException {
-        return super.getResources("s3://" + bucket + locationPattern);
+        return super.getResources("s3://" + bucket.getBucketName() + locationPattern);
     }
 
     @Override
@@ -39,11 +40,11 @@ class S3ResourceResolver extends AbstractResourceResolver {
             throw new IllegalArgumentException("Location can not be empty (was '" + location + "')");
         }
 
-        return super.getResource("s3://" + bucket + "/" + toS3Location(location));
+        return super.getResource("s3://" + bucket.getBucketName() + "/" + toS3Location(location));
     }
 
     @Override
     protected DeletableResource convert(WritableResource writableResource) {
-        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket);
+        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket.getBucketName());
     }
 }

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/provider/AmazonS3Provider.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/provider/AmazonS3Provider.java
@@ -1,0 +1,19 @@
+package org.talend.daikon.content.s3.provider;
+
+import com.amazonaws.services.s3.AmazonS3;
+
+/**
+ * An interface to be implemented to supply Amazon S3 clients. Examples of implementation include:
+ * <ul>
+ * <li>Static bucket name (read from {@link org.springframework.core.env.Environment}).</li>
+ * <li>Runtime-defined bucket name (for multi tenant use cases).</li>
+ * </ul>
+ */
+@FunctionalInterface
+public interface AmazonS3Provider {
+
+    /**
+     * @return A configured {@link AmazonS3 S3 client} ready for use.
+     */
+    AmazonS3 getAmazonS3Client();
+}

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/provider/S3BucketProvider.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/provider/S3BucketProvider.java
@@ -1,0 +1,17 @@
+package org.talend.daikon.content.s3.provider;
+
+/**
+ * An interface to be implemented to supply bucket names. Examples of implementation include:
+ * <ul>
+ * <li>Static bucket name (read from {@link org.springframework.core.env.Environment}).</li>
+ * <li>Runtime-defined bucket name (for multi tenant use cases).</li>
+ * </ul>
+ */
+@FunctionalInterface
+public interface S3BucketProvider {
+
+    /**
+     * @return The tenant bucket name.
+     */
+    String getBucketName();
+}

--- a/daikon-content-service/s3-content-service/src/test/resources/META-INF/spring.factories
+++ b/daikon-content-service/s3-content-service/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.boot.diagnostics.FailureAnalyzer=org.talend.daikon.content.s3.IncorrectS3ConfigurationAnalyzer

--- a/daikon-content-service/s3-content-service/src/test/resources/application.properties
+++ b/daikon-content-service/s3-content-service/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+content-service.store=s3
+content-service.store.s3.authentication=CUSTOM
+multi-tenancy.s3.active=true


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)

**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** 

Impossible to change S3 bucket name at runtime.

**What is the new behavior?**

Add multi tenancy support to S3 (allow to change bucket name at runtime).

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**Other information**:

* Add "multi-tenancy.s3.active" to activate multi tenant in S3 resource resolver.
* Improve error message in case of misconfiguration relative to S3 configuration.
* Update README with multi tenant usage.
