### PR TITLE
feat(daikon-tql-client): add modifiers

### DIFF
--- a/daikon-tql/daikon-tql-client/README.md
+++ b/daikon-tql/daikon-tql-client/README.md
@@ -37,6 +37,23 @@ query.equal('f1', 666).or().equal('f2', 777);
 ```
 
 
+Modifier
+-------
+
+A Modifier changes the meaning of an operator or a query.
+
+The following modifiers are supported :
+
+- `not`
+
+They can be part of a query :
+
+
+```javascript
+query.equal('f1', 666).or().not(new Equal('f2', 777));
+```
+
+
 Query
 -------
 

--- a/daikon-tql/daikon-tql-client/README.md
+++ b/daikon-tql/daikon-tql-client/README.md
@@ -93,7 +93,7 @@ query
 	.or()
 	.equal('f2', 777);
 
-query.serialize(); // -> '(f2 > 42)  and  (f2 < 76)  or  (f2 = 777)'
+query.serialize(); // -> '(f2 > 42) and (f2 < 76)  or  (f2 = 777)'
 ```
 
 Obviously, priority is conserved on nested queries :
@@ -132,8 +132,8 @@ Will produce :
 ```sql
 (f2 > 42)  and (
 	(q2f1 = 76)  or  (q2f2 = 77)
-)  and  (f2 < 666)  or  (
-	(q3f1 = 78)  and  (q3f2 = 79)
+) and (f2 < 666)  or  (
+	(q3f1 = 78) and (q3f2 = 79)
 )  or  (f2 = 777)
 ```
 
@@ -178,7 +178,7 @@ query
 	.and()
 	.toto('f2');
 
