### PR TITLE
TDS-1288 : Add getter for isNegation.

### DIFF
--- a/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
+++ b/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
@@ -231,6 +231,7 @@ public class ASTVisitor implements IASTVisitor<Object> {
         return c;
     }
 
+    // May be needed in sub-classes.
     protected boolean isNegation() {
         return isNegation;
     }

--- a/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
+++ b/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
@@ -231,6 +231,10 @@ public class ASTVisitor implements IASTVisitor<Object> {
         return c;
     }
 
+    public boolean isNegation() {
+        return isNegation;
+    }
+
     private String getFieldName(String fieldName) {
         return fieldName;
     }

--- a/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
+++ b/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
@@ -231,7 +231,7 @@ public class ASTVisitor implements IASTVisitor<Object> {
         return c;
     }
 
-    public boolean isNegation() {
+    protected boolean isNegation() {
         return isNegation;
     }
 

--- a/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
+++ b/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
@@ -240,7 +240,7 @@ public class ASTVisitor implements IASTVisitor<Object> {
         return fieldName;
     }
 
-    private String patternToMongoRegex(String pattern) {
+    protected String patternToMongoRegex(String pattern) {
         StringBuilder sb = new StringBuilder();
         sb.append("^");
         for (int i = 0; i < pattern.length(); i++) {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 A protected getter is needed for isNegation attribute in ASTVisitor, it has been turned to private (thank you codacy -_-), as well as the method patternToMongoRegex().
**What is the chosen solution to this problem?**
 Add a protected getter for isNegation, and make patternToMongoRegex protected.
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDS-1288
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
