### PR TITLE
fix(TDP-5356): Reuse of mongo clients may lead to closed clients.

### DIFF
--- a/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/CachedMongoClientProvider.java
+++ b/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/CachedMongoClientProvider.java
@@ -1,18 +1,16 @@
 package org.talend.daikon.spring.mongo;
 
-import java.io.IOException;
-import java.util.concurrent.TimeUnit;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.dao.InvalidDataAccessResourceUsageException;
-
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.cache.RemovalListener;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.InvalidDataAccessResourceUsageException;
+
+import java.util.concurrent.TimeUnit;
 
 /**
  * An implementation of {@link MongoClientProvider} that has automatic client clean up after a time period.
@@ -83,6 +81,21 @@ public class CachedMongoClientProvider implements MongoClientProvider {
 
     @Override
     public void close(TenantInformationProvider provider) {
+        try {
+            final MongoClientURI uri = provider.getDatabaseURI();
+            final MongoClient mongoClient = cache.get(uri);
+            try {
+                mongoClient.close();
+            } finally {
+                cache.asMap().remove(uri);
+            }
+        } catch (Exception e) {
+            throw new InvalidDataAccessResourceUsageException("Unable to close client.", e);
+        }
+    }
+
+    @Override
+    public void close() {
         for (MongoClient client : cache.asMap().values()) {
             client.close();
         }

--- a/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/MongoClientProvider.java
+++ b/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/MongoClientProvider.java
@@ -8,7 +8,7 @@ import java.io.Closeable;
  * Implement this interface to obtain a {@link MongoClient client} for a tenant (with information available through
  * {@link TenantInformationProvider}).
  */
