### PR TITLE
Fhuaulme/fix/concurrent close issue

### DIFF
--- a/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProvider.java
+++ b/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProvider.java
@@ -46,7 +46,7 @@ public class SynchronizedMongoClientProvider implements MongoClientProvider {
             LOGGER.debug("Unable to obtain database URI (configuration might be missing for tenant).", e);
         }
         if (openCount <= 0) {
-            delegate.close(tenantInformationProvider);
+            delegate.get(tenantInformationProvider).close();
         } else {
             LOGGER.trace("Not closing mongo clients ({} remain in use for database '{}')", openCount, databaseURI == null ? "N/A" : databaseURI);
         }

--- a/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProvider.java
+++ b/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProvider.java
@@ -1,15 +1,14 @@
 package org.talend.daikon.spring.mongo;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * A {@link MongoClientProvider} implementation that provides thread safety around the
@@ -38,12 +37,18 @@ public class SynchronizedMongoClientProvider implements MongoClientProvider {
 
     @Override
     public synchronized void close(TenantInformationProvider tenantInformationProvider) {
-        final MongoClientURI databaseURI = tenantInformationProvider.getDatabaseURI();
-        final int openCount = concurrentOpens.getOrDefault(databaseURI, new AtomicInteger(0)).decrementAndGet();
-        if(openCount <= 0) {
+        MongoClientURI databaseURI = null;
+        int openCount = 0;
+        try {
+            databaseURI = tenantInformationProvider.getDatabaseURI();
+            openCount = concurrentOpens.getOrDefault(databaseURI, new AtomicInteger(0)).decrementAndGet();
+        } catch (Exception e) {
+            LOGGER.debug("Unable to obtain database URI (configuration might be missing for tenant).", e);
+        }
+        if (openCount <= 0) {
             delegate.close(tenantInformationProvider);
         } else {
-            LOGGER.trace("Not closing mongo clients ({} remain in use for database '{}')", openCount, databaseURI);
+            LOGGER.trace("Not closing mongo clients ({} remain in use for database '{}')", openCount, databaseURI == null ? "N/A" : databaseURI);
         }
     }
 }

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProviderTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProviderTest.java
@@ -64,4 +64,19 @@ public class SynchronizedMongoClientProviderTest {
         verify(mongoClientProvider, times(2)).close(any());
     }
 
+    @Test
+    public void shouldCloseInCaseOfMissingConfiguration() {
+        // given
+        final MongoClientProvider mongoClientProvider = mock(MongoClientProvider.class);
+        SynchronizedMongoClientProvider provider = new SynchronizedMongoClientProvider(mongoClientProvider);
+        final TenantInformationProvider tenantInformationProvider1 = mock(TenantInformationProvider.class);
+        when(tenantInformationProvider1.getDatabaseURI()).thenThrow(new RuntimeException("On purpose thrown exception"));
+
+        // when
+        provider.close(tenantInformationProvider1);
+
+        // then
+        verify(mongoClientProvider, times(1)).close(any());
+    }
+
 }

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProviderTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProviderTest.java
@@ -1,9 +1,9 @@
 package org.talend.daikon.spring.mongo;
 
+import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import org.junit.Test;
 
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class SynchronizedMongoClientProviderTest {
@@ -15,6 +15,8 @@ public class SynchronizedMongoClientProviderTest {
         SynchronizedMongoClientProvider provider = new SynchronizedMongoClientProvider(mongoClientProvider);
         final TenantInformationProvider tenantInformationProvider = mock(TenantInformationProvider.class);
         when(tenantInformationProvider.getDatabaseURI()).thenReturn(new MongoClientURI("mongodb://no_host"));
+        final MongoClient mongoClient = mock(MongoClient.class);
+        when(mongoClientProvider.get(eq(tenantInformationProvider))).thenReturn(mongoClient);
 
         // when
         provider.get(tenantInformationProvider);
@@ -23,7 +25,7 @@ public class SynchronizedMongoClientProviderTest {
         provider.close(tenantInformationProvider);
 
         // then
-        verify(mongoClientProvider, times(1)).close(any());
+        verify(mongoClient, times(1)).close();
     }
 
     @Test
@@ -33,6 +35,8 @@ public class SynchronizedMongoClientProviderTest {
         SynchronizedMongoClientProvider provider = new SynchronizedMongoClientProvider(mongoClientProvider);
         final TenantInformationProvider tenantInformationProvider = mock(TenantInformationProvider.class);
         when(tenantInformationProvider.getDatabaseURI()).thenReturn(new MongoClientURI("mongodb://no_host"));
+        final MongoClient mongoClient = mock(MongoClient.class);
+        when(mongoClientProvider.get(eq(tenantInformationProvider))).thenReturn(mongoClient);
 
         // when
         provider.get(tenantInformationProvider);
@@ -41,7 +45,7 @@ public class SynchronizedMongoClientProviderTest {
         provider.close(tenantInformationProvider);
 
         // then
-        verify(mongoClientProvider, times(2)).close(any());
+        verify(mongoClient, times(2)).close();
     }
 
     @Test
@@ -53,6 +57,10 @@ public class SynchronizedMongoClientProviderTest {
         final TenantInformationProvider tenantInformationProvider2 = mock(TenantInformationProvider.class);
         when(tenantInformationProvider1.getDatabaseURI()).thenReturn(new MongoClientURI("mongodb://no_host_1"));
         when(tenantInformationProvider2.getDatabaseURI()).thenReturn(new MongoClientURI("mongodb://no_host_2"));
+        final MongoClient mongoClient1 = mock(MongoClient.class);
+        final MongoClient mongoClient2 = mock(MongoClient.class);
+        when(mongoClientProvider.get(eq(tenantInformationProvider1))).thenReturn(mongoClient1);
+        when(mongoClientProvider.get(eq(tenantInformationProvider2))).thenReturn(mongoClient2);
 
         // when
         provider.get(tenantInformationProvider1);
@@ -61,7 +69,8 @@ public class SynchronizedMongoClientProviderTest {
         provider.close(tenantInformationProvider2);
 
         // then
-        verify(mongoClientProvider, times(2)).close(any());
+        verify(mongoClient1, times(1)).close();
+        verify(mongoClient2, times(1)).close();
     }
 
     @Test
@@ -69,14 +78,16 @@ public class SynchronizedMongoClientProviderTest {
         // given
         final MongoClientProvider mongoClientProvider = mock(MongoClientProvider.class);
         SynchronizedMongoClientProvider provider = new SynchronizedMongoClientProvider(mongoClientProvider);
-        final TenantInformationProvider tenantInformationProvider1 = mock(TenantInformationProvider.class);
-        when(tenantInformationProvider1.getDatabaseURI()).thenThrow(new RuntimeException("On purpose thrown exception"));
+        final TenantInformationProvider tenantInformationProvider = mock(TenantInformationProvider.class);
+        when(tenantInformationProvider.getDatabaseURI()).thenThrow(new RuntimeException("On purpose thrown exception"));
+        final MongoClient mongoClient = mock(MongoClient.class);
+        when(mongoClientProvider.get(eq(tenantInformationProvider))).thenReturn(mongoClient);
 
         // when
-        provider.close(tenantInformationProvider1);
+        provider.close(tenantInformationProvider);
 
         // then
-        verify(mongoClientProvider, times(1)).close(any());
+        verify(mongoClient, times(1)).close();
     }
 
 }

--- a/daikon-spring/daikon-spring-tenancy/src/main/java/org/talend/tenancy/ForAll.java
+++ b/daikon-spring/daikon-spring-tenancy/src/main/java/org/talend/tenancy/ForAll.java
@@ -11,6 +11,7 @@ public interface ForAll {
      * Execute the provided <code>runnable</code> for all tenants.
      *
      * @param runnable The {@link Runnable} to execute.
+     * @param condition A {@link Supplier} to execute to decide whether to execute <code>runnable</code> or not.
      */
     void execute(final Supplier<Boolean> condition, Runnable runnable);
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Method close in SynchronizedMongoClientProvider may have issue closing the mongoldb client when tenant information provider is unable to get configuration.

**What is the chosen solution to this problem?**
SynchronizedMongoClientProvider ignores exceptions when tenant information provider is unable to return database URI. This is a edge case since tenants with no configuration are somewhat rare in production.

**Link to the JIRA issue**
(no jira)
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request