### PR TITLE
chore(logging): set locationInfo to false

### DIFF
--- a/daikon-logging/logging-event-layout/README.MD
+++ b/daikon-logging/logging-event-layout/README.MD
@@ -86,7 +86,6 @@ with the `RollingFileAppender` in your `logback.xml`, `log4j.xml` or `log4j2.xml
     </rollingPolicy>
     <layout class="org.talend.daikon.logging.event.layout.LogbackJSONLayout">
         <param name="UserFields" value="service:dataset,application:tdp" />
-        <param name="LocationInfo" value="false"/>
     </layout>
  </appender>
   <root level="INFO">
@@ -109,7 +108,6 @@ with the `RollingFileAppender` in your `logback.xml`, `log4j.xml` or `log4j2.xml
         <param name="encoding" value="UTF-8" />
         <layout class="org.talend.daikon.logging.event.layout.Log4jJSONLayout">
             <param name="UserFields" value="service:dataset,application:tdp" />
-            <param name="LocationInfo" value="false"/>
         </layout>
     </appender>   
     <root> 
@@ -127,7 +125,7 @@ with the `RollingFileAppender` in your `logback.xml`, `log4j.xml` or `log4j2.xml
   <appenders>
     <RollingFile name="File" fileName="${LOG_PATH}/application.log"
         filePattern="${LOG_PATH}/application-%d{yyyy-MM-dd}.log">
-        <Log4j2JSONLayout charset="UTF-8" skipJsonEscapeSubLayout="true" locationInfo="false" subLayoutAsElement="true">
+        <Log4j2JSONLayout charset="UTF-8" skipJsonEscapeSubLayout="true" subLayoutAsElement="true">
             <KeyValuePair key="service" value="dataset"/>
             <KeyValuePair key="application" value="tdp"/>
         </Log4j2JSONLayout>

--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/Log4jJSONLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/Log4jJSONLayout.java
@@ -31,11 +31,10 @@ public class Log4jJSONLayout extends Layout {
     private JSONObject logstashEvent;
 
     /**
-     * For backwards compatibility, the default is to generate location information
-     * in the log messages.
+     * Print no location info by default.
      */
     public Log4jJSONLayout() {
-        this(true);
+        this(false);
     }
 
     /**

--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONLayout.java
@@ -29,11 +29,10 @@ public class LogbackJSONLayout extends JsonLayout<ILoggingEvent> {
     private JSONObject logstashEvent;
 
     /**
-     * For backwards compatibility, the default is to generate location information
-     * in the log messages.
+     * Print no location info by default.
      */
     public LogbackJSONLayout() {
-        this(true);
+        this(false);
     }
 
     /**

--- a/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/Log4jJSONLayoutTest.java
+++ b/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/Log4jJSONLayoutTest.java
@@ -1,5 +1,7 @@
 package org.talend.daikon.logging.layout;
 
+import static org.junit.Assert.assertFalse;
+
 import java.util.Properties;
 
 import org.apache.log4j.Level;
@@ -7,11 +9,18 @@ import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LocationInfo;
 import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.ThrowableInformation;
+import org.junit.Test;
 import org.talend.daikon.logging.event.layout.Log4jJSONLayout;
 
 public class Log4jJSONLayoutTest extends AbstractLayoutTest {
 
     static final Logger LOGGER = Logger.getRootLogger();
+
+    @Test
+    public void testDefaultLocationInfo() {
+        Log4jJSONLayout layout = new Log4jJSONLayout();
+        assertFalse(layout.getLocationInfo());
+    }
 
     @Override
     protected Object newEvent(LogDetails logDetails) {

--- a/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/LogBackJSONLayoutTest.java
+++ b/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/LogBackJSONLayoutTest.java
@@ -1,5 +1,8 @@
 package org.talend.daikon.logging.layout;
 
+import static org.junit.Assert.assertFalse;
+
+import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.daikon.logging.event.layout.LogbackJSONLayout;
@@ -10,6 +13,12 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 public class LogBackJSONLayoutTest extends AbstractLayoutTest {
 
     static final Logger LOGGER = LoggerFactory.getLogger(LogBackJSONLayoutTest.class);
+
+    @Test
+    public void testDefaultLocationInfo() {
+        LogbackJSONLayout layout = new LogbackJSONLayout();
+        assertFalse(layout.getLocationInfo());
+    }
 
     @Override
     protected Object newEvent(LogDetails logDetails) {


### PR DESCRIPTION
Log4J and logback locationInfo was set to true.
We set it to false by default (as is the case
for built-in log layouts).

**What is the problem this Pull Request is trying to solve?**
 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
