### PR TITLE
fix(TDKN-158): make ValidationResult.OK deprecated this causing logic…

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/ValidationResult.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/ValidationResult.java
@@ -33,7 +33,17 @@ public class ValidationResult {
         ERROR
     }
 
+    /**
+     * <b>TDKN-158</b> - this causing validation error.<br/>
+     * As the OK instance is static it's can be modified while validation process and loose it's real sense
+     * Use {@link #ok()} method to get a new instance instead of that
+     */
+    @Deprecated
     public static ValidationResult OK = new ValidationResult().setStatus(Result.OK);
+
+    public static ValidationResult ok() {
+        return new ValidationResult().setStatus(Result.OK);
+    }
 
     @JsonIgnore
     public Result status = Result.OK;


### PR DESCRIPTION
… issues

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)
https://jira.talendforge.org/browse/TDKN-158


**What is the new behavior?**
make ValidationResult.OK deprecated 
we provide a new method ok() to be used instead of ValidationResult.OK.
the ok() method deliver a new instance every time called to avoid the logic mismatch caused with the static shared instance ValidationResult.OK

**This ValidationResult.OK attribute should be removed in the incoming version**

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
