### PR TITLE
feat(TDKN-167):remove refreshProperties and added ref after callback

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/Properties.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/Properties.java
@@ -151,15 +151,6 @@ public interface Properties extends AnyProperty, ToStringIndent {
     void refreshLayout(Form form);
 
     /**
-     * This method intent is to be called at the end of the initialization process of a {@link Properties} object.
-     * For instance it can be used after the deserialization of a properties, from a Json object, containing a some
-     * {@link Property} that need runtime to retrieve some values.
-     *
-     * Class implementing this method may implement a stub of this method and its sub classes overwrite it if needed.
-     */
-    void refreshProperties();
-
-    /**
      * Returns all of the {@link Form} objects associated with this object.
      */
     List<Form> getForms();

--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesDynamicMethodHelper.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesDynamicMethodHelper.java
@@ -29,7 +29,7 @@ public class PropertiesDynamicMethodHelper {
 
     static private boolean REQUIRED = true;
 
-    static private Method findMethod(Object obj, String type, String propertyName, boolean required) {
+    private static Method findMethod(Object obj, String type, String propertyName, boolean required) {
         if (propertyName == null || "".equals(propertyName)) {
             throw new IllegalArgumentException(
                     "The ComponentService was used to access a property with a null(or empty) property name. Type: " + type
@@ -49,7 +49,7 @@ public class PropertiesDynamicMethodHelper {
         return null;
     }
 
-    static private void doInvoke(Properties props, Method m) throws Throwable {
+    private static void doInvoke(Properties props, Method m) throws Throwable {
         try {
             m.setAccessible(true);
             Object result = m.invoke(props);
@@ -79,7 +79,7 @@ public class PropertiesDynamicMethodHelper {
         }
     }
 
-    static public void validateProperty(Properties props, String propName) throws Throwable {
+    public static void validateProperty(Properties props, String propName) throws Throwable {
         Method m = findMethod(props, Properties.METHOD_VALIDATE, propName, REQUIRED);
         try {
             m.setAccessible(true);
@@ -89,42 +89,42 @@ public class PropertiesDynamicMethodHelper {
         }
     }
 
-    static public void beforePropertyActivate(Properties props, String propName) throws Throwable {
+    public static void beforePropertyActivate(Properties props, String propName) throws Throwable {
         doInvoke(props, findMethod(props, Properties.METHOD_BEFORE, propName, REQUIRED));
     }
 
-    static public void beforePropertyPresent(Properties props, String propName) throws Throwable {
+    public static void beforePropertyPresent(Properties props, String propName) throws Throwable {
         doInvoke(props, findMethod(props, Properties.METHOD_BEFORE, propName, REQUIRED));
     }
 
-    static public void afterProperty(Properties props, String propName) throws Throwable {
+    public static void afterProperty(Properties props, String propName) throws Throwable {
         doInvoke(props, findMethod(props, Properties.METHOD_AFTER, propName, REQUIRED));
     }
 
-    static public void beforeFormPresent(Properties props, String formName) throws Throwable {
+    public static void beforeFormPresent(Properties props, String formName) throws Throwable {
         doInvoke(props, findMethod(props, Properties.METHOD_BEFORE_FORM, formName, REQUIRED));
     }
 
-    static public void afterFormNext(Properties props, String formName) throws Throwable {
+    public static void afterFormNext(Properties props, String formName) throws Throwable {
         doInvoke(props, findMethod(props, Properties.METHOD_AFTER_FORM_NEXT, formName, REQUIRED));
     }
 
-    static public void afterFormBack(Properties props, String formName) throws Throwable {
+    public static void afterFormBack(Properties props, String formName) throws Throwable {
         doInvoke(props, findMethod(props, Properties.METHOD_AFTER_FORM_BACK, formName, REQUIRED));
     }
 
-    static public void afterFormFinish(Properties props, String formName, Repository repostory) throws Throwable {
+    public static void afterFormFinish(Properties props, String formName, Repository repostory) throws Throwable {
         doInvoke(props, findMethod(props, Properties.METHOD_AFTER_FORM_FINISH, formName, REQUIRED), repostory);
     }
 
-    static public void afterReference(Properties props, ReferenceProperties<Properties> refProp) throws Throwable {
+    public static void afterReference(Properties props, ReferenceProperties<Properties> refProp) throws Throwable {
         Method afterRefCallback = findMethod(props, Properties.METHOD_AFTER, refProp.getName(), !REQUIRED);
         if (afterRefCallback != null) {
             doInvoke(props, afterRefCallback);
         } // else not method to call back so ignores it
     }
 
-    static public void setFormLayoutMethods(Properties props, String property, Form form) {
+    public static void setFormLayoutMethods(Properties props, String property, Form form) {
         Method m;
         m = findMethod(props, Properties.METHOD_BEFORE_FORM, property, !REQUIRED);
         if (m != null) {
@@ -144,7 +144,7 @@ public class PropertiesDynamicMethodHelper {
         }
     }
 
-    static public void setWidgetLayoutMethods(Properties props, String property, Widget widget) {
+    public static void setWidgetLayoutMethods(Properties props, String property, Widget widget) {
         Method m;
         m = findMethod(props, Properties.METHOD_BEFORE, property, !REQUIRED);
         if (m != null) {

--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesDynamicMethodHelper.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesDynamicMethodHelper.java
@@ -117,6 +117,13 @@ public class PropertiesDynamicMethodHelper {
         doInvoke(props, findMethod(props, Properties.METHOD_AFTER_FORM_FINISH, formName, REQUIRED), repostory);
     }
 
+    static public void afterReference(Properties props, ReferenceProperties<Properties> refProp) throws Throwable {
+        Method afterRefCallback = findMethod(props, Properties.METHOD_AFTER, refProp.getName(), !REQUIRED);
+        if (afterRefCallback != null) {
+            doInvoke(props, afterRefCallback);
+        } // else not method to call back so ignores it
+    }
+
     static public void setFormLayoutMethods(Properties props, String property, Form form) {
         Method m;
         m = findMethod(props, Properties.METHOD_BEFORE_FORM, property, !REQUIRED);

--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
@@ -15,7 +15,11 @@ package org.talend.daikon.properties;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -290,11 +294,6 @@ public class PropertiesImpl extends TranslatableTaggedImpl
     }
 
     @Override
-    public void refreshProperties() {
-        // No op
-    }
-
-    @Override
     public List<Form> getForms() {
         return forms;
     }
@@ -459,8 +458,8 @@ public class PropertiesImpl extends TranslatableTaggedImpl
     }
 
     /**
-     * @return a NamedThing from a property path which allow to recurse into nested properties using the . as a separator
-     * for Properties names and the final Property. Or null if none found
+     * @return a NamedThing from a property path which allow to recurse into nested properties using the . as a
+     * separator for Properties names and the final Property. Or null if none found
      */
     @Override
     public NamedThing getProperty(String propPath) {

--- a/daikon/src/test/java/org/talend/daikon/properties/ReferenceExampleProperties.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/ReferenceExampleProperties.java
@@ -1,6 +1,6 @@
 package org.talend.daikon.properties;
 
-import static org.talend.daikon.properties.property.PropertyFactory.*;
+import static org.talend.daikon.properties.property.PropertyFactory.newString;
 
 import org.talend.daikon.properties.presentation.Form;
 import org.talend.daikon.properties.property.Property;
@@ -12,6 +12,13 @@ public class ReferenceExampleProperties extends PropertiesImpl {
     public ReferenceProperties<TestAProperties> testAPropReference = new ReferenceProperties<>("testAPropReference",
             TestAProperties.TEST_A_PROPERTIES_DEFINTION_NAME);
 
+    // this has no callback and used to ensure it does not trigger any exception during callback check upton ref
+    // resolution
+    public ReferenceProperties<TestAProperties> testAPropReference2 = new ReferenceProperties<>("testAPropReference2",
+            TestAProperties.TEST_A_PROPERTIES_DEFINTION_NAME);
+
+    public boolean afterRefCallbackCalled;
+
     public ReferenceExampleProperties(String name) {
         super(name);
     }
@@ -20,6 +27,10 @@ public class ReferenceExampleProperties extends PropertiesImpl {
     public void setupLayout() {
         super.setupLayout();
         new Form(this, Form.MAIN);
+    }
+
+    public void afterTestAPropReference() {
+        afterRefCallbackCalled = true;
     }
 
     public static class TestAProperties extends PropertiesImpl {

--- a/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
@@ -147,7 +147,7 @@ public class ReferencePropertiesTest {
         definition2PropertiesMap.put("no_used", refEProp);
         definition2PropertiesMap.put(TestAProperties.TEST_A_PROPERTIES_DEFINTION_NAME, testAProp);
         definition2PropertiesMap.put(TestBProperties.TEST_B_PROPERTIES_DEFINTION_NAME, testBProp);
-        ReferenceProperties.resolveReferenceProperties(definition2PropertiesMap);
+        ReferenceProperties.resolveReferenceProperties(definition2PropertiesMap, true);
 
         // then
         assertTrue(refEProp.afterRefCallbackCalled);

--- a/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/ReferencePropertiesTest.java
@@ -13,8 +13,10 @@
 package org.talend.daikon.properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -57,6 +59,7 @@ public class ReferencePropertiesTest {
         TestBProperties testBProp = new TestBProperties(null);
 
         assertNull(refEProp.testAPropReference.getReference());
+        assertNull(refEProp.testAPropReference2.getReference());
         assertNull(testAProp.testBPropReference.getReference());
 
         // merge everything to the parent
@@ -67,6 +70,7 @@ public class ReferencePropertiesTest {
         ReferenceProperties.resolveReferenceProperties(definition2PropertiesMap);
 
         assertEquals(testAProp, refEProp.testAPropReference.getReference());
+        assertEquals(testAProp, refEProp.testAPropReference2.getReference());
         assertEquals(testBProp, testAProp.testBPropReference.getReference());
     }
 
@@ -124,6 +128,29 @@ public class ReferencePropertiesTest {
         }, null);
 
         assertNotNull("Referenced properties visited", visited.contains(testAProp));
+    }
+
+    @Test
+    public void testResolveReferenceCallBackCalled() throws ParseException, IOException {
+
+        // given
+        ReferenceExampleProperties refEProp = new ReferenceExampleProperties(null);
+        TestAProperties testAProp = new TestAProperties(null);
+        TestBProperties testBProp = new TestBProperties(null);
+
+        assertFalse(refEProp.afterRefCallbackCalled);
+
+        // when
+
+        // merge everything to the parent
+        Map<String, Properties> definition2PropertiesMap = new HashMap<>();
+        definition2PropertiesMap.put("no_used", refEProp);
+        definition2PropertiesMap.put(TestAProperties.TEST_A_PROPERTIES_DEFINTION_NAME, testAProp);
+        definition2PropertiesMap.put(TestBProperties.TEST_B_PROPERTIES_DEFINTION_NAME, testBProp);
+        ReferenceProperties.resolveReferenceProperties(definition2PropertiesMap);
+
+        // then
+        assertTrue(refEProp.afterRefCallbackCalled);
     }
 
 }

--- a/daikon/src/test/resources/org/talend/daikon/serialize/jsonschema/ReferenceExampleUiSchema.json
+++ b/daikon/src/test/resources/org/talend/daikon/serialize/jsonschema/ReferenceExampleUiSchema.json
@@ -1,1 +1,1 @@
-{"ui:order":["parentProp","testAPropReference"],"parentProp":{"ui:widget":"hidden"},"testAPropReference":{"ui:widget":"hidden"},"ui:widget":"hidden"}
+{"ui:order":["parentProp","testAPropReference","testAPropReference2"],"parentProp":{"ui:widget":"hidden"},"testAPropReference":{"ui:widget":"hidden"},"testAPropReference2":{"ui:widget":"hidden"},"ui:widget":"hidden"}


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
refreshProperties where hastily developed for dataprep cause there was a need to update the current properties state after the Properties is deserialized and references are setup. This is not required.

**What is the new behavior?**
Properties already has a deserialized method to be overriden if necessary but for notification after the references are setup the Studio already use an after callback, so I also implemented it when the references are automatically resolved in daikon. 

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...
Only salesforce if using this removed refresh method and I will create a PR to fix this.
The way to go is to create an after<MyReferenceProperties>() method to get notified.

