### PR TITLE
fix(TDKN-175):fix NPE when double nested unused props in uispecs

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGenerator.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGenerator.java
@@ -107,7 +107,7 @@ public class JsonSchemaGenerator {
                         processReferenceProperties(referenceProperties));
             } else {
                 // compute if the properties is visible, meaning it was added to the current form
-                Widget widget = form.getWidget(properties.getName());
+                Widget widget = form != null ? form.getWidget(properties.getName()) : null;
                 boolean isVisible = widget != null && widget.isVisible();
                 // compute the formName is one of the properties form was added as a subform
                 String propertiesFormName = null;


### PR DESCRIPTION
**What is the current behavior?** (You can also link to an open issue here)
NPE when serializing ui-specs of a 2 nested properties that are not added to a form.

**What is the new behavior?**
fixed the NPE.

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [x] Tests for the changes have been added (for bug fixes / features) ?
- [ ] Docs have been added / updated (for bug fixes / features) ?
- [x] The code coverage on new code >75%
- [ ] The new code does not introduce new technical issues (sonar / eslint)


**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build / CI related changes
- [ ] Other... Please describe:


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No
