### PR TITLE
fix(TCOMP-538): Fix visiting of referenced properties in ReferenceProperties

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
@@ -77,7 +77,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
                     if (property.isFlag(Flags.ENCRYPT)) {
                         property.encryptStoredValue(!ENCRYPT);
                     } // else not an encrypted property
-                } // else not a Property so ignors it.
+                } // else not a Property so ignores it.
             }
         }
 
@@ -135,7 +135,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
                     se = (NamedThing) f.get(this);
                     if (se != null) {
                         initializeField(f, se);
-                    } else {// field not initilaized but is should be (except for returns field)
+                    } else {// field not initialized but is should be (except for returns field)
                         if (!acceptUninitializedField(f)) {
                             throw new TalendRuntimeException(PropertiesErrorCode.PROPERTIES_HAS_UNITIALIZED_PROPS,
                                     ExceptionContext.withBuilder().put("name", this.getClass().getCanonicalName())
@@ -147,7 +147,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
                 }
             }
             propsAlreadyInitialized = true;
-        } // else already intialized
+        } // else already initialized
     }
 
     protected List<Field> initializeFields() {
@@ -185,7 +185,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
 
     /**
      * This shall set the value holder for all the properties, set the i18n formatter of this current class to the
-     * properties so that the i18n values are computed agains this class message properties. This calls the
+     * properties so that the i18n values are computed against this class message properties. This calls the
      * initProperties for all field of type {@link Property}
      *
      * @param f field to be initialized
@@ -334,7 +334,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
                     if (fValue != null) {
                         NamedThing se = (NamedThing) fValue;
                         properties.add(se);
-                    } // else not initalized but this is already handled in the initProperties that must be called
+                    } // else not initialized but this is already handled in the initProperties that must be called
                       // before the getProperties
                 }
             } catch (IllegalAccessException e) {
@@ -372,15 +372,52 @@ public class PropertiesImpl extends TranslatableTaggedImpl
             return;
         }
         visited.add(this);
+        visitProperties(visitor, visited);
+        visitor.visit(this, parent);
+    }
+
+    /**
+     * Traverse all visitable properties and accept <code>AnyPropertyVisitor</code>.
+     *
+     * <p>Can be overriden by subclasses to visit extra properties that are not exposed but should be visited.
+     *
+     * <p>Example:<blockquote>
+     * <pre>
+     *     {@literal @Override}
+     *     protected void visitProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
+     *         super.visitProperties(visitor, visited);
+     *
+     *         if (someSpecialProperty != null) {
+     *             visitProperty(visitor, visited, someSpecialProperty);
+     *         }
+     *     }
+     * </pre></blockquote>
+     *
+     * @see #visitProperty(AnyPropertyVisitor, Set, NamedThing)
+     *
+     * @param visitor visitor to be used
+     * @param visited collection to register visited properties
+     */
+    protected void visitProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
         List<NamedThing> properties = getProperties();
         for (NamedThing nt : properties) {
-            if (nt instanceof PropertiesImpl) {
-                ((PropertiesImpl) nt).acceptInternal(visitor, this, visited);
-            } else if (nt instanceof AnyProperty) {
-                ((AnyProperty) nt).accept(visitor, this);
-            }
+            visitProperty(visitor, visited, nt);
         }
-        visitor.visit(this, parent);
+    }
+
+    /**
+     * Accept visitor for a single property.
+     *
+     * @param visitor visitor to be used
+     * @param visited collection to register visited properties
+     * @param nt object to be visited
+     */
+    protected final void visitProperty(AnyPropertyVisitor visitor, Set<Properties> visited, NamedThing nt) {
+        if (nt instanceof PropertiesImpl) {
+            ((PropertiesImpl) nt).acceptInternal(visitor, this, visited);
+        } else if (nt instanceof AnyProperty) {
+            ((AnyProperty) nt).accept(visitor, this);
+        }
     }
 
     /**
@@ -394,7 +431,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
     }
 
     /**
-     * @return a Namething from a property path wich allow to recurse into nested properties using the . as a separator
+     * @return a NamedThing from a property path which allow to recurse into nested properties using the . as a separator
      * for Properties names and the final Property. Or null if none found
      */
     @Override

--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
@@ -77,7 +77,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
                     if (property.isFlag(Flags.ENCRYPT)) {
                         property.encryptStoredValue(!ENCRYPT);
                     } // else not an encrypted property
-                } // else not a Property so ignores it.
+                } // else not a Property so ignore it.
             }
         }
 

--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
@@ -372,7 +372,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
             return;
         }
         visited.add(this);
-        visitProperties(visitor, visited);
+        acceptForAllProperties(visitor, visited);
         visitor.visit(this, parent);
     }
 
@@ -384,35 +384,35 @@ public class PropertiesImpl extends TranslatableTaggedImpl
      * <p>Example:<blockquote>
      * <pre>
      *     {@literal @Override}
-     *     protected void visitProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
-     *         super.visitProperties(visitor, visited);
+     *     protected void acceptForAllProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
+     *         super.acceptForAllProperties(visitor, visited);
      *
      *         if (someSpecialProperty != null) {
-     *             visitProperty(visitor, visited, someSpecialProperty);
+     *             acceptForProperty(visitor, visited, someSpecialProperty);
      *         }
      *     }
      * </pre></blockquote>
      *
