### PR TITLE
feat(TCOMP-317): implement AbstractAvroConverter

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/avro/converter/AbstractAvroConverter.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/converter/AbstractAvroConverter.java
@@ -1,0 +1,58 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2017 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.avro.converter;
+
+import org.apache.avro.Schema;
+
+/**
+ * Abstract implementation of {@link AvroConverter}, which implements common methods
+ */
+public abstract class AbstractAvroConverter<DatumT, AvroT> implements AvroConverter<DatumT, AvroT> {
+
+    /**
+     * Class of DI data
+     */
+    private final Class<DatumT> clazz;
+
+    /**
+     * Schema of Avro data
+     */
+    private final Schema schema;
+
+    /**
+     * Sets Avro {@link Schema} and DI {@link Class} of data
+     * 
+     * @param clazz type of DI data
+     * @param schema schema of a Avro data
+     */
+    public AbstractAvroConverter(Class<DatumT> clazz, Schema schema) {
+        this.clazz = clazz;
+        this.schema = schema;
+    }
+
+    /**
+     * Returns {@link Class} of DI data
+     */
+    @Override
+    public Class<DatumT> getDatumClass() {
+        return this.clazz;
+    }
+
+    /**
+     * Returns {@link Schema} of Avro data
+     */
+    @Override
+    public Schema getSchema() {
+        return this.schema;
+    }
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

It backports AbstractAvroConverter, which is required for backporting Couchbase component.
Probably this backport won't be merged this requires Daikon 0.17.3 release. But we have another way to solve it. We may modify Couchbase comp itself to make it not use new API
 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
