### PR TITLE
fix(TMDM-11854): Output with keywords fields names

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/avro/AvroNamesValidationHelper.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/AvroNamesValidationHelper.java
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 /**
  * Helper class that provides utility methods for validation of identifiers according to Java naming conventions.
  */
-public class JavaNamesValidationHelper {
+public class AvroNamesValidationHelper {
 
     private static final Set<String> JAVA_KEYWORDS = new HashSet<String>(Arrays.asList("abstract", "continue", "for", "new",
             "switch", "assert", "default", "goto", "package", "synchronized", "boolean", "do", "if", "private", "this", "break",
@@ -16,7 +16,22 @@ public class JavaNamesValidationHelper {
             "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char", "final", "interface",
             "static", "void", "class", "finally", "long", "strictfp", "volatile", "const", "float", "native", "super", "while"));
 
-    private static final String CONTEXT_AND_VARIABLE_PATTERN = "^[a-zA-Z_][a-zA-Z_0-9]*$";
+    private static final Pattern CONTEXT_AND_VARIABLE_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z_0-9]*$");
+
+    /**
+     * Checks whether specified name is a valid identifier according to Java conventions,
+     * if specified name is invalid - generates a new name value that can be used in Avro schema.
+     *
+     * @param name identifier to validate
+     * @return valid name that can be used in Avro schema
+     */
+    public static String getAvroCompatibleName(String name) {
+        if (isValidParameterName(name)) {
+            return name;
+        } else {
+            return "_" + name;
+        }
+    }
 
     /**
      * Checks whether specified name is a valid identifier according to Java conventions.
@@ -25,17 +40,14 @@ public class JavaNamesValidationHelper {
      * @return true, if name is a valid Java identifier
      */
     public static boolean isValidParameterName(String name) {
-        if (name != null) {
-            if (isJavaKeyWord(name)) {
-                return false;
-            }
-            return Pattern.matches(CONTEXT_AND_VARIABLE_PATTERN, name);
+        if (name == null || isJavaKeyWord(name)) {
+            return false;
         }
-        return false;
+        return CONTEXT_AND_VARIABLE_PATTERN.matcher(name).matches();
     }
 
     /**
-     * Checks whether specified name is a Java keyword
+     * Checks whether specified name is a Java keyword.
      *
      * @param name identifier to validate
      * @return true, if name is a Java keyword

--- a/daikon/src/main/java/org/talend/daikon/avro/AvroNamesValidationHelper.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/AvroNamesValidationHelper.java
@@ -1,3 +1,15 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
 package org.talend.daikon.avro;
 
 import java.util.Arrays;
@@ -10,11 +22,12 @@ import java.util.regex.Pattern;
  */
 public class AvroNamesValidationHelper {
 
-    private static final Set<String> JAVA_KEYWORDS = new HashSet<String>(Arrays.asList("abstract", "continue", "for", "new",
-            "switch", "assert", "default", "goto", "package", "synchronized", "boolean", "do", "if", "private", "this", "break",
-            "double", "implements", "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum",
-            "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char", "final", "interface",
-            "static", "void", "class", "finally", "long", "strictfp", "volatile", "const", "float", "native", "super", "while"));
+    private static final Set<String> JAVA_KEYWORDS = new HashSet<String>(
+            Arrays.asList("abstract", "continue", "for", "new", "switch", "assert", "default", "goto", "package", "synchronized",
+                    "boolean", "do", "if", "private", "this", "break", "double", "implements", "protected", "throw", "byte",
+                    "else", "import", "public", "throws", "case", "enum", "instanceof", "return", "transient", "catch", "extends",
+                    "int", "short", "try", "char", "final", "interface", "static", "void", "class", "finally", "long", "strictfp",
+                    "volatile", "const", "float", "native", "super", "while", "true", "false", "null"));
 
     private static final Pattern CONTEXT_AND_VARIABLE_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z_0-9]*$");
 

--- a/daikon/src/main/java/org/talend/daikon/avro/JavaNamesValidationHelper.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/JavaNamesValidationHelper.java
@@ -1,0 +1,46 @@
+package org.talend.daikon.avro;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+/**
+ * Helper class that provides utility methods for validation of identifiers according to Java naming conventions.
+ */
+public class JavaNamesValidationHelper {
+
+    private static final Set<String> JAVA_KEYWORDS = new HashSet<String>(Arrays.asList("abstract", "continue", "for", "new",
+            "switch", "assert", "default", "goto", "package", "synchronized", "boolean", "do", "if", "private", "this", "break",
+            "double", "implements", "protected", "throw", "byte", "else", "import", "public", "throws", "case", "enum",
+            "instanceof", "return", "transient", "catch", "extends", "int", "short", "try", "char", "final", "interface",
+            "static", "void", "class", "finally", "long", "strictfp", "volatile", "const", "float", "native", "super", "while"));
+
+    private static final String CONTEXT_AND_VARIABLE_PATTERN = "^[a-zA-Z_][a-zA-Z_0-9]*$";
+
+    /**
+     * Checks whether specified name is a valid identifier according to Java conventions.
+     *
+     * @param name identifier to validate
+     * @return true, if name is a valid Java identifier
+     */
+    public static boolean isValidParameterName(String name) {
+        if (name != null) {
+            if (isJavaKeyWord(name)) {
+                return false;
+            }
+            return Pattern.matches(CONTEXT_AND_VARIABLE_PATTERN, name);
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether specified name is a Java keyword
+     *
+     * @param name identifier to validate
+     * @return true, if name is a Java keyword
+     */
+    public static boolean isJavaKeyWord(String name) {
+        return JAVA_KEYWORDS.contains(name);
+    }
+}

--- a/daikon/src/test/java/org/talend/daikon/avro/AvroNamesValidationHelperTest.java
+++ b/daikon/src/test/java/org/talend/daikon/avro/AvroNamesValidationHelperTest.java
@@ -1,0 +1,44 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2018 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.daikon.avro;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link org.talend.daikon.avro.AvroNamesValidationHelper}
+ *
+ */
+public class AvroNamesValidationHelperTest {
+
+    private static final Set<String> AVRO_INVALID_NAMES = new HashSet<String>(Arrays.asList("abstract", "const", "continue",
+            "float", "for", "native", "new", "super", "switch", "while", "true", "false", "null"));
+
+    private static final Set<String> AVRO_COMPATIBLE_NAMES = new HashSet<String>(Arrays.asList("_abstract", "_const", "_continue",
+            "_float", "_for", "_native", "_new", "_super", "_switch", "_while", "_true", "_false", "_null"));
+
+    @Test
+    public void testGetAvroCompatibleName() {
+        Set<String> convertedNames = new HashSet<String>();
+
+        for (String name : AVRO_INVALID_NAMES) {
+            convertedNames.add(AvroNamesValidationHelper.getAvroCompatibleName(name));
+        }
+
+        Assert.assertEquals(convertedNames, AVRO_COMPATIBLE_NAMES);
+    }
+}


### PR DESCRIPTION
* added utility methods for validation of field names

**What is the problem this Pull Request is trying to solve?**
 Utility methods are necessary to validate the field names on Java conventions.
**What is the chosen solution to this problem?**
 Add utility methods to daikon, so that this functionality will be available in all components
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 https://jira.talendforge.org/browse/TMDM-11854
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