-     * @see #visitProperty(AnyPropertyVisitor, Set, NamedThing)
+     * @see #acceptForProperty(AnyPropertyVisitor, Set, NamedThing)
      *
-     * @param visitor visitor to be used
+     * @param visitor visitor to be accepted
      * @param visited collection to register visited properties
      */
-    protected void visitProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
+    protected void acceptForAllProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
         List<NamedThing> properties = getProperties();
         for (NamedThing nt : properties) {
-            visitProperty(visitor, visited, nt);
+            acceptForProperty(visitor, visited, nt);
         }
     }
 
     /**
      * Accept visitor for a single property.
      *
-     * @param visitor visitor to be used
+     * @param visitor visitor to be accepted
      * @param visited collection to register visited properties
      * @param nt object to be visited
      */
-    protected final void visitProperty(AnyPropertyVisitor visitor, Set<Properties> visited, NamedThing nt) {
+    protected final void acceptForProperty(AnyPropertyVisitor visitor, Set<Properties> visited, NamedThing nt) {
         if (nt instanceof PropertiesImpl) {
             ((PropertiesImpl) nt).acceptInternal(visitor, this, visited);
         } else if (nt instanceof AnyProperty) {

--- a/daikon/src/main/java/org/talend/daikon/properties/ReferenceProperties.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/ReferenceProperties.java
@@ -72,11 +72,11 @@ public class ReferenceProperties<T extends Properties> extends PropertiesImpl {
     }
 
     @Override
-    protected void visitProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
-        super.visitProperties(visitor, visited);
+    protected void acceptForAllProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
+        super.acceptForAllProperties(visitor, visited);
 
         if (reference != null) {
-            visitProperty(visitor, visited, reference);
+            acceptForProperty(visitor, visited, reference);
         }
     }
 

--- a/daikon/src/main/java/org/talend/daikon/properties/ReferenceProperties.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/ReferenceProperties.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -68,6 +69,15 @@ public class ReferenceProperties<T extends Properties> extends PropertiesImpl {
         }
         // we accept that return field is not initialized after setupProperties.
         return "reference".equals(f.getName());
+    }
+
+    @Override
+    protected void visitProperties(AnyPropertyVisitor visitor, Set<Properties> visited) {
+        super.visitProperties(visitor, visited);
+
+        if (reference != null) {
+            visitProperty(visitor, visited, reference);
+        }
     }
 
     /**

--- a/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
@@ -12,15 +12,20 @@
 // ============================================================================
 package org.talend.daikon.properties;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,6 +34,7 @@ import org.talend.daikon.definition.Definition;
 import org.talend.daikon.definition.service.DefinitionRegistryService;
 import org.talend.daikon.properties.ReferenceExampleProperties.TestAProperties;
 import org.talend.daikon.properties.ReferenceExampleProperties.TestBProperties;
+import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.test.PropertiesTestUtils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -92,4 +98,31 @@ public class ReferencePropertiesTest {
         assertEquals(testAProp, refEProp.testAPropReference.getReference());
         assertEquals(testBProp, testAProp.testBPropReference.getReference());
     }
+
+    @Test
+    public void testReferencedPropertiesVisited() throws ParseException, IOException {
+
+        ReferenceExampleProperties refEProp = new ReferenceExampleProperties(null);
+
+        TestAProperties testAProp = new TestAProperties("testAProp");
+        refEProp.testAPropReference.setReference(testAProp);
+
+        refEProp.init();
+
+        final Set<AnyProperty> visited = new HashSet<>();
+        refEProp.accept(new AnyPropertyVisitor() {
+            @Override
+            public void visit(Property property, Properties parent) {
+                visited.add(property);
+            }
+
+            @Override
+            public void visit(Properties properties, Properties parent) {
+                visited.add(properties);
+            }
+        }, null);
+
+        assertNotNull(visited.contains(testAProp));
+    }
+
 }

--- a/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
@@ -122,7 +122,7 @@ public class ReferencePropertiesTest {
             }
         }, null);
 
-        assertNotNull(visited.contains(testAProp));
+        assertNotNull("Referenced properties visited", visited.contains(testAProp));
     }
 
 }

--- a/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
@@ -111,6 +111,7 @@ public class ReferencePropertiesTest {
 
         final Set<AnyProperty> visited = new HashSet<>();
         refEProp.accept(new AnyPropertyVisitor() {
+
             @Override
             public void visit(Property property, Properties parent) {
                 visited.add(property);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [X] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [X] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
- ReferenceProperties doesn't traverse referenced properties instance when accepting a visitor and as, consequence, referenced properties are excluded from processing (f.x. encryption of properties before serialization to JSON)


**What is the new behavior?**
- ReferenceProperties traverse referenced properties instance when accepting a visitor, referenced properties are included into processing (f.x. encryption of properties before serialization to JSON)


**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
JIRA issue: https://jira.talendforge.org/browse/TCOMP-538