### PR TITLE
fix(TCOMP-541): remove LogLog.debug from layout classes

### DIFF
--- a/daikon-logging/.gitignore
+++ b/daikon-logging/.gitignore
@@ -1,1 +1,2 @@
 /target/
+*.log

--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/Log4jJSONLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/Log4jJSONLayout.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import java.util.Map;
 
 import org.apache.log4j.Layout;
-import org.apache.log4j.helpers.LogLog;
 import org.apache.log4j.pattern.ThrowableInformationPatternConverter;
 import org.apache.log4j.spi.LocationInfo;
 import org.apache.log4j.spi.LoggingEvent;
@@ -63,7 +62,6 @@ public class Log4jJSONLayout extends Layout {
          */
         if (getUserFields() != null) {
             String userFlds = getUserFields();
-            LogLog.debug("[" + whoami + "] Got user data from log4j property: " + userFlds);
             LayoutUtils.addUserFields(userFlds, userFieldsEvent);
         }
 

--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONLayout.java
@@ -6,7 +6,6 @@ import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 
-import org.apache.log4j.helpers.LogLog;
 import org.talend.daikon.logging.event.field.HostData;
 import org.talend.daikon.logging.event.field.LayoutFields;
 
@@ -58,7 +57,6 @@ public class LogbackJSONLayout extends JsonLayout<ILoggingEvent> {
          */
         if (getUserFields() != null) {
             String userFlds = getUserFields();
-            LogLog.debug("[" + whoami + "] Got user data from logback property: " + userFlds);
             LayoutUtils.addUserFields(userFlds, userFieldsEvent);
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

LogLog.debug is used in Layout classes which causes an error, when Logback layout is used.
When Logback is used log4j classes are not present in classpath, thus NoClassDefFoundException appears

**What is the new behavior?**

LogLog.debug was removed

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Related to https://jira.talendforge.org/browse/TCOMP-541