### PR TITLE
feat(TDS-3154): support single quotes in TQL queries

### DIFF
--- a/daikon-tql/daikon-tql-core/src/main/antlr4/TqlLexer.g4
+++ b/daikon-tql/daikon-tql-core/src/main/antlr4/TqlLexer.g4
@@ -53,4 +53,5 @@ DECIMAL: ('-')?('0' .. '9')+('.')('0' .. '9')*;
 FIELD: ('a' .. 'z' | 'A' .. 'Z' | '0' .. '9' | '_' | '.' )+;
 
 // literal values
-QUOTED_VALUE : ( '\'' ( ~ '\'' )* '\'' );
+fragment ESC : '\\\'';
+QUOTED_VALUE : ( '\'' (ESC|.)*? '\'' );

--- a/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/parser/TqlExpressionVisitor.java
+++ b/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/parser/TqlExpressionVisitor.java
@@ -78,7 +78,7 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
         LiteralValue.Enum literalValue = LiteralValue.Enum.valueOf(symbolicName);
         LOG.debug("Found literal value " + literalValue);
         String v = symbol.getText();
-        String value = literalValue.equals(LiteralValue.Enum.QUOTED_VALUE) ? unescapeSingleQuote(v.substring(1, v.length() - 1))
+        String value = literalValue.equals(LiteralValue.Enum.QUOTED_VALUE) ? unescapeSingleQuotes(v.substring(1, v.length() - 1))
                 : v;
         LiteralValue lv = new LiteralValue(literalValue, value);
         LOG.debug("End visit literal value: " + ctx.getText());
@@ -185,7 +185,7 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
 
         String quotedValue = valueNode.getSymbol().getText();
         String value = quotedValue.substring(1, quotedValue.length() - 1);
-        FieldContainsExpression fieldContainsExpression = new FieldContainsExpression(fieldName, unescapeSingleQuote(value));
+        FieldContainsExpression fieldContainsExpression = new FieldContainsExpression(fieldName, unescapeSingleQuotes(value));
         LOG.debug("End visit field contains: " + ctx.getText());
         return fieldContainsExpression;
     }
@@ -202,7 +202,7 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
 
         String quotedRegex = regexNode.getSymbol().getText();
         String regex = quotedRegex.substring(1, quotedRegex.length() - 1);
-        FieldMatchesRegex fieldMatchesRegex = new FieldMatchesRegex(fieldName, unescapeSingleQuote(regex));
+        FieldMatchesRegex fieldMatchesRegex = new FieldMatchesRegex(fieldName, unescapeSingleQuotes(regex));
         LOG.debug("End visit field matches: " + ctx.getText());
         return fieldMatchesRegex;
     }
@@ -218,7 +218,7 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
 
         String quotedPattern = patternNode.getText();
         String pattern = quotedPattern.substring(1, quotedPattern.length() - 1);
-        FieldCompliesPattern fieldCompliesPattern = new FieldCompliesPattern(fieldName, unescapeSingleQuote(pattern));
+        FieldCompliesPattern fieldCompliesPattern = new FieldCompliesPattern(fieldName, unescapeSingleQuotes(pattern));
         LOG.debug("End visit field complies: " + ctx.getText());
         return fieldCompliesPattern;
     }
@@ -331,21 +331,21 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
     }
 
     /**
-     * The single quote is used in the antlr grammar as a litteral delimeter, but can still be used inside a litteral.
-     * To avoid literals being truncated when parsed by antlr, single quotes are escaped by the tql clients, and then
+     * The single quote is used in the ANTLR grammar as a literal delimiter, but can still be used inside a literal.
+     * To avoid literals being truncated when parsed by ANTLR, single quotes are escaped by the TQL clients, and then
      * need to be unescaped after the parse operation.
      *
      * <pre>
-     * unescapeSingleQuote(null)       = null
-     * unescapeSingleQuote("O\'Reilly")= "O'Reilly"
-     * unescapeSingleQuote("\\")= "\\"
+     * unescapeSingleQuotes(null)       = null
+     * unescapeSingleQuotes("O\'Reilly")= "O'Reilly"
+     * unescapeSingleQuotes("\\")= "\\"
      *
      * </pre>
      *
      * @param token the parsed token
      * @return the token unescaped for single quotes
      */
-    private String unescapeSingleQuote(String token) {
+    private String unescapeSingleQuotes(String token) {
         return token != null ? token.replaceAll("\\\\'", "'") : null;
     }
 }

--- a/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/parser/TqlExpressionVisitor.java
+++ b/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/parser/TqlExpressionVisitor.java
@@ -13,7 +13,25 @@ import org.talend.tql.TqlLexer;
 import org.talend.tql.TqlParser;
 import org.talend.tql.TqlParserVisitor;
 import org.talend.tql.excp.TqlException;
-import org.talend.tql.model.*;
+import org.talend.tql.model.AllFields;
+import org.talend.tql.model.AndExpression;
+import org.talend.tql.model.BooleanValue;
+import org.talend.tql.model.ComparisonExpression;
+import org.talend.tql.model.ComparisonOperator;
+import org.talend.tql.model.Expression;
+import org.talend.tql.model.FieldBetweenExpression;
+import org.talend.tql.model.FieldCompliesPattern;
+import org.talend.tql.model.FieldContainsExpression;
+import org.talend.tql.model.FieldInExpression;
+import org.talend.tql.model.FieldIsEmptyExpression;
+import org.talend.tql.model.FieldIsInvalidExpression;
+import org.talend.tql.model.FieldIsValidExpression;
+import org.talend.tql.model.FieldMatchesRegex;
+import org.talend.tql.model.FieldReference;
+import org.talend.tql.model.LiteralValue;
+import org.talend.tql.model.NotExpression;
+import org.talend.tql.model.OrExpression;
+import org.talend.tql.model.TqlElement;
 
 /**
  * Visitor for building the AST Tql tree.
@@ -60,7 +78,8 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
         LiteralValue.Enum literalValue = LiteralValue.Enum.valueOf(symbolicName);
         LOG.debug("Found literal value " + literalValue);
         String v = symbol.getText();
-        String value = literalValue.equals(LiteralValue.Enum.QUOTED_VALUE) ? v.substring(1, v.length() - 1) : v;
+        String value = literalValue.equals(LiteralValue.Enum.QUOTED_VALUE) ? unescapeSingleQuote(v.substring(1, v.length() - 1))
+                : v;
         LiteralValue lv = new LiteralValue(literalValue, value);
         LOG.debug("End visit literal value: " + ctx.getText());
         return lv;
@@ -166,7 +185,7 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
 
         String quotedValue = valueNode.getSymbol().getText();
         String value = quotedValue.substring(1, quotedValue.length() - 1);
-        FieldContainsExpression fieldContainsExpression = new FieldContainsExpression(fieldName, value);
+        FieldContainsExpression fieldContainsExpression = new FieldContainsExpression(fieldName, unescapeSingleQuote(value));
         LOG.debug("End visit field contains: " + ctx.getText());
         return fieldContainsExpression;
     }
@@ -183,7 +202,7 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
 
         String quotedRegex = regexNode.getSymbol().getText();
         String regex = quotedRegex.substring(1, quotedRegex.length() - 1);
-        FieldMatchesRegex fieldMatchesRegex = new FieldMatchesRegex(fieldName, regex);
+        FieldMatchesRegex fieldMatchesRegex = new FieldMatchesRegex(fieldName, unescapeSingleQuote(regex));
         LOG.debug("End visit field matches: " + ctx.getText());
         return fieldMatchesRegex;
     }
@@ -199,7 +218,7 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
 
         String quotedPattern = patternNode.getText();
         String pattern = quotedPattern.substring(1, quotedPattern.length() - 1);
-        FieldCompliesPattern fieldCompliesPattern = new FieldCompliesPattern(fieldName, pattern);
+        FieldCompliesPattern fieldCompliesPattern = new FieldCompliesPattern(fieldName, unescapeSingleQuote(pattern));
         LOG.debug("End visit field complies: " + ctx.getText());
         return fieldCompliesPattern;
     }
@@ -309,5 +328,24 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
     @Override
     public TqlElement visitChildren(RuleNode node) {
         throw new TqlException("Unhandled children node: " + node.getText());
+    }
+
+    /**
+     * The single quote is used in the antlr grammar as a litteral delimeter, but can still be used inside a litteral.
+     * To avoid literals being truncated when parsed by antlr, single quotes are escaped by the tql clients, and then
+     * need to be unescaped after the parse operation.
+     *
+     * <pre>
+     * unescapeSingleQuote(null)       = null
+     * unescapeSingleQuote("O\'Reilly")= "O'Reilly"
+     * unescapeSingleQuote("\\")= "\\"
+     *
+     * </pre>
+     *
+     * @param token the parsed token
+     * @return the token unescaped for single quotes
+     */
+    private String unescapeSingleQuote(String token) {
+        return token != null ? token.replaceAll("\\\\'", "'") : null;
     }
 }

