### PR TITLE
[Audit] Support for placeholders in configuration file

### DIFF
--- a/daikon-audit/docs/README.adoc
+++ b/daikon-audit/docs/README.adoc
@@ -1,4 +1,8 @@
-= Audit Logging API - Pending Approval
+:javadoc_url: https://ci-common.datapwn.com/view/Daikon/job/daikon_master/ws/daikon-audit/target/apidocs
+:audit_source_url: https://github.com/Talend/daikon/tree/master/daikon-audit
+:audit_sample_url: https://github.com/Talend/platform-services-logging/blob/audit-logging-tpsvc-3638/samples/audit
+
+= Audit Logging API
 
 Rq: template taken from https://in.talend.com/13994923[R&D Policies and Procedures wiki].
 
@@ -12,8 +16,8 @@ Audit Logging client library provides unified API for logging and processing aud
 |Next version|1.0
 |Packaging|Library
 |Programming model|Library
-|Java version|JDK 1.7
-|Javadoc|https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/allclasses-noframe.html[Here]
+|Java version|JDK 1.7 or higher
+|Javadoc|{javadoc_url}/allclasses-noframe.html[Here]
 |Swagger|<does not apply>|
 |===
 
@@ -80,7 +84,7 @@ WARNING: Audit Logging artifact group and id will change after moving it to daik
 .For gradle:
 [source,groovy]
 ----
-compile "org.talend.logging.audit:audit-logging:$auditLoggingVersion"
+compile "org.talend.daikon:daikon-audit:$auditLoggingVersion"
 
 compile "org.slf4j:slf4j-log4j12:1.7.25"
 
@@ -91,8 +95,8 @@ compile "log4j:log4j:1.2.17"
 [source,xml]
 ----
 <dependency>
-    <groupId>org.talend.logging.audit</groupId>
-    <artifactId>audit-logging</artifactId>
+    <groupId>org.talend.daikon</groupId>
+    <artifactId>daikon-audit</artifactId>
     <version>...</version>
 </dependency>
 
@@ -113,7 +117,7 @@ compile "log4j:log4j:1.2.17"
 ==== Configuration
 
 Audit Logging client uses simple
-https://github.com/Talend/platform-services-logging/blob/audit-logging-tpsvc-3638/audit/src/main/resources/audit.properties.example[properties file]
+{audit_source_url}/src/main/resources/audit.properties.example[properties file]
 for all its configuration (in future, if needed, yaml-based configuration may be implemented).
 It looks for the configuration file in the next places (in given order):
 
@@ -124,39 +128,7 @@ Here's an example of the configuration file:
 
 [source,properties]
 ----
-# Logger name prefix which will be added to event category (logger name in terms of slf4j).
-#
-# For example, if "root.logger=audit" then logging an audit event with category "activity" with result in
-# logger name "audit.activity" being used.
-#
-# Also all appenders will be configured on this logger, and it can be used to distinguish between audit events and
-# all other events.
-root.logger=audit
-
-# Name of the application which logs audit event (this value will be put into MDC for each logged event).
-application.name=Platform
-# Name of the instance of the application (this value will be put into MDC for each logged event).
-instance.name=TestInstance1
-
-# Type of log appender to use (none deactivates audit logging).
-# Possible values: none, socket, file, console
-log.appender=socket
-
-# File appender puts log entries into a json file. In most cases there should be a FileBeat instance picking up
-# new messages and sending them to logstash.
-appender.file.path=/tmp/audit/test.log
-appender.file.maxsize=52428800
-appender.file.maxbackup=20
-
-# Socket appender sends logs to a remote host, where usually logstash receives and processes them.
-#
-# local
-#appender.socket.host=localhost
-#appender.socket.port=4560
-#
-# logstash
-appender.socket.host=localhost
-appender.socket.port=8056
+include::../src/main/resources/audit.properties.example[]
 ----
 
 If audit events are to be sent to LogStash as in this example, it has to have an additional input in its configuration:
@@ -177,9 +149,8 @@ NOTE: Platform Service team provides LogServer with LogStash which is pre-config
 
 From applications perspective the basic use case is logging an audit event.
 If it's one of the standard audit events, then all that is necessary to do is to create an instance of
