### PR TITLE
feat(TDP-3377): Allow S3 Bucket provider to customize root directory

### DIFF
--- a/daikon-content-service/content-service-common/src/test/java/org/talend/daikon/content/DeletableResourceTest.java
+++ b/daikon-content-service/content-service-common/src/test/java/org/talend/daikon/content/DeletableResourceTest.java
@@ -117,9 +117,7 @@ public abstract class DeletableResourceTest extends DeletableLoaderResourceTests
     }
 
     @Test
-    public void getFilename() throws Exception {
-        assertEquals(LOCATION, resource.getFilename());
-    }
+    public abstract void getFilename() throws Exception;
 
     @Test
     public abstract void shouldGetDescription() throws Exception;

--- a/daikon-content-service/local-content-service/src/test/java/org/talend/daikon/content/local/LocalDeletableResourceTest.java
+++ b/daikon-content-service/local-content-service/src/test/java/org/talend/daikon/content/local/LocalDeletableResourceTest.java
@@ -1,7 +1,6 @@
 package org.talend.daikon.content.local;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import org.springframework.test.context.TestPropertySource;
 import org.talend.daikon.content.DeletableResourceTest;
@@ -27,6 +26,11 @@ public class LocalDeletableResourceTest extends DeletableResourceTest {
     @Override
     public void lastModifiedShouldBeComputed() throws Exception {
         assertTrue(resource.lastModified() > 0);
+    }
+
+    @Override
+    public void getFilename() throws Exception {
+        assertEquals(LOCATION, resource.getFilename());
     }
 
     @Override

--- a/daikon-content-service/s3-content-service/README.md
+++ b/daikon-content-service/s3-content-service/README.md
@@ -76,3 +76,5 @@ multi-tenancy.s3.active=true
 ```
 
 In this case you are required to provide an implementation of `org.talend.daikon.content.s3.provider.S3BucketProvider` that provide the current bucket name.
+
+`S3BucketProvider` needs to implement two methods: one returns the S3 bucket name, the other the root directory for the tenant (might be empty string if all data is to be stored at root level of the S3 bucket).

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/LocationUtils.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/LocationUtils.java
@@ -1,5 +1,7 @@
 package org.talend.daikon.content.s3;
 
+import org.apache.commons.lang.StringUtils;
+
 /**
  * Utility class for processing location in order to align them with S3's internals.
  */
@@ -24,5 +26,42 @@ class LocationUtils {
         } else {
             return location;
         }
+    }
+
+    public static class S3PathBuilder {
+
+        private final StringBuilder path = new StringBuilder();
+
+        private final String bucket;
+
+        private S3PathBuilder(String bucket) {
+            this.bucket = bucket;
+        }
+
+        public static S3PathBuilder builder(String bucket) {
+            return new S3PathBuilder(bucket);
+        }
+
+        public static S3PathBuilder builder() {
+            return new S3PathBuilder(StringUtils.EMPTY);
+        }
+
+        public S3PathBuilder append(String path) {
+            String trimmedPath = StringUtils.trim(path);
+            if (StringUtils.isEmpty(trimmedPath)) {
+                return this;
+            }
+            if (trimmedPath.startsWith("/")) {
+                this.path.append(trimmedPath);
+            } else {
+                this.path.append('/').append(trimmedPath);
+            }
+            return this;
+        }
+
+        public String build() {
+            return bucket + path;
+        }
+
     }
 }

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ContentServiceConfiguration.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ContentServiceConfiguration.java
@@ -101,7 +101,18 @@ public class S3ContentServiceConfiguration implements ContentServiceEnabled {
             }
         } else {
             final String staticBucketName = environment.getProperty("content-service.store.s3.bucket", String.class);
-            return new S3ResourceResolver(resolver, amazonS3, () -> staticBucketName);
+            final S3BucketProvider provider = new S3BucketProvider() {
+                @Override
+                public String getBucketName() {
+                    return staticBucketName;
+                }
+
+                @Override
+                public String getRoot() {
+                    return StringUtils.EMPTY;
+                }
+            };
+            return new S3ResourceResolver(resolver, amazonS3, provider);
         }
     }
 

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -1,6 +1,7 @@
 package org.talend.daikon.content.s3;
 
 import static org.talend.daikon.content.s3.LocationUtils.toS3Location;
+import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
 
 import java.io.IOException;
 
@@ -27,7 +28,11 @@ class S3ResourceResolver extends AbstractResourceResolver {
 
     @Override
     public DeletableResource[] getResources(String locationPattern) throws IOException {
-        return super.getResources("s3://" + bucket.getBucketName() + locationPattern);
+        final String location = builder(bucket.getBucketName()) //
+                .append(bucket.getRoot()) //
+                .append(locationPattern) //
+                .build();
+        return super.getResources("s3://" + location);
     }
 
     @Override
@@ -40,11 +45,16 @@ class S3ResourceResolver extends AbstractResourceResolver {
             throw new IllegalArgumentException("Location can not be empty (was '" + location + "')");
         }
 
-        return super.getResource("s3://" + bucket.getBucketName() + "/" + toS3Location(location));
+        final String s3Location = builder(bucket.getBucketName()) //
+                .append(bucket.getRoot()) //
+                .append(toS3Location(location)) //
+                .build();
+        return super.getResource("s3://" + s3Location);
     }
 
     @Override
     protected DeletableResource convert(WritableResource writableResource) {
-        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket.getBucketName());
+        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket.getBucketName(),
+                bucket.getRoot());
     }
 }

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/provider/S3BucketProvider.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/provider/S3BucketProvider.java
@@ -7,11 +7,15 @@ package org.talend.daikon.content.s3.provider;
  * <li>Runtime-defined bucket name (for multi tenant use cases).</li>
  * </ul>
  */
-@FunctionalInterface
 public interface S3BucketProvider {
 
     /**
      * @return The tenant bucket name.
      */
     String getBucketName();
+
+    /**
+     * @return The root directory name to use inside the bucket.
+     */
+    String getRoot();
 }

--- a/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/AmazonS3TestWrapper.java
+++ b/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/AmazonS3TestWrapper.java
@@ -15,7 +15,7 @@ import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.S3ResponseMetadata;
 import com.amazonaws.services.s3.model.*;
 
-class AmazonS3TestWrapper implements AmazonS3 {
+public class AmazonS3TestWrapper implements AmazonS3 {
 
     private final AmazonS3 delegate;
 

--- a/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3DeletableResourceTest.java
+++ b/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3DeletableResourceTest.java
@@ -54,9 +54,14 @@ public class S3DeletableResourceTest extends DeletableResourceTest {
         assertEquals(0, resource.lastModified()); // Not implemented by S3 mock.
     }
 
+    @Override
+    public void getFilename() throws Exception {
+        assertEquals("app1/" + LOCATION, resource.getFilename());
+    }
+
     @Test
     public void shouldGetDescription() throws Exception {
-        assertEquals("Amazon s3 resource [bucket='s3-content-service1' and object='file.txt']", resource.getDescription());
+        assertEquals("Amazon s3 resource [bucket='s3-content-service1' and object='app1/file.txt']", resource.getDescription());
     }
 
     @Test
@@ -66,14 +71,21 @@ public class S3DeletableResourceTest extends DeletableResourceTest {
         final Resource resource1 = resolver.getResource(LOCATION);
 
         // Then
-        assertEquals("Amazon s3 resource [bucket='s3-content-service1' and object='file.txt']", resource1.getDescription());
+        assertEquals("Amazon s3 resource [bucket='s3-content-service1' and object='app1/file.txt']", resource1.getDescription());
 
         // Given
         TestConfiguration.clientNumber.set(1);
         final Resource resource2 = resolver.getResource(LOCATION);
 
         // Then
-        assertEquals("Amazon s3 resource [bucket='s3-content-service2' and object='file.txt']", resource2.getDescription());
+        assertEquals("Amazon s3 resource [bucket='s3-content-service2' and object='app2/file.txt']", resource2.getDescription());
+
+        // Given
+        TestConfiguration.clientNumber.set(2);
+        final Resource resource3 = resolver.getResource(LOCATION);
+
+        // Then
+        assertEquals("Amazon s3 resource [bucket='s3-content-service2' and object='file.txt']", resource3.getDescription());
     }
 
     @Test

--- a/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/TestConfiguration.java
+++ b/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/TestConfiguration.java
@@ -40,11 +40,25 @@ public class TestConfiguration implements InitializingBean, DisposableBean {
 
     @Bean
     public S3BucketProvider s3BucketProvider() {
-        return () -> {
-            if (clientNumber.get() == 0) {
-                return "s3-content-service1";
-            } else {
-                return "s3-content-service2";
+        return new S3BucketProvider() {
+            @Override
+            public String getBucketName() {
+                if (clientNumber.get() == 0) {
+                    return "s3-content-service1";
+                } else {
+                    return "s3-content-service2";
+                }
+            }
+
+            @Override
+            public String getRoot() {
+                if (clientNumber.get() == 0) {
+                    return "app1";
+                } else if (clientNumber.get() == 1) {
+                    return "app2";
+                } else {
+                    return "";
+                }
             }
         };
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [x] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
There was no way to configure the root directory per tenant in the S3 content service. This is required by TDP-3377.

**What is the new behavior?**
Similarly to multi tenancy in MongoDB, S3BucketProvider can provide the root directory.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

**Other information**:
