### PR TITLE
fix(TFD-2824): Use specific exceptions for date parsing.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/converter/LocalDateConverter.java
+++ b/daikon/src/main/java/org/talend/daikon/converter/LocalDateConverter.java
@@ -1,10 +1,16 @@
 package org.talend.daikon.converter;
 
-import org.talend.daikon.exception.TalendRuntimeException;
-
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.talend.daikon.exception.ExceptionContext;
+import org.talend.daikon.exception.TalendRuntimeException;
+import org.talend.daikon.exception.error.ErrorCode;
 
 public class LocalDateConverter extends Converter<LocalDate> {
 
@@ -16,7 +22,7 @@ public class LocalDateConverter extends Converter<LocalDate> {
             try {
                 return LocalDate.parse(value.toString(), getDateTimeFormatter());
             } catch (DateTimeParseException dtpe) {
-                throw TalendRuntimeException.createUnexpectedException("Unable to parse " + value.toString());
+                throw LocalDateConverterErrorCode.createCannotParse(dtpe, value.toString(), getDateTimeFormatter().toString());
             }
         }
         return LocalDate.parse(value.toString());
@@ -29,5 +35,89 @@ public class LocalDateConverter extends Converter<LocalDate> {
 
     public DateTimeFormatter getDateTimeFormatter() {
         return (DateTimeFormatter) properties.get(LocalDateTimeConverter.FORMATTER);
+    }
+
+    /**
+     * Error codes for the {@link LocalDateConverter}.
+     */
+    public enum LocalDateConverterErrorCode implements ErrorCode {
+
+        /** The user is attempting to create an output on a path that already exists, but is not set to overwrite. */
+        CANNOT_PARSE("CANNOT_PARSE", HttpServletResponse.SC_INTERNAL_SERVER_ERROR, "value", "format");
+
+        private final String code;
+
+        private final int httpStatus;
+
+        private final Collection<String> contextEntries;
+
+        LocalDateConverterErrorCode(String code, int httpStatus, String... contextEntries) {
+            this.httpStatus = httpStatus;
+            this.code = code;
+            this.contextEntries = Arrays.asList(contextEntries);
+        }
+
+        @Override
+        public String getProduct() {
+            return "Talend";
+        }
+
+        @Override
+        public String getGroup() {
+            return "ALL";
+        }
+
+        @Override
+        public int getHttpStatus() {
+            return httpStatus;
+        }
+
+        @Override
+        public Collection<String> getExpectedContextEntries() {
+            return contextEntries;
+        }
+
+        @Override
+        public String getCode() {
+            return code;
+        }
+
+        /**
+         * Create an exception with the error code and context for {@link #CANNOT_PARSE}.
+         *
+         * @param cause The technical exception that was caught when the error occurred.
+         * @param value The value that was being parsed.
+         * @param format The format that the value could not be parsed with.
+         * @return An exception corresponding to the error code.
+         */
+        public static TalendRuntimeException createCannotParse(Throwable cause, String value, String format) {
+            // TODO: The format looks like Value(DayOfMonth,2)'/'Value(MonthOfYear,2)'/'Value(YearOfEra,4,19,EXCEEDS_PAD)
+            return new TalendMsgRuntimeException(cause, CANNOT_PARSE,
+                    ExceptionContext.withBuilder().put("value", value).put("format", format).build(),
+                    "Cannot parse '" + value + "' using the specified format.");
+        }
+
+        /**
+         * {@link TalendRuntimeException} with a reasonable user-friendly message in English.
+         */
+        private static class TalendMsgRuntimeException extends TalendRuntimeException {
+
+            private final String localizedMessage;
+
+            public TalendMsgRuntimeException(Throwable cause, ErrorCode code, ExceptionContext context, String localizedMessage) {
+                super(code, cause, context);
+                this.localizedMessage = localizedMessage;
+            }
+
+            @Override
+            public String getMessage() {
+                return getLocalizedMessage();
+            }
+
+            @Override
+            public String getLocalizedMessage() {
+                return localizedMessage;
+            }
+        }
     }
 }

--- a/daikon/src/main/java/org/talend/daikon/converter/LocalDateTimeConverter.java
+++ b/daikon/src/main/java/org/talend/daikon/converter/LocalDateTimeConverter.java
@@ -16,7 +16,8 @@ public class LocalDateTimeConverter extends Converter<LocalDateTime> {
             try {
                 return LocalDateTime.parse(value.toString(), getDateTimeFormatter());
             } catch (DateTimeParseException dtpe) {
-                throw TalendRuntimeException.createUnexpectedException("Unable to parse " + value.toString());
+                throw LocalDateConverter.LocalDateConverterErrorCode.createCannotParse(dtpe, value.toString(),
+                        getDateTimeFormatter().toString());
             }
         }
         return LocalDateTime.parse(value.toString());

--- a/daikon/src/main/java/org/talend/daikon/converter/LocalTimeConverter.java
+++ b/daikon/src/main/java/org/talend/daikon/converter/LocalTimeConverter.java
@@ -16,7 +16,8 @@ public class LocalTimeConverter extends Converter<LocalTime> {
             try {
                 return LocalTime.parse(value.toString(), getDateTimeFormatter());
             } catch (DateTimeParseException dtpe) {
-                throw TalendRuntimeException.createUnexpectedException("Unable to parse " + value.toString());
+                throw LocalDateConverter.LocalDateConverterErrorCode.createCannotParse(dtpe, value.toString(),
+                        getDateTimeFormatter().toString());
             }
         }
         return LocalTime.parse(value.toString());

--- a/daikon/src/test/java/org/talend/daikon/converter/LocalDateConverterTest.java
+++ b/daikon/src/test/java/org/talend/daikon/converter/LocalDateConverterTest.java
@@ -1,11 +1,16 @@
 package org.talend.daikon.converter;
 
-import org.junit.Test;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.talend.daikon.exception.TalendRuntimeException;
 
 /**
  * To find more test, please refer to TypeConverterTest
@@ -13,10 +18,23 @@ import static org.junit.Assert.assertEquals;
  */
 public class LocalDateConverterTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void testAsLocalDateWithDateTimeFormatter() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
         assertEquals(LocalDate.of(2007, 12, 03),
                 TypeConverter.asLocalDate().withDateTimeFormatter(formatter).convert("03/12/2007"));
     }
+
+    @Test
+    public void testError() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        thrown.expect(TalendRuntimeException.class);
+        thrown.expect(hasProperty("code", is(LocalDateConverter.LocalDateConverterErrorCode.CANNOT_PARSE)));
+        thrown.expectMessage("Cannot parse '  03/12/2007' using the specified format.");
+        TypeConverter.asLocalDate().withDateTimeFormatter(formatter).convert("  03/12/2007");
+    }
+
 }

--- a/daikon/src/test/java/org/talend/daikon/converter/LocalDateTimeConverterTest.java
+++ b/daikon/src/test/java/org/talend/daikon/converter/LocalDateTimeConverterTest.java
@@ -1,18 +1,25 @@
 package org.talend.daikon.converter;
 
-import org.junit.Test;
-import org.talend.daikon.exception.TalendRuntimeException;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.talend.daikon.exception.TalendRuntimeException;
 
 /**
  * To find more test, please refer to TypeCOnverterTest
  *
  */
 public class LocalDateTimeConverterTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testAsLocalDateTimeWithDateTimeFormatter() {
@@ -21,11 +28,13 @@ public class LocalDateTimeConverterTest {
                 TypeConverter.asLocalDateTime().withDateTimeFormatter(formatter).convert("03/12/2007 10:15:30"));
     }
 
-    @Test(expected = TalendRuntimeException.class)
-    public void testAsLocalDateTimeParseException() {
+    @Test
+    public void testError() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
-        assertEquals(LocalDateTime.of(2007, 12, 03, 10, 15, 30),
-                TypeConverter.asLocalDateTime().withDateTimeFormatter(formatter).convert("dd/12/2007 10:15:30"));
+        thrown.expect(TalendRuntimeException.class);
+        thrown.expect(hasProperty("code", is(LocalDateConverter.LocalDateConverterErrorCode.CANNOT_PARSE)));
+        thrown.expectMessage("Cannot parse 'dd/12/2007 10:15:30' using the specified format.");
+        TypeConverter.asLocalDateTime().withDateTimeFormatter(formatter).convert("dd/12/2007 10:15:30");
     }
 
 }

--- a/daikon/src/test/java/org/talend/daikon/converter/LocalTimeConverterTest.java
+++ b/daikon/src/test/java/org/talend/daikon/converter/LocalTimeConverterTest.java
@@ -1,12 +1,16 @@
 package org.talend.daikon.converter;
 
-import org.junit.Test;
-import org.talend.daikon.exception.TalendRuntimeException;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.talend.daikon.exception.TalendRuntimeException;
 
 /**
  * To find more test, please refer to TypeCOnverterTest
@@ -14,16 +18,22 @@ import static org.junit.Assert.assertEquals;
  */
 public class LocalTimeConverterTest {
 
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
     @Test
     public void testAsLocalTimeWithDateTimeFormatter() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("ss:mm:HH");
         assertEquals(LocalTime.of(8, 15, 20), TypeConverter.asLocalTime().withDateTimeFormatter(formatter).convert("20:15:08"));
     }
 
-    @Test(expected = TalendRuntimeException.class)
-    public void testAsLocalTimeParseException() {
+    @Test
+    public void testError() {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("ss:mm:HH");
-        assertEquals(LocalTime.of(8, 15, 20), TypeConverter.asLocalTime().withDateTimeFormatter(formatter).convert("ss:15:08"));
+        thrown.expect(TalendRuntimeException.class);
+        thrown.expect(hasProperty("code", is(LocalDateConverter.LocalDateConverterErrorCode.CANNOT_PARSE)));
+        thrown.expectMessage("Cannot parse 'ss:15:08' using the specified format.");
+        TypeConverter.asLocalTime().withDateTimeFormatter(formatter).convert("ss:15:08");
     }
 
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
We are currently using an UNEXPECTED_EXCEPTION when there is a problem parsing dates.   We can use a better type to give a more informative message on the UI.

**What is the chosen solution to this problem?**

Add an error code and specific TalendRuntimeException for DateTimeFormatter parsing errors.
 
**Link to the JIRA issue**

https://jira.talendforge.org/browse/TFD-2824
 
**Please check if the Pull Request fulfills these requirements**
- [X] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
