### PR TITLE
fix(TDKN-179): Set to minItems=0 for hidden list fields

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/WidgetSpecificJsonSchemaUtils.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/WidgetSpecificJsonSchemaUtils.java
@@ -8,21 +8,20 @@ import org.talend.daikon.properties.property.Property;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
- * This class contains some methods that are coupling the UI schema and the Json schema.
- * Normally the UISchema and the Json schema should not be coupled. But for some specific cases we need that.
+ * This class contains some methods that are coupling the UI schema and the Json schema. Normally the UISchema and the
+ * Json schema should not be coupled. But for some specific cases we need that.
  *
- * TODO remove the coupling of Json schema and UI schema
  */
-public class WidgetSpecificJsonSchemaUtils {
+class WidgetSpecificJsonSchemaUtils {
+
+    private WidgetSpecificJsonSchemaUtils() {
+    }
 
     /**
      * Adds the <tt>uniqueItems</tt> <tt>minItems</tt> tags to the <i>schema</i> if the property corresponds to a list view.
      *
-     * Normally the UISchema and the Json schema should not be coupled. But for the specific case of the list View component the
-     * json schema must be tagged with <tt>uniqueItems</tt> and <tt>minItems</tt>.
-     *
-     * TODO find a better way to take care of list_view values uniqueness without coupling the json schema with the ui schema
-     * using a Set may be a good start.
+     * Normally the UISchema and the Json schema should not be coupled. But for the specific case of the list View component
+     * the json schema must be tagged with <tt>uniqueItems</tt> and <tt>minItems</tt>.
      *
      * @param form the specified form
      * @param property the specified property
@@ -38,7 +37,13 @@ public class WidgetSpecificJsonSchemaUtils {
                     schema.put(JsonSchemaConstants.TAG_UNIQUE_ITEMS, "true");
                     schema.put(JsonSchemaConstants.TAG_MIN_ITEMS, 1);
                 }
+
+                // TDKN-179: ensure "min_items=0" if widget is hidden in form to prevent validation issues.
+                if(widget.isHidden()) {
+                    schema.put(JsonSchemaConstants.TAG_MIN_ITEMS, 0);
+                }
             }
+
         }
     }
 

--- a/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/WidgetSpecificJsonSchemaUtils.java
+++ b/daikon/src/main/java/org/talend/daikon/serialize/jsonschema/WidgetSpecificJsonSchemaUtils.java
@@ -39,7 +39,7 @@ class WidgetSpecificJsonSchemaUtils {
                 }
 
                 // TDKN-179: ensure "min_items=0" if widget is hidden in form to prevent validation issues.
-                if(widget.isHidden()) {
+                if (widget.isHidden()) {
                     schema.put(JsonSchemaConstants.TAG_MIN_ITEMS, 0);
                 }
             }

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGeneratorTest.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGeneratorTest.java
@@ -83,6 +83,7 @@ public class JsonSchemaGeneratorTest extends AbstractSchemaGenerator {
     @Test
     public void testStringListProperty_whenHidden() throws JSONException {
         StringListProperty stringListProperty = new StringListProperty("selectColumnIds") {
+
             @Override
             public Form getPreferredForm(String formName) {
                 final Form form = new Form(this, formName);

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGeneratorTest.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonschema/JsonSchemaGeneratorTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.talend.daikon.properties.PropertiesImpl;
 import org.talend.daikon.properties.presentation.Form;
+import org.talend.daikon.properties.presentation.Widget;
 import org.talend.daikon.properties.property.Property;
 import org.talend.daikon.properties.property.PropertyFactory;
 import org.talend.daikon.properties.property.StringProperty;
@@ -76,6 +77,31 @@ public class JsonSchemaGeneratorTest extends AbstractSchemaGenerator {
                 + ":{\"selectColumnIds\":{\"title\":\"property.selectColumnIds.displayName\","
                 + "\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"col1\",\"col2\",\"col3\"],"
                 + "\"enumNames\":[\"Surname\",\"Name\",\"Phone\"]},\"uniqueItems\":\"true\",\"minItems\":1}}}";
+        assertEquals(expectedPartial, genSchema.toString(), false);
+    }
+
+    @Test
+    public void testStringListProperty_whenHidden() throws JSONException {
+        StringListProperty stringListProperty = new StringListProperty("selectColumnIds") {
+            @Override
+            public Form getPreferredForm(String formName) {
+                final Form form = new Form(this, formName);
+
+                final Widget widget = new Widget(this);
+                widget.setHidden();
+
+                form.addRow(widget);
+                return form;
+            }
+        };
+        stringListProperty.init();
+        JsonSchemaGenerator generator = new JsonSchemaGenerator();
+        ObjectNode genSchema = generator.generateJsonSchema(stringListProperty, Form.MAIN);
+        // Only difference is the "minItems=0" since widget is hidden
+        String expectedPartial = "{\"title\":\"form.Main.displayName\",\"type\":\"object\",\"properties\""
+                + ":{\"selectColumnIds\":{\"title\":\"property.selectColumnIds.displayName\","
+                + "\"type\":\"array\",\"items\":{\"type\":\"string\",\"enum\":[\"col1\",\"col2\",\"col3\"],"
+                + "\"enumNames\":[\"Surname\",\"Name\",\"Phone\"]},\"minItems\":0}}}";
         assertEquals(expectedPartial, genSchema.toString(), false);
     }
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

When a widget contains a list property, minItems is automatically set to 1, causing UI validation issues when widget is hidden in form.

**What is the chosen solution to this problem?**

To prevent validation issues, set to minItems=0 if widget for property is hidden.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-179
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