-https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/org/talend/logging/audit/StandardEventAuditLogger.html[StandardEventAuditLogger]
-using
-https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/org/talend/logging/audit/AuditLoggerFactory.html[AuditLoggerFactory]:
+{javadoc_url}/org/talend/logging/audit/StandardEventAuditLogger.html[StandardEventAuditLogger]
+using {javadoc_url}/org/talend/logging/audit/AuditLoggerFactory.html[AuditLoggerFactory]:
 
 [source,java]
 ----
@@ -204,9 +175,8 @@ auditLogger.loginSuccess(ctx);
 ----
 
 For details, see
-https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/org/talend/logging/audit/Context.html[Context]
-and
-https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/org/talend/logging/audit/ContextBuilder.html[ContextBuilder].
+{javadoc_url}/org/talend/logging/audit/Context.html[Context]
+and {javadoc_url}/org/talend/logging/audit/ContextBuilder.html[ContextBuilder].
 
 
 ==== Passing an exception as a parameter
@@ -242,16 +212,14 @@ public interface CustomEventAuditLogger extends StandardEventAuditLogger {
 }
 ----
 
-https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/org/talend/logging/audit/AuditEvent.html[AuditEvent]
-is an annotation which defines event metadata.
+{javadoc_url}/org/talend/logging/audit/AuditEvent.html[AuditEvent] is an annotation which defines event metadata.
 
 Category parameter allows to group all events into few groups. Usually events fall into
 three categories: security, activity, failure. But any application is free to specify any string
 value as a category.
 
-https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/org/talend/logging/audit/LogLevel.html[Log level]
-is similar to the same concept from normal logging frameworks,
-but only has three values: INFO, WARNING or ERROR.
+{javadoc_url}/org/talend/logging/audit/LogLevel.html[Log level] is similar to the same concept from normal
+logging frameworks, but only has three values: INFO, WARNING or ERROR.
 
 After defining new event the app needs to obtain an instance of this interface using the same factory method:
 
@@ -333,13 +301,13 @@ None expected.
 
 The framework provides two kinds of APIs:
 
-- https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/org/talend/logging/audit/StandardEventAuditLogger.html[Event-based] (main)
-- https://ci-tpsvc.datapwn.com/job/tpsvc-logging_logging-build_audit-logging-tpsvc-3638/ws/audit/build/docs/javadoc/org/talend/logging/audit/AuditLogger.html[Simple] (mostly for tests and very simple applications)
+- {javadoc_url}/org/talend/logging/audit/StandardEventAuditLogger.html[Event-based] (main)
+- {javadoc_url}/org/talend/logging/audit/AuditLogger.html[Simple] (mostly for tests and very simple applications)
 
-There are a few https://github.com/Talend/platform-services-logging/tree/audit-logging-tpsvc-3638/samples/audit[samples] that show how to use the API:
+There are a few {audit_sample_url}[samples] that show how to use the API:
 
-- https://github.com/Talend/platform-services-logging/blob/audit-logging-tpsvc-3638/samples/audit/src/main/java/org/talend/logging/samples/audit/events/EventMain.java[Event-based]
-- https://github.com/Talend/platform-services-logging/blob/audit-logging-tpsvc-3638/samples/audit/src/main/java/org/talend/logging/samples/audit/simple/SimpleMain.java[Simple]
+- {audit_sample_url}/src/main/java/org/talend/logging/samples/audit/events/EventMain.java[Event-based]
+- {audit_sample_url}/src/main/java/org/talend/logging/samples/audit/simple/SimpleMain.java[Simple]
 
 
 == Security

