### PR TITLE
fix(TCOMP-402):ignore mvn url created from an exisiting url

### DIFF
--- a/daikon/src/test/java/org/talend/daikon/runtime/RuntimeUtilTest.java
+++ b/daikon/src/test/java/org/talend/daikon/runtime/RuntimeUtilTest.java
@@ -1,0 +1,23 @@
+package org.talend.daikon.runtime;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.junit.Test;
+
+public class RuntimeUtilTest {
+
+    @Test
+    public void testMvnUrlParseUrl() throws MalformedURLException, IOException {
+        RuntimeUtil.registerMavenUrlHandler();
+        URL url = new URL("mvn:org/art/1.2");
+        assertEquals("org/art/1.2", url.getPath());
+        // check that foo is not parsed at all
+        URL badurl = new URL(url, "foo");
+        assertEquals("org/art/1.2", badurl.getPath());
+    }
+
+}

--- a/daikon/src/test/java/org/talend/daikon/sandbox/SandboxInstanceFactoryTest.java
+++ b/daikon/src/test/java/org/talend/daikon/sandbox/SandboxInstanceFactoryTest.java
@@ -18,9 +18,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
-import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -36,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.daikon.runtime.RuntimeInfo;
 import org.talend.daikon.runtime.RuntimeUtil;
-import org.talend.daikon.runtime.RuntimeUtil.MavenUrlStreamHandler;
 import org.talend.daikon.sandbox.properties.ClassLoaderIsolatedSystemProperties;
 import org.talend.java.util.ClosableLRUMap;
 
@@ -402,26 +399,6 @@ public class SandboxInstanceFactoryTest {
         thread2.join();
         isol1.assertSuccess();
         isol2.assertSuccess();
-    }
-
-    @Test
-    public void testTCOMP402PreventResolutionIfVersionLooksLikeJar() throws MalformedURLException {
-        MavenUrlStreamHandler mavenUrlStreamHandler = new RuntimeUtil.MavenUrlStreamHandler();
-        try {
-            // should not throw IOException
-            mavenUrlStreamHandler.openConnection(new URL("mvn:org.talend.test/zeLib/0.0.1"));
-        } catch (IOException e) {
-            fail("IOException should not be thrown" + e.getMessage());
-        }
-
-        try {
-            // should throw IOException
-            mavenUrlStreamHandler.openConnection(new URL("mvn:org.talend.test/zeLib/somethig.jar"));
-            fail("The line above should throw an error");
-        } catch (IOException e) {
-            // expected
-        }
-
     }
 
     private void waitTrue(final AtomicBoolean valuetoWaitForTrue, String mess) {


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
java tries to play around with mvn url when it tries to look for some files in the classloader. it basically creates new url from the base mvn uri, removes the last element of the uri (usually a version of a type) and replace it by  a file path which is completl nonsense for the mvn: protocol

**What is the new behavior?**
mvn url that are created from an existing url and a path (spec) are simply ignoring the specs.

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [x] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:



**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