-query.serialize(); // -> '(f1 > 42)  and  (f2 is toto)'
+query.serialize(); // -> '(f1 > 42) and (f2 is toto)'
 ```
 
 

--- a/daikon-tql/daikon-tql-client/src/converter/__tests__/compositor.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/__tests__/compositor.spec.js
@@ -5,13 +5,13 @@ describe('Compositor', () => {
 		const c = Compositor.get(Compositor.and);
 
 		expect(c instanceof Compositor).toBe(true);
-		expect(c.serialize()).toBe(' and ');
+		expect(c.serialize()).toBe('and');
 	});
 
 	it('should create a OR compositor', () => {
 		const c = Compositor.get(Compositor.or);
 
 		expect(c instanceof Compositor).toBe(true);
-		expect(c.serialize()).toBe(' or ');
+		expect(c.serialize()).toBe('or');
 	});
 });

--- a/daikon-tql/daikon-tql-client/src/converter/__tests__/modifier.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/__tests__/modifier.spec.js
@@ -1,0 +1,11 @@
+import Modifier from '../modifier';
+import { Equal } from '../operators';
+
+describe('Modifier', () => {
+	it('should create a NOT modifier', () => {
+		const c = new Modifier(Modifier.not, new Equal('f1', 42));
+
+		expect(c instanceof Modifier).toBe(true);
+		expect(c.serialize()).toBe('not((f1 = 42))');
+	});
+});

--- a/daikon-tql/daikon-tql-client/src/converter/__tests__/parser.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/__tests__/parser.spec.js
@@ -81,7 +81,7 @@ describe('Parser', () => {
 		const query = Parser.parse(mock);
 
 		expect(query.serialize()).toEqual(
-			"((0001 contains 'euge')  or  (0001 contains 'secondtestvalue'))  and  ((0000 between [342273, 542874]))  and  (* is invalid)  and  (* is empty)  and  (((* is empty) or (* is invalid)))  and  ((0006 = 'Indonesia')  or  (0006 = 'Russia'))",
+			"((0001 contains 'euge') or (0001 contains 'secondtestvalue')) and ((0000 between [342273, 542874])) and (* is invalid) and (* is empty) and (((* is empty) or (* is invalid))) and ((0006 = 'Indonesia') or (0006 = 'Russia'))",
 		);
 	});
 });

--- a/daikon-tql/daikon-tql-client/src/converter/__tests__/query.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/__tests__/query.spec.js
@@ -11,7 +11,7 @@ describe('Query', () => {
 			.and()
 			.valid('f3');
 
-		expect(q.serialize()).toBe('(f1 = 42)  and  (f2 is empty)  and  (f3 is valid)');
+		expect(q.serialize()).toBe('(f1 = 42) and (f2 is empty) and (f3 is valid)');
 	});
 
 	it('should be able to perform OR statements', () => {
@@ -24,7 +24,7 @@ describe('Query', () => {
 			.or()
 			.equal('f2', 666);
 
-		expect(q.serialize()).toBe("(f1 contains 'heho')  or  (f2 > 42)  or  (f2 = 666)");
+		expect(q.serialize()).toBe("(f1 contains 'heho') or (f2 > 42) or (f2 = 666)");
 	});
 
 	it('should be able to mix OR and AND statements', () => {
@@ -37,7 +37,7 @@ describe('Query', () => {
 			.or()
 			.equal('f2', 777);
 
-		expect(q.serialize()).toBe('(f2 > 42)  and  (f2 < 666)  or  (f2 = 777)');
+		expect(q.serialize()).toBe('(f2 > 42) and (f2 < 666) or (f2 = 777)');
 	});
 
 	it('should be able to nest queries', () => {
@@ -75,7 +75,7 @@ describe('Query', () => {
 			.nest(q4);
 
 		expect(q1.serialize()).toBe(
-			'((q2f1 = 76)  or  (q2f2 = 77))  and  (f2 > 42)  and  (f2 < 666)  or  ((q3f1 = 78)  and  (q3f2 = 79))  or  (f2 = 777)  and  ((q4f1 = 80)  and  (q4f2 = 81))',
+			'((q2f1 = 76) or (q2f2 = 77)) and (f2 > 42) and (f2 < 666) or ((q3f1 = 78) and (q3f2 = 79)) or (f2 = 777) and ((q4f1 = 80) and (q4f2 = 81))',
 		);
 	});
 
@@ -113,5 +113,29 @@ describe('Query', () => {
 				.nest(q2)
 				.lessThan('f2', 666);
 		}).toThrow('Only AND or OR operators are allowed after a query.');
+	});
+
+	it('should modify the query', () => {
+		const q1 = new Query();
+		const q2 = new Query();
+		const q3 = new Query();
+
+		q2
+			.equal('q2f1', 76)
+			.or()
+			.greaterThan('q2f2', 666);
+
+		q3.equal('q3f1', 78);
+
+		const test = q1
+			.greaterThan('f2', 42)
+			.or()
+			.not(q2)
+			.and()
+			.lessThan('f2', 666);
+
+		expect(test.serialize()).toEqual(
+			'(f2 > 42) or not((q2f1 = 76) or (q2f2 > 666)) and (f2 < 666)',
+		);
 	});
 });

--- a/daikon-tql/daikon-tql-client/src/converter/__tests__/query.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/__tests__/query.spec.js
@@ -127,14 +127,14 @@ describe('Query', () => {
 
 		q3.equal('q3f1', 78);
 
-		const test = q1
+		q1
 			.greaterThan('f2', 42)
 			.or()
 			.not(q2)
 			.and()
 			.lessThan('f2', 666);
 
-		expect(test.serialize()).toEqual(
+		expect(q1.serialize()).toEqual(
 			'(f2 > 42) or not((q2f1 = 76) or (q2f2 > 666)) and (f2 < 666)',
 		);
 	});

--- a/daikon-tql/daikon-tql-client/src/converter/compositor.js
+++ b/daikon-tql/daikon-tql-client/src/converter/compositor.js
@@ -18,6 +18,6 @@ export default class Compositor extends ISerializable {
 	}
 
 	serialize() {
-		return ` ${this.type} `;
+		return this.type;
 	}
 }

--- a/daikon-tql/daikon-tql-client/src/converter/modifier.js
+++ b/daikon-tql/daikon-tql-client/src/converter/modifier.js
@@ -1,0 +1,19 @@
+import ISerializable from './operators/iserializable';
+
+export default class Modifier extends ISerializable {
+	static not = 'not';
+
+	constructor(type, query) {
+		super();
+		if (type !== Modifier.not) {
+			throw new Error('Unknown modifier');
+		}
+
+		this.type = type;
+		this.query = query;
+	}
+
+	serialize() {
+		return `${this.type}(${this.query.serialize()})`;
+	}
+}

--- a/daikon-tql/daikon-tql-client/src/converter/query.js
+++ b/daikon-tql/daikon-tql-client/src/converter/query.js
@@ -1,6 +1,8 @@
 import * as operators from './operators';
 import ISerializable from './operators/iserializable';
 import Compositor from './compositor';
+import Modifier from './modifier';
+import Operator from './operators/operator';
 
 export default class Query extends ISerializable {
 	constructor() {
@@ -14,11 +16,22 @@ export default class Query extends ISerializable {
 
 		this.and = () => this.add(Compositor.get(Compositor.and));
 		this.or = () => this.add(Compositor.get(Compositor.or));
+
+		this.not = query => this.add(new Modifier(Modifier.not, query));
 	}
 
 	add(op) {
-		if (this.last instanceof Query && !(op instanceof Compositor)) {
+		if (
+			(this.last instanceof Query ||
+				this.last instanceof Modifier ||
+				this.last instanceof Operator) &&
+			!(op instanceof Compositor)
+		) {
 			throw new Error('Only AND or OR operators are allowed after a query.');
+		}
+
+		if (op instanceof Modifier && !(this.last instanceof Compositor)) {
+			throw new Error('Only Compositors are allowed after a Modifier.');
 		}
 
 		this.stack.push(op);


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
There is no `not` modifier in the TQL client proposal.

**What is the chosen solution to this problem?**
 
Add a new `Modifier` class which can be part of a query. It accepts a type (`not`) and a `Quey` or `Operator`.

```javascript
const q1 = new Query();
const q2 = new Query();

q2
	.equal('q2f1', 76)
	.or()
	.greaterThan('q2f2', 666);

q1
	.greaterThan('f2', 42)
	.or()
	.not(q2);
```

Will give the following result :

```
(f2 > 42) or not((q2f1 = 76) or (q2f2 > 666))
```
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
