### PR TITLE
fix(TCOMP-541): fix logging configuration examples

### DIFF
--- a/daikon-logging/logging-event-layout/README.MD
+++ b/daikon-logging/logging-event-layout/README.MD
@@ -85,7 +85,7 @@ with the `RollingFileAppender` in your `logback.xml`, `log4j.xml` or `log4j2.xml
       <maxHistory>30</maxHistory>
     </rollingPolicy>
     <layout class="org.talend.daikon.logging.event.layout.LogbackJSONLayout">
-        <param name="UserFields" value="" />
+        <param name="UserFields" value="field1:value1,field2:value2" />
         <param name="LocationInfo" value="false"/>
     </layout>
  </appender>
@@ -108,7 +108,7 @@ with the `RollingFileAppender` in your `logback.xml`, `log4j.xml` or `log4j2.xml
         <param name="MaxBackupIndex" value="20" />
         <param name="encoding" value="UTF-8" />
         <layout class="org.talend.daikon.logging.event.layout.Log4jJSONLayout">
-            <param name="UserFields" value="" />
+            <param name="UserFields" value="field1:value1,field2:value2" />
             <param name="LocationInfo" value="false"/>
         </layout>
     </appender>   
@@ -128,8 +128,8 @@ with the `RollingFileAppender` in your `logback.xml`, `log4j.xml` or `log4j2.xml
     <RollingFile name="File" fileName="${LOG_PATH}/application.log"
         filePattern="${LOG_PATH}/application-%d{yyyy-MM-dd}.log">
         <Log4j2JSONLayout charset="UTF-8" skipJsonEscapeSubLayout="true" locationInfo="false" subLayoutAsElement="true">
-            <KeyValuePair key="" value=""/>
-            <KeyValuePair key="" value=""/>
+            <KeyValuePair key="field1" value="value1"/>
+            <KeyValuePair key="field2" value="value2"/>
         </Log4j2JSONLayout>
         <Policies>
           <TimeBasedTriggeringPolicy interval="1" modulate="true"/>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

Current example logging configuration for logback has an error: param name="UserFields" value="" - value is empty. If you use such configuration than logs are not written. 

**What is the new behavior?**

Fixed an error in logback and other configuration examples

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...


**Other information**:
Related to https://jira.talendforge.org/browse/TCOMP-541