### PR TITLE
fix(TDKN-195): fix i18n for ListProperties

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
@@ -201,7 +201,10 @@ public class PropertiesImpl extends TranslatableTaggedImpl
             throw new IllegalArgumentException("The java field [" + this.getClass().getCanonicalName() + "." + f.getName()
                     + "] should be named identically to the instance name [" + value.getName() + "]");
         }
-        if (value instanceof PropertiesImpl) {// a nested Properties so recurse
+        if (value instanceof PropertiesList) {// a list of pros so set the formatter and recusrs
+            ((PropertiesImpl) value).initProperties();
+            value.setI18nMessageFormatter(getI18nMessageFormatter());
+        } else if (value instanceof PropertiesImpl) {// a nested Properties so recurse
             // Do not set the i18N for nested Properties, they already handle their i18n
             ((PropertiesImpl) value).initProperties();
         } else {// a simple Property or PresentationItem so just set i18n

--- a/daikon/src/test/java/org/talend/daikon/properties/PropertiesListTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/PropertiesListTest.java
@@ -159,6 +159,13 @@ public class PropertiesListTest {
         Assert.assertEquals(propertiesList.getMaxItems(), "20");
     }
 
+    @Test
+    public void testi18N() {
+        TestPropertiesList.TestComponentProperties tpl = (TestPropertiesList.TestComponentProperties) new TestPropertiesList.TestComponentProperties(
+                "foo").init();
+        Assert.assertEquals(tpl.filters.getDisplayName(), "Filters");
+    }
+
     private PropertiesList<TestProperties> createPropertiesList() {
         PropertiesList<TestProperties> propertiesList = new PropertiesList<>("propertiesList",
                 new PropertiesList.NestedPropertiesFactory<TestProperties>() {

--- a/daikon/src/test/java/org/talend/daikon/properties/TestPropertiesList.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/TestPropertiesList.java
@@ -61,7 +61,6 @@ public class TestPropertiesList {
 
         public TestComponentProperties(String name) {
             super(name);
-            this.filters.setI18nMessageFormatter(getI18nMessageFormatter());
         }
 
         @Override


### PR DESCRIPTION
This reverts commit 2d20a812a5e24426f303c6ffccdb5d8b25d05db6.
oops I did push to master (and reverted it) but this commit unrevert it.

**What is the problem this Pull Request is trying to solve?**
PropertiesList i18n is not handled properly
 
**What is the chosen solution to this problem?**
now it is
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-195
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