-public interface MongoClientProvider {
+public interface MongoClientProvider extends Closeable {
 
     /**
      * <p>
@@ -27,11 +27,11 @@ public interface MongoClientProvider {
     MongoClient get(TenantInformationProvider provider);
 
     /**
-     * Close the connections managed by this implementation. Implementations may use {@link TenantInformationProvider} to
-     * decide whether connections should be closed or not.
+     * Close the connection managed by this implementation <b>only</b> for the tenant given by {@link TenantInformationProvider}.
      *
      * @param provider An implementation of {@link TenantInformationProvider} to be used to get tenant information (database uri,
      *                 database name).
+     * @see #close() To closing <b>all</b> connections managed by implementation.
      */
     void close(TenantInformationProvider provider);
 

--- a/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SimpleMongoClientProvider.java
+++ b/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SimpleMongoClientProvider.java
@@ -1,6 +1,5 @@
 package org.talend.daikon.spring.mongo;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;

--- a/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SimpleMongoClientProvider.java
+++ b/daikon-spring/daikon-spring-mongo/src/main/java/org/talend/daikon/spring/mongo/SimpleMongoClientProvider.java
@@ -40,6 +40,16 @@ public class SimpleMongoClientProvider implements MongoClientProvider {
 
     @Override
     public void close(TenantInformationProvider provider) {
+        final MongoClientURI uri = provider.getDatabaseURI();
+        final MongoClient mongoClient = clients.get(uri);
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+        clients.remove(uri);
+    }
+
+    @Override
+    public void close() {
         for (Map.Entry<MongoClientURI, MongoClient> entry : clients.entrySet()) {
             entry.getValue().close();
         }

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/AbstractMultiTenantMongoDbTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/AbstractMultiTenantMongoDbTest.java
@@ -9,6 +9,7 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.talend.daikon.spring.mongo.TestMultiTenantConfiguration.changeTenant;
@@ -29,7 +30,7 @@ public abstract class AbstractMultiTenantMongoDbTest {
     private TenantInformationProvider tenantInformationProvider;
 
     @Before
-    public void tearDown() {
+    public void tearDown() throws IOException {
         // Drop all created databases during test
         final List<String> databases = fongo.getDatabaseNames();
         for (String database : databases) {
@@ -38,6 +39,6 @@ public abstract class AbstractMultiTenantMongoDbTest {
         // Switch back to default tenant
         changeTenant("default");
         // Clean up mongo clients
-        mongoClientProvider.close(tenantInformationProvider);
+        mongoClientProvider.close();
     }
 }

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/CachedMongoClientProviderTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/CachedMongoClientProviderTest.java
@@ -2,7 +2,6 @@ package org.talend.daikon.spring.mongo;
 
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/CachedMongoClientProviderTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/CachedMongoClientProviderTest.java
@@ -1,5 +1,7 @@
 package org.talend.daikon.spring.mongo;
 
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.TimeUnit;
@@ -54,7 +56,7 @@ public class CachedMongoClientProviderTest {
         final MongoClient client2 = cachedMongoClientProvider.get(TENANT1);
 
         // Then
-        assertTrue(client1 == client2);
+        assertSame(client1, client2);
     }
 
     @Test
@@ -65,7 +67,7 @@ public class CachedMongoClientProviderTest {
         final MongoClient client2 = cachedMongoClientProvider.get(TENANT1);
 
         // Then
-        assertTrue(client1 != client2);
+        assertNotSame(client1, client2);
     }
 
     @Test
@@ -75,6 +77,20 @@ public class CachedMongoClientProviderTest {
         final MongoClient client2 = cachedMongoClientProvider.get(TENANT2);
 
         // Then
-        assertTrue(client1 != client2);
+        assertNotSame(client1, client2);
+    }
+
+    @Test
+    public void shouldCloseClient() {
+        // Given
+        final TenantInformationProvider tenantInformationProvider = getTenantInformationProvider("Tenant1");
+
+        // When
+        final MongoClient client1 = cachedMongoClientProvider.get(tenantInformationProvider);
+        cachedMongoClientProvider.close(tenantInformationProvider);
+        final MongoClient client2 = cachedMongoClientProvider.get(tenantInformationProvider);
+
+        // Then
+        assertNotSame(client1, client2);
     }
 }

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/MultiTenantMongoDbFactoryTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/MultiTenantMongoDbFactoryTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.github.fakemongo.Fongo;
-import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/MultiTenantMongoDbFactoryTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/MultiTenantMongoDbFactoryTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.github.fakemongo.Fongo;
+import org.junit.After;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.InvalidDataAccessResourceUsageException;

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProviderTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProviderTest.java
@@ -3,10 +3,13 @@ package org.talend.daikon.spring.mongo;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class SynchronizedMongoClientProviderTest {
 

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProviderTest.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/SynchronizedMongoClientProviderTest.java
@@ -3,6 +3,8 @@ package org.talend.daikon.spring.mongo;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import static org.mockito.Mockito.*;
 
@@ -17,6 +19,14 @@ public class SynchronizedMongoClientProviderTest {
         when(tenantInformationProvider.getDatabaseURI()).thenReturn(new MongoClientURI("mongodb://no_host"));
         final MongoClient mongoClient = mock(MongoClient.class);
         when(mongoClientProvider.get(eq(tenantInformationProvider))).thenReturn(mongoClient);
+        doAnswer(invocation -> {
+            try {
+                mongoClient.close();
+            } catch (Exception e) {
+                // Ignored
+            }
+            return null;
+        }).when(mongoClientProvider).close(eq(tenantInformationProvider));
 
         // when
         provider.get(tenantInformationProvider);
@@ -37,6 +47,14 @@ public class SynchronizedMongoClientProviderTest {
         when(tenantInformationProvider.getDatabaseURI()).thenReturn(new MongoClientURI("mongodb://no_host"));
         final MongoClient mongoClient = mock(MongoClient.class);
         when(mongoClientProvider.get(eq(tenantInformationProvider))).thenReturn(mongoClient);
+        doAnswer(invocation -> {
+            try {
+                mongoClient.close();
+            } catch (Exception e) {
+                // Ignored
+            }
+            return null;
+        }).when(mongoClientProvider).close(eq(tenantInformationProvider));
 
         // when
         provider.get(tenantInformationProvider);
@@ -61,6 +79,22 @@ public class SynchronizedMongoClientProviderTest {
         final MongoClient mongoClient2 = mock(MongoClient.class);
         when(mongoClientProvider.get(eq(tenantInformationProvider1))).thenReturn(mongoClient1);
         when(mongoClientProvider.get(eq(tenantInformationProvider2))).thenReturn(mongoClient2);
+        doAnswer(invocation -> {
+            try {
+                mongoClient1.close();
+            } catch (Exception e) {
+                // Ignored
+            }
+            return null;
+        }).when(mongoClientProvider).close(eq(tenantInformationProvider1));
+        doAnswer(invocation -> {
+            try {
+                mongoClient2.close();
+            } catch (Exception e) {
+                // Ignored
+            }
+            return null;
+        }).when(mongoClientProvider).close(eq(tenantInformationProvider2));
 
         // when
         provider.get(tenantInformationProvider1);
@@ -82,6 +116,14 @@ public class SynchronizedMongoClientProviderTest {
         when(tenantInformationProvider.getDatabaseURI()).thenThrow(new RuntimeException("On purpose thrown exception"));
         final MongoClient mongoClient = mock(MongoClient.class);
         when(mongoClientProvider.get(eq(tenantInformationProvider))).thenReturn(mongoClient);
+        doAnswer(invocation -> {
+            try {
+                mongoClient.close();
+            } catch (Exception e) {
+                // Ignored
+            }
+            return null;
+        }).when(mongoClientProvider).close(eq(tenantInformationProvider));
 
         // when
         provider.close(tenantInformationProvider);

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/TestMultiTenantConfiguration.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/TestMultiTenantConfiguration.java
@@ -80,6 +80,14 @@ public class TestMultiTenantConfiguration {
         return new MongoClientProvider() {
 
             @Override
+            public void close() {
+                for (Map.Entry<String, Fongo> entry : fongoInstances.entrySet()) {
+                    entry.getValue().getMongo().close();
+                }
+                fongoInstances.clear();
+            }
+
+            @Override
             public MongoClient get(TenantInformationProvider provider) {
                 final String name = provider.getDatabaseURI().getURI();
                 fongoInstances.computeIfAbsent(name, Fongo::new);
@@ -88,10 +96,12 @@ public class TestMultiTenantConfiguration {
 
             @Override
             public void close(TenantInformationProvider provider) {
-                for (Map.Entry<String, Fongo> entry : fongoInstances.entrySet()) {
-                    entry.getValue().getMongo().close();
+                final String uri = provider.getDatabaseURI().getURI();
+                final Fongo fongo = fongoInstances.get(uri);
+                if (fongo != null) {
+                    fongo.getMongo().close();
                 }
-                fongoInstances.clear();
+                fongoInstances.remove(uri);
             }
         };
     }

--- a/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/TestMultiTenantConfiguration.java
+++ b/daikon-spring/daikon-spring-mongo/src/test/java/org/talend/daikon/spring/mongo/TestMultiTenantConfiguration.java
@@ -10,7 +10,6 @@ import com.github.fakemongo.Fongo;
 import com.mongodb.MongoClient;
 import org.springframework.data.mongodb.core.SimpleMongoDbFactory;
 
-import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
`MongoClient` comes from a cache managed by `CachedMongoClientProvider`. Current implementation in `org.talend.daikon.spring.mongo.SynchronizedMongoClientProvider` performs a direct close on the mongo client:
```java
delegate.get(tenantInformationProvider).close();
```
This leads to a major issue, in case of sequential access to the mongo client with operations such as:
```
SynchronizedMongoClientProvider provider = ...;
provider.get(tenant1);
provider.close(tenant1); // (1)
provider.get(tenant1); // (2) <- returned client may be closed
```
This only happens when (1) and (2) are performed in less time than the renewal of mongo clients (which is what `CachedMongoClientProvider` does).
Bottom line is: in case of many concurrent operations on the same tenants and if these operations performs close calls on returned `MongoClient`, cache in `CachedMongoClientProvider` may contain several closed mongo client (that are not suited for usage).

**What is the chosen solution to this problem?**
The `close(TenantInformationProvider)` is now responsible for closing and clean up the mongo client. This means the following pseudo-test should work:
```
SynchronizedMongoClientProvider provider = ...;
MongoClient mc1 = provider.get(tenant1);
provider.close(tenant1);
MongoClient mc2 = provider.get(tenant1);
assertTrue(mc1 != mc2);
```

Git commit details:
* Sequential migration tasks may reuse closed mongo client.
* Update behavior for SynchronizedMongoClientProvider::close(TenantInformationProvider).
* New unit test (improve code coverage + new close methods).

No breaking change expected.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5356
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request 