### PR TITLE
fix(TFD-1000): Hide nested properties with no visible widgets.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/UiSchemaGenerator.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/UiSchemaGenerator.java
@@ -4,7 +4,6 @@ import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getSubProperti
 import static org.talend.daikon.serialize.jsonschema.JsonBaseTool.getSubProperty;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -17,7 +16,6 @@ import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.Property;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -34,15 +32,18 @@ public class UiSchemaGenerator {
      */
     private ObjectNode processTPropertiesWidget(Properties cProperties, String formName) {
         Form mainForm = cProperties.getPreferredForm(formName);
-        return processTPropertiesWidget(mainForm);
+        return processTPropertiesWidget(mainForm, new boolean[] { false });
     }
 
     /**
      * ComponentProeprties could use multiple forms in one time to represent the graphic setting, Main & Advanced for
      * instance. ComponentProperties could has Properties/Property which are not in Form, treat it as hidden
      * Properties/Property
+     * 
+     * @param hasVisible Secondary return value: If anything in this form is visible, the first boolean value will be
+     * set to true. Otherwise, this remains untouched. (otherwise, this array will be untouched).
      */
-    private ObjectNode processTPropertiesWidget(Form form) {
+    private ObjectNode processTPropertiesWidget(Form form, boolean[] hasVisible) {
         ObjectNode jsonToReturn = JsonNodeFactory.instance.objectNode();
         if (form == null) {
             return jsonToReturn;
@@ -62,7 +63,7 @@ public class UiSchemaGenerator {
             NamedThing content = jsonWidget.getContent();
             // If it is a top-level property or PresentationItem, then add it directly to the output.
             if (propertyList.contains(content) || content instanceof PresentationItem) {
-                ObjectNode jsonNodes = processTWidget(jsonWidget.getWidget(), JsonNodeFactory.instance.objectNode());
+                ObjectNode jsonNodes = processTWidget(jsonWidget.getWidget(), JsonNodeFactory.instance.objectNode(), hasVisible);
                 if (jsonNodes.size() != 0) {
                     jsonToReturn.set(jsonWidget.getName(), jsonNodes);
                 }
@@ -81,34 +82,20 @@ public class UiSchemaGenerator {
 
                 if (propertiesList.contains(checkProperties)) {
                     ObjectNode jsonNodes = null;
-                    if (resolveForm != null) {// Properties associated with a form
-                        jsonNodes = processTPropertiesWidget(resolveForm);
-                        jsonNodes = processTWidget(jsonWidget.getWidget(), jsonNodes);// add the current
+                    if (resolveForm != null) {
+                        // Properties associated with a form
+                        boolean[] subFormVisible = { false };
+                        jsonNodes = processTPropertiesWidget(resolveForm, subFormVisible);
+                        if (subFormVisible[0])
+                            hasVisible[0] = true;
+                        jsonNodes = processTWidget(jsonWidget.getWidget(), jsonNodes, hasVisible);
                     } else {// Properties is associated with a widget
-                        jsonNodes = processTWidget(jsonWidget.getWidget(), JsonNodeFactory.instance.objectNode());// add
+                        jsonNodes = processTWidget(jsonWidget.getWidget(), JsonNodeFactory.instance.objectNode(), hasVisible);
                     }
                     order.put(jsonWidget.getOrder(), jsonWidget.getName());
                     if (jsonNodes.size() != 0) {
                         jsonToReturn.set(jsonWidget.getName(), jsonNodes);
                     }
-
-                    // If nothing is visible in the properties, then this widget should also be hidden.
-                    Iterator<Map.Entry<String, JsonNode>> innerFields = jsonNodes.fields();
-                    boolean hasVisibleInnerField = false;
-                    while (innerFields.hasNext()) {
-                        Map.Entry<String, JsonNode> inner = innerFields.next();
-                        if (inner.getKey().startsWith("ui:"))
-                            continue;
-                        JsonNode innerWidget = inner.getValue().get("ui:widget");
-                        if (innerWidget == null || !"hidden".equals(innerWidget.asText())) {
-                            hasVisibleInnerField = true;
-                            break;
-                        }
-                    }
-                    if (!hasVisibleInnerField) {
-                        setHiddenWidget(jsonNodes);
-                    }
-
                 }
             }
         }
@@ -130,13 +117,16 @@ public class UiSchemaGenerator {
         }
         // For the properties which not in the form(hidden properties)
         for (Properties properties : propertiesList) {
-
             String propName = properties.getName();
             if (!order.values().contains(propName)) {
                 jsonToReturn.set(propName, setHiddenWidget(JsonNodeFactory.instance.objectNode()));
                 orderSchema.add(propName);
             }
+        }
 
+        // If there aren't any visible contents, then set this form as hidden as well.
+        if (!hasVisible[0]) {
+            setHiddenWidget(jsonToReturn);
         }
 
         return jsonToReturn;
@@ -147,9 +137,11 @@ public class UiSchemaGenerator {
      *
      * @param widget The widget associated with the Property or Presentation item.
      * @param schema The uiSchema currently being generated for the widget.
+     * @param hasVisible Secondary return value: If this widget is visible, the first boolean value will be set to true.
+     * Otherwise, this remains untouched.
      * @return The generated uiSchema.
      */
-    private ObjectNode processTWidget(Widget widget, ObjectNode schema) {
+    private ObjectNode processTWidget(Widget widget, ObjectNode schema, boolean[] hasVisible) {
         if (widget.isHidden()) {
             NamedThing content = widget.getContent();
             if (content != null) {
@@ -171,12 +163,19 @@ public class UiSchemaGenerator {
 
                     schema.set(UiSchemaConstants.TAG_OPTIONS, options);
                 }
-            } else {// no supported widget for this, so if Properties then hide
+                // Any other widget type than hidden causes means that it is visible.
+                if (!UiSchemaConstants.TYPE_HIDDEN.equals(widgetType)) {
+                    hasVisible[0] = true;
+                }
+            } else {//no supported widget for this, so if Properties then hide 
                 NamedThing content = widget.getContent();
                 if (content instanceof Properties) {
                     // hide the Properties that do not have a Widget to render it.
                     return setHiddenWidget(schema);
-                } // else for primitive it means default, and do not add type tag in schema
+                } else {
+                    // else for primitive it means default, and do not add type tag in schema
+                    hasVisible[0] = true;
+                }
             }
             return addTriggerTWidget(widget, schema);
         }

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/UiSchemaGeneratorTest.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/UiSchemaGeneratorTest.java
@@ -1,6 +1,7 @@
 package org.talend.daikon.serialize.jsonschema;
 
 import static org.junit.Assert.assertEquals;
+import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 import org.junit.Test;
 import org.talend.daikon.properties.PropertiesImpl;
@@ -13,8 +14,6 @@ import org.talend.daikon.properties.property.PropertyFactory;
 import org.talend.daikon.serialize.FullExampleProperties;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import static org.skyscreamer.jsonassert.JSONAssert.assertEquals;
 
 public class UiSchemaGeneratorTest {
 
@@ -111,4 +110,37 @@ public class UiSchemaGeneratorTest {
         String expectedPartial = "{\"np\":{\"myNestedStr\":{\"ui:widget\":\"textarea\"}},\"np4\":{\"ui:widget\":\"hidden\"},\"np5\":{\"ui:widget\":\"hidden\"},\"np2\":{\"ui:widget\":\"hidden\"},\"np3\":{\"ui:widget\":\"hidden\"}}";
         assertEquals(expectedPartial, uiSchemaJsonObj.toString(), false);
     }
+
+    @Test
+    public void testAllHidden() throws Exception {
+        // When all of the properties are hidden, the form will be hidden too.
+        AProperties aProperties = new AProperties("foo");
+        aProperties.init();
+        Form f = aProperties.getForm("MyForm");
+        for (Widget w : f.getWidgets()) {
+            w.setHidden();
+        }
+
+        // When all of the widgets are hidden, there should be a ui:widget = hidden on the root uiSchema.
+        ObjectNode uiSchema = new UiSchemaGenerator().genWidget(aProperties, f.getName());
+        String expectedPartial = "{\"ui:widget\":\"hidden\"}";
+        assertEquals(expectedPartial, uiSchema.toString(), false);
+    }
+
+    @Test
+    public void testSomeHidden() throws Exception {
+        // When all of the properties are hidden, the form will be hidden too.
+        AProperties aProperties = new AProperties("foo");
+        aProperties.init();
+        Form f = aProperties.getForm("MyForm");
+
+        // Hide the only property on the nested form.
+        ((Form) f.getWidget("np").getContent()).getWidget("myNestedStr").setHidden();
+
+        // When all of the widgets are hidden, there should be a ui:widget = hidden on the root uiSchema.
+        ObjectNode uiSchema = new UiSchemaGenerator().genWidget(aProperties, f.getName());
+        String expectedPartial = "{\"np\": {\"ui:widget\":\"hidden\"}}";
+        assertEquals(expectedPartial, uiSchema.toString(), false);
+    }
+
 }

--- a/daikon/src/test/resources/org/talend/daikon/serialize/jsonschema/ReferenceExampleUiSchema.json
+++ b/daikon/src/test/resources/org/talend/daikon/serialize/jsonschema/ReferenceExampleUiSchema.json
@@ -1,1 +1,1 @@
-{"ui:order":["parentProp","testAPropReference"],"parentProp":{"ui:widget":"hidden"},"testAPropReference":{"ui:widget":"hidden"}}
+{"ui:order":["parentProp","testAPropReference"],"parentProp":{"ui:widget":"hidden"},"testAPropReference":{"ui:widget":"hidden"},"ui:widget":"hidden"}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [X] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

When you hide ALL of the elements inside nested properties (i.e. no form components are expected to be shown), the `Properties` will still show its title.  As a consequence, you have a title in the UI without any form components to adjust.

This is particularly confusing for `SchemaProperties` when the Schema itself is hidden.  We see a MAIN schema title without any editor.

**What is the new behavior?**

When you hide ALL of the elements inside nested properties, the `ui:widget` for the Properties is also set to `hidden`.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No