--- a/daikon-audit/src/main/java/org/talend/logging/audit/impl/AuditConfiguration.java
+++ b/daikon-audit/src/main/java/org/talend/logging/audit/impl/AuditConfiguration.java
@@ -24,13 +24,7 @@ enum AuditConfiguration {
     APPENDER_SOCKET_PORT("appender.socket.port", Integer.class, 4560),
     APPENDER_CONSOLE_PATTERN("appender.console.pattern", String.class, "%d{yyyy-MM-dd HH:mm:ss} %-5p %c - %m%n"),
     APPENDER_CONSOLE_TARGET("appender.console.target", LogTarget.class, LogTarget.OUTPUT),
-    LOG_APPENDER("log.appender", LogAppenders.class) {
-
-        @Override
-        public <T> void setValue(T value, Class<? extends T> clz) {
-            super.setValue(value, clz);
-        }
-    };
+    LOG_APPENDER("log.appender", LogAppendersSet.class);
 
     private static final String PLACEHOLDER_START = "${";
 
@@ -160,6 +154,13 @@ enum AuditConfiguration {
             } else if (Enum.class.isAssignableFrom(prop.getClz())) {
                 Class<? extends Enum> enumClz = (Class<? extends Enum>) prop.getClz();
                 prop.setValue(Enum.valueOf(enumClz, value.toUpperCase()), enumClz);
+            } else if (LogAppendersSet.class.isAssignableFrom(prop.getClz())) {
+                String[] parts = value.split(",");
+                LogAppendersSet appenders = new LogAppendersSet();
+                for (String app : parts) {
+                    appenders.add(Enum.valueOf(LogAppenders.class, app.toUpperCase()));
+                }
+                prop.setValue(appenders, LogAppendersSet.class);
             } else {
                 throw new IllegalArgumentException("Unsupported property type " + prop.getClz().getName());
             }

--- a/daikon-audit/src/main/java/org/talend/logging/audit/impl/LogAppendersSet.java
+++ b/daikon-audit/src/main/java/org/talend/logging/audit/impl/LogAppendersSet.java
@@ -1,9 +1,18 @@
 package org.talend.logging.audit.impl;
 
+import java.util.Collection;
 import java.util.LinkedHashSet;
 
 /**
  *
  */
 public class LogAppendersSet extends LinkedHashSet<LogAppenders> {
+
+    public LogAppendersSet() {
+        super();
+    }
+
+    public LogAppendersSet(Collection<LogAppenders> appenders) {
+        super(appenders);
+    }
 }

--- a/daikon-audit/src/main/resources/audit.properties.example
+++ b/daikon-audit/src/main/resources/audit.properties.example
@@ -1,6 +1,10 @@
 # This file contains configuration for audit logging. Usually the path to this file is passed to the application
 # using "talend.logging.audit.config" system property. The default location is "classpath:/audit.properties".
 
+# Placeholders are supported with format ${name} or ${name:defaultValue}. Name will be resolved against system properties.
+# If not found, then an environment variable with name converted to upper case replacing dots with underscores (for example
+# java.home will be replaced with JAVA_HOME). If a such environment variable doesn't exist, the default value will be
+# used. If default value not provided then an instance of AuditLoggingException will be thrown.
 
 # Logger name prefix which will be added to event category (logger name in terms of slf4j).
 #
@@ -20,13 +24,13 @@ service.name=ServiceA
 # Name of the instance of the service (this value will be put into MDC for each logged event).
 instance.name=TestInstance1
 
-# Type of log appender to use.
+# Type of log appender to use (multiple appenders can be used simultaneously if provided as a comma-separated list).
 # Possible values: socket, file, console
-log.appender=socket
+log.appender=socket,file
 
 # File appender puts log entries into a json file. In most cases there should be a FileBeat instance picking up
 # new messages and sending them to logstash.
-appender.file.path=/tmp/audit/test.log.json
+appender.file.path=${audit.log.folder}/audit.json
 appender.file.maxsize=52428800
 appender.file.maxbackup=20
 

--- a/daikon-audit/src/test/java/org/talend/logging/audit/impl/AuditConfigurationTest.java
+++ b/daikon-audit/src/test/java/org/talend/logging/audit/impl/AuditConfigurationTest.java
@@ -3,6 +3,7 @@ package org.talend.logging.audit.impl;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.*;
@@ -49,6 +50,8 @@ public class AuditConfigurationTest {
             }
         }
 
+        final LogAppendersSet expectedAppenders = new LogAppendersSet(Arrays.asList(LogAppenders.FILE, LogAppenders.SOCKET));
+
         assertEquals("testLogger", AuditConfiguration.ROOT_LOGGER.getString());
         assertEquals("TestApplicationName", AuditConfiguration.APPLICATION_NAME.getString());
         assertEquals("DefaultServiceName", AuditConfiguration.SERVICE_NAME.getString());
@@ -61,6 +64,6 @@ public class AuditConfigurationTest {
         assertEquals((Integer) 8056, AuditConfiguration.APPENDER_SOCKET_PORT.getInteger());
         assertEquals("ConsolePattern", AuditConfiguration.APPENDER_CONSOLE_PATTERN.getString());
         assertEquals(LogTarget.ERROR, AuditConfiguration.APPENDER_CONSOLE_TARGET.getValue(LogTarget.class));
-        assertEquals(LogAppenders.SOCKET, AuditConfiguration.LOG_APPENDER.getValue(LogAppenders.class));
+        assertEquals(expectedAppenders, AuditConfiguration.LOG_APPENDER.getValue(LogAppendersSet.class));
     }
 }

--- a/daikon-audit/src/test/java/org/talend/logging/audit/impl/AuditConfigurationTest.java
+++ b/daikon-audit/src/test/java/org/talend/logging/audit/impl/AuditConfigurationTest.java
@@ -38,6 +38,9 @@ public class AuditConfigurationTest {
 
     @Test
     public void testLoadConfiguration() {
+        System.setProperty("test.file.path.property", "/tmp/testSysPropValue");
+        final String javaHome = System.getenv("JAVA_HOME");
+
         AuditConfiguration.loadFromClasspath("/test.audit.properties");
 
         for (AuditConfiguration c : AuditConfiguration.values()) {
@@ -48,9 +51,9 @@ public class AuditConfigurationTest {
 
         assertEquals("testLogger", AuditConfiguration.ROOT_LOGGER.getString());
         assertEquals("TestApplicationName", AuditConfiguration.APPLICATION_NAME.getString());
-        assertEquals("TestServiceName", AuditConfiguration.SERVICE_NAME.getString());
-        assertEquals("TestInstanceName", AuditConfiguration.INSTANCE_NAME.getString());
-        assertEquals("test.json", AuditConfiguration.APPENDER_FILE_PATH.getString());
+        assertEquals("DefaultServiceName", AuditConfiguration.SERVICE_NAME.getString());
+        assertEquals(javaHome, AuditConfiguration.INSTANCE_NAME.getString());
+        assertEquals("/tmp/testSysPropValue/test.json", AuditConfiguration.APPENDER_FILE_PATH.getString());
         assertEquals((Long) 30L, AuditConfiguration.APPENDER_FILE_MAXSIZE.getLong());
         assertEquals((Integer) 100, AuditConfiguration.APPENDER_FILE_MAXBACKUP.getInteger());
         assertEquals(Boolean.TRUE, AuditConfiguration.LOCATION.getBoolean());

--- a/daikon-audit/src/test/java/org/talend/logging/audit/impl/UtilsTest.java
+++ b/daikon-audit/src/test/java/org/talend/logging/audit/impl/UtilsTest.java
@@ -2,14 +2,13 @@ package org.talend.logging.audit.impl;
 
 import static org.junit.Assert.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.talend.logging.audit.Context;
-import org.talend.logging.audit.ContextBuilder;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import org.junit.Test;
+import org.talend.logging.audit.Context;
+import org.talend.logging.audit.ContextBuilder;
 
 public class UtilsTest {
 

--- a/daikon-audit/src/test/resources/test.audit.properties
+++ b/daikon-audit/src/test/resources/test.audit.properties
@@ -2,14 +2,14 @@ root.logger=testLogger
 
 # this field ends with two spaces intentionally to verify that the value will be trimmed
 application.name=TestApplicationName   
-service.name=TestServiceName
-instance.name=TestInstanceName
+service.name=${test.service.name.property:DefaultServiceName}
+instance.name=${Java.Home}
 
 location=true
 
 log.appender=socket
 
-appender.file.path=test.json
+appender.file.path=${test.file.path.property}/test.json
 appender.file.maxsize=30
 appender.file.maxbackup=100
 

--- a/daikon-audit/src/test/resources/test.audit.properties
+++ b/daikon-audit/src/test/resources/test.audit.properties
@@ -7,7 +7,7 @@ instance.name=${Java.Home}
 
 location=true
 
-log.appender=socket
+log.appender=socket,file
 
 appender.file.path=${test.file.path.property}/test.json
 appender.file.maxsize=30


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
This PR adds support for placeholders in audit configuration file. The placeholder is replaced with a value from either system properties, environment vars or a default.

Additionally, this PR introduces support for multiple appenders for audit logs. 

**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
