### PR TITLE
fix(TCOMP-422): Add finer-grained control to sandbox caching.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/sandbox/SandboxControl.java
+++ b/daikon/src/main/java/org/talend/daikon/sandbox/SandboxControl.java
@@ -1,6 +1,6 @@
 // ============================================================================
 //
-// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
 //
 // This source code is available under agreement available at
 // %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt

--- a/daikon/src/main/java/org/talend/daikon/sandbox/SandboxControl.java
+++ b/daikon/src/main/java/org/talend/daikon/sandbox/SandboxControl.java
@@ -12,9 +12,6 @@
 // ============================================================================
 package org.talend.daikon.sandbox;
 
-import java.net.URL;
-import java.util.List;
-
 /**
  * Provide finer-grained control for the creation of {@link SandboxedInstance}s.
  *

--- a/daikon/src/main/java/org/talend/daikon/sandbox/SandboxControl.java
+++ b/daikon/src/main/java/org/talend/daikon/sandbox/SandboxControl.java
@@ -1,0 +1,38 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.sandbox;
+
+import java.net.URL;
+import java.util.List;
+
+/**
+ * Provide finer-grained control for the creation of {@link SandboxedInstance}s.
+ *
+ * A {@link org.talend.daikon.runtime.RuntimeInfo} can also optionally implement this class to guide the creation of
+ * runtime instances.
+ */
+public interface SandboxControl {
+
+    /**
+     * Most {@link org.talend.daikon.runtime.RuntimeInfo} instances can reuse the classloader that dynamically adds
+     * dependencies to the classpath. This can largely improve performance. However, in certain cases, the loaded
+     * classes retain state between calls and should not be reused (notably when static members of loaded classes
+     * contain state information, and can't be reset within the runtime instance). In this case, this method can be
+     * overridden to determine whether the ClassLoader can be obtained from the cache (if available) and saved in the
+     * cache for future use.
+     * 
+     * @return true if the ClassLoader can be cached for future reuse. If false, a new ClassLoader should be created and
+     * never reused for future runtime instances.
+     */
+    boolean isClassLoaderReusable();
+}

