### PR TITLE
chore(MultiTenancy): move thread safe mongo client provider from tdp to daikon

### DIFF
--- a/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProvider.java
+++ b/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProvider.java
@@ -1,0 +1,28 @@
+package org.talend.daikon.spring.mongo;
+
+import java.io.IOException;
+
+import com.mongodb.MongoClient;
+
+/**
+ * A {@link MongoClientProvider} implementation that provides thread safety around the
+ * {@link MongoClientProvider#close()} method.
+ */
+public class SynchronizedMongoClientProvider implements MongoClientProvider {
+
+    private final MongoClientProvider delegate;
+
+    public SynchronizedMongoClientProvider(MongoClientProvider delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public MongoClient get(TenantInformationProvider tenantInformationProvider) {
+        return delegate.get(tenantInformationProvider);
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+        delegate.close();
+    }
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
The CachedMongoClientProvider is not threadsafe, especially close method, leading to errors during application runtime (_state should be: open_ message).
To avoid this, TDP team implemented a SynchronizedMongoClientProvider, which prevents such concurrency problems.
This PR aims at moving this SynchronizedMongoClientProvider from TDP to daikon to share it between all Talend apps.
 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