--- a/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/api/TestTqlApi_Comply.java
+++ b/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/api/TestTqlApi_Comply.java
@@ -80,4 +80,22 @@ public class TestTqlApi_Comply extends TestTqlParser_Abstract {
         TqlElement tqlElement = complies("name", "");
         Assert.assertEquals(expected.toString(), tqlElement.toString());
     }
+
+    @Test
+    public void testApiFieldCompliesPattern9() throws Exception {
+        // TQL native query
+        TqlElement expected = doTest("name complies '\\''");
+        // TQL api query
+        TqlElement tqlElement = complies("name", "'");
+        Assert.assertEquals(expected.toString(), tqlElement.toString());
+    }
+
+    @Test
+    public void testApiFieldCompliesPattern10() throws Exception {
+        // TQL native query
+        TqlElement expected = doTest("name complies 'C\\'est quoi'");
+        // TQL api query
+        TqlElement tqlElement = complies("name", "C'est quoi");
+        Assert.assertEquals(expected.toString(), tqlElement.toString());
+    }
 }

--- a/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/api/TestTqlApi_Contains.java
+++ b/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/api/TestTqlApi_Contains.java
@@ -53,4 +53,12 @@ public class TestTqlApi_Contains extends TestTqlParser_Abstract {
         Assert.assertEquals(expected.toString(), tqlElement.toString());
     }
 
+    @Test
+    public void testApiFieldContains6() throws Exception {
+        TqlElement expected = doTest("name contains 'aze\\'rty'");
+        // TQL api query
+        TqlElement tqlElement = contains("name", "aze'rty");
+        Assert.assertEquals(expected.toString(), tqlElement.toString());
+    }
+
 }

--- a/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/api/TestTqlApi_FieldComparison.java
+++ b/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/api/TestTqlApi_FieldComparison.java
@@ -207,4 +207,12 @@ public class TestTqlApi_FieldComparison extends TestTqlParser_Abstract {
         Assert.assertEquals(expected.toString(), tqlElement.toString());
     }
 
+    @Test
+    public void testApiStringComparisonWithSingleQuote() throws Exception {
+        // TQL native query
+        TqlElement expected = doTest("field1 != 'fiel\\'d2'");
+        // TQL api query
+        TqlElement tqlElement = neq("field1", "fiel'd2");
+        Assert.assertEquals(expected.toString(), tqlElement.toString());
+    }
 }

--- a/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/api/TestTqlApi_Match.java
+++ b/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/api/TestTqlApi_Match.java
@@ -36,4 +36,13 @@ public class TestTqlApi_Match extends TestTqlParser_Abstract {
         Assert.assertEquals(expected.toString(), tqlElement.toString());
     }
 
+    @Test
+    public void testApiFieldMatchPattern4() throws Exception {
+        // TQL native query
+        TqlElement expected = doTest("name ~ '^[A-Z][\\'][a-z]*$'");
+        // TQL api query
+        TqlElement tqlElement = match("name", "^[A-Z]['][a-z]*$");
+        Assert.assertEquals(expected.toString(), tqlElement.toString());
+    }
+
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
The TQL support filters like : field = 'literal value'. The apostrophe ' is used as a delimiter, to let ANTLR find literal tokens. But if the literal itself contains an apostrophe, the TQL is not able do parse correctly the literal: depending of the whole filter parsed by TQL, either it leads to an exception being thrown during the parse operation, either the literal value is truncated and then the TQL results are not consistent with the filter.
 
**What is the chosen solution to this problem?**
- The TQL grammar now accepts literal with single quotes inside, eg _O'Reilly_ is now accepted. (see TQLParser.g4)
- After the parse operation, the grammar rules which use a literal value unescape single quotes from the literal inputs. (see TqlExpressionVisitor.java)
Only the apostrophe character is escaped, because it is the only character which is used by the TQL grammar, in the case of literal. 
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDS-3154
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