--- a/daikon/src/main/java/org/talend/daikon/sandbox/SandboxInstanceFactory.java
+++ b/daikon/src/main/java/org/talend/daikon/sandbox/SandboxInstanceFactory.java
@@ -29,8 +29,8 @@ import org.talend.java.util.ClosableLRUMap;
 public class SandboxInstanceFactory {
 
     /**
-     * TODO: Add context variable to allow the user to configure the maximum size of the cache.
-     * Maybe using a CacheBuilder.
+     * TODO: Add context variable to allow the user to configure the maximum size of the cache. Maybe using a
+     * CacheBuilder.
      */
     static Map<RuntimeInfo, ClassLoader> classLoaderCache = Collections
             .synchronizedMap(new ClosableLRUMap<RuntimeInfo, ClassLoader>(3, 10));
@@ -45,16 +45,13 @@ public class SandboxInstanceFactory {
 
     /**
      * This will create a new class instance base on an URLClassLoader using the <code>classPathUrls</code> and the
-     * <code>parentClassLoader</code>.
-     * This instance will be embed in a {@link SandboxedInstance} so that it provides a SystemProperty isolation.<brW
-     * All the isolation constraints are to be found in the {@link SandboxedInstance} javadoc, please make sure you read it
-     * carefully.
+     * <code>parentClassLoader</code>. This instance will be embed in a {@link SandboxedInstance} so that it provides a
+     * SystemProperty isolation.<brW All the isolation constraints are to be found in the {@link SandboxedInstance}
+     * javadoc, please make sure you read it carefully.
      * 
-     * @param classToInstanciate name of the class to instantiate
-     * @param classPathUrls set of URLs to be used for creating a new {@link ClassLoader}.
      * @param parentClassLoader used a parent ClassLoader for the newly created classloader, may be null.
-     * @param useCurrentJvmProperties if true, a copy of the current jvm system properties will be used, if false then a default
-     *            jvm set of properties (see {@link StandardPropertiesStrategyFactory} will be used
+     * @param useCurrentJvmProperties if true, a copy of the current jvm system properties will be used, if false then a
+     * default jvm set of properties (see {@link StandardPropertiesStrategyFactory} will be used
      * 
      * @return a SandboxedInstance object ready for System Properties isolation
      */
@@ -63,27 +60,44 @@ public class SandboxInstanceFactory {
         if (runtimeInfo.getRuntimeClassName() == null) {
             throw new IllegalArgumentException("classToInstantiate should not be null");
         }
-        synchronized (classLoaderCache) {
-            if (classLoaderCache.containsKey(runtimeInfo) && classLoaderCache.get(runtimeInfo) != null) {
-                return new SandboxedInstance(runtimeInfo.getRuntimeClassName(), useCurrentJvmProperties,
-                        classLoaderCache.get(runtimeInfo));
-            } else {
-                // the following classloader is closeable so there is a possible resource leak.
-                // if the returned SandboxInstance is properly closed this classLoader shall be closed too.
-                ClassLoader sandboxClassLoader = new URLClassLoader(
-                        runtimeInfo.getMavenUrlDependencies().toArray(new URL[runtimeInfo.getMavenUrlDependencies().size()]),
-                        parentClassLoader) {
 
-                    @Override
-                    public void close() throws IOException {
-                        super.close();
-                        ClassLoaderIsolatedSystemProperties.getInstance().stopIsolateClassLoader(this);
-                    }
-                };
-                classLoaderCache.put(runtimeInfo, sandboxClassLoader);
-                return new SandboxedInstance(runtimeInfo.getRuntimeClassName(), useCurrentJvmProperties, sandboxClassLoader);
+        // Determine whether the ClassLoader for the runtimeInfo can be safely cached for performance.
+        ClassLoader sandboxClassLoader;
+        boolean reusableClassLoader = true;
+        if (runtimeInfo instanceof SandboxControl)
+            reusableClassLoader = ((SandboxControl) runtimeInfo).isClassLoaderReusable();
+
+        if (reusableClassLoader) {
+            // When the ClassLoader is reusable, use it from the cache.
+            synchronized (classLoaderCache) {
+                if (classLoaderCache.containsKey(runtimeInfo) && classLoaderCache.get(runtimeInfo) != null) {
+                    sandboxClassLoader = classLoaderCache.get(runtimeInfo);
+                } else {
+                    // the following classloader is closeable so there is a possible resource leak.
+                    // if the returned SandboxInstance is properly closed this classLoader shall be closed too.
+                    sandboxClassLoader = createClassLoader(runtimeInfo, parentClassLoader);
+                    classLoaderCache.put(runtimeInfo, sandboxClassLoader);
+                }
             }
+        } else {
+            // When the ClassLoader is not reusable, never used a cached instance or save it for reuse.
+            sandboxClassLoader = createClassLoader(runtimeInfo, parentClassLoader);
         }
+
+        return new SandboxedInstance(runtimeInfo.getRuntimeClassName(), useCurrentJvmProperties, sandboxClassLoader);
+    }
+
+    private static URLClassLoader createClassLoader(RuntimeInfo runtimeInfo, ClassLoader parentClassLoader) {
+        return new URLClassLoader(
+                runtimeInfo.getMavenUrlDependencies().toArray(new URL[runtimeInfo.getMavenUrlDependencies().size()]),
+                parentClassLoader) {
+
+            @Override
+            public void close() throws IOException {
+                super.close();
+                ClassLoaderIsolatedSystemProperties.getInstance().stopIsolateClassLoader(this);
+            }
+        };
     }
 
     public static void clearCache() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [X] Tests for the changes have been added (for bug fixes / features) ?
- [X] Docs have been added / updated (for bug fixes / features) ?
- [ ] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The SandboxInstanceFactory reuses ClassLoaders from a cache to improve performance.

Normally this is not a problem, since ClassLoaders are *mostly* stateless.   The exception is static variables inside loaded classes, which can retain state across runtime instances.

**What is the new behavior?**

The SandboxControl class is an optional interface that the RuntimeInfo can implement to determine whether the ClassLoader should be reused by the SandboxedInstanceFactory.

Most runtime instances should continue with the current behaviour, but HDFS has static state that causes problems after a certain length of time and can't be cleanly cleared.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

**Other information**:

The JarRuntimeInfo in the components framework will be updated to implement SandboxControl for finer control over ClassLoading caching, but retain the default behaviour for all components except fileio.