### PR TITLE
chore(multi-tenancy): AutoConf classes name

### DIFF
--- a/daikon-multitenant/multitenant-spring-async/src/main/java/org/talend/daikon/multitenant/async/AsyncSupportAutoConfiguration.java
+++ b/daikon-multitenant/multitenant-spring-async/src/main/java/org/talend/daikon/multitenant/async/AsyncSupportAutoConfiguration.java
@@ -12,17 +12,17 @@
 // ============================================================================
 package org.talend.daikon.multitenant.async;
 
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.util.concurrent.ListenableFuture;
-
-import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 
 /**
  * Configures a custom async executor which propagates the request context to the child threads
@@ -34,7 +34,7 @@ import java.util.concurrent.Future;
 @Import({ RequestContextPropagationConfiguration.class, TenancyContextPropagationConfiguration.class,
         SecurityContextPropagationConfiguration.class })
 @EnableAsync
-public class AsyncSupportConfiguration {
+public class AsyncSupportAutoConfiguration {
 
     @Bean(name = "contextAwarePoolExecutor")
     public Executor contextAwarePoolExecutor(List<ContextPropagatorFactory> contextPropagatorFactories) {

--- a/daikon-multitenant/multitenant-spring-async/src/main/resources/META-INF/spring.factories
+++ b/daikon-multitenant/multitenant-spring-async/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.talend.daikon.multitenant.async.AsyncSupportConfiguration
+org.talend.daikon.multitenant.async.AsyncSupportAutoConfiguration

--- a/daikon-multitenant/multitenant-spring-web/src/main/java/org/talend/daikon/multitenant/web/TenancyFiltersAutoConfiguration.java
+++ b/daikon-multitenant/multitenant-spring-web/src/main/java/org/talend/daikon/multitenant/web/TenancyFiltersAutoConfiguration.java
@@ -23,7 +23,7 @@ import org.talend.daikon.multitenant.provider.TenantProvider;
 import java.util.List;
 
 @Configuration
-public class TenancyFiltersConfiguration {
+public class TenancyFiltersAutoConfiguration {
 
     private static final int SPRING_SECURITY_FILTERS_ORDER = 5;
 
@@ -32,7 +32,7 @@ public class TenancyFiltersConfiguration {
     private static final int ASYNC_TENANCY_CONTEXT_INTEGRATION_FILTER_ORDER = TENANCY_CONTEXT_INTEGRATION_FILTER_ORDER - 1;
 
     @Bean
-    @Conditional(TenancyFiltersConfiguration.TenantCondition.class)
+    @Conditional(TenancyFiltersAutoConfiguration.TenantCondition.class)
     public FilterRegistrationBean tenancyContextIntegrationFilter(TenantProvider tenantProvider,
             List<TenantIdentificationStrategy> strategyList) {
         FilterRegistrationBean registration = new FilterRegistrationBean();
@@ -46,7 +46,7 @@ public class TenancyFiltersConfiguration {
     }
 
     @Bean
-    @Conditional(TenancyFiltersConfiguration.TenantCondition.class)
+    @Conditional(TenancyFiltersAutoConfiguration.TenantCondition.class)
     public FilterRegistrationBean tenancyWebAsyncFilter() {
         FilterRegistrationBean registration = new FilterRegistrationBean();
         TenancyWebAsyncFilter filter = new TenancyWebAsyncFilter();

--- a/daikon-multitenant/multitenant-spring-web/src/main/resources/META-INF/spring.factories
+++ b/daikon-multitenant/multitenant-spring-web/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.talend.daikon.multitenant.web.TenancyFiltersConfiguration
+org.talend.daikon.multitenant.web.TenancyFiltersAutoConfiguration


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Spring AutoConfiguration classes should
contain AutoConfiguration in their name
for easier differentiate them
from classic Configuration classes.
 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
