### PR TITLE
fix: Additional fixes for TQL

### DIFF
--- a/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/TestTqlParser_AllFields.java
+++ b/daikon-tql/daikon-tql-core/src/test/java/org/talend/tql/TestTqlParser_AllFields.java
@@ -75,4 +75,25 @@ public class TestTqlParser_AllFields extends TestTqlParser_Abstract {
         String expected = "OrExpression{expressions=[AndExpression{expressions=[FieldBetweenExpression{field='AllFields{}', left=LiteralValue{literal=INT, value='0'}, right=LiteralValue{literal=INT, value='5'}, isLowerOpen=false, isUpperOpen=false}]}]}";
         Assert.assertEquals(expected, tqlElement.toString());
     }
+
+    @Test
+    public void testParseLiteralComparisonIn() throws Exception {
+        TqlElement tqlElement = doTest("* in ['value1', 'value2']");
+        String expected = "OrExpression{expressions=[AndExpression{expressions=[FieldInExpression{field='AllFields{}', values=[LiteralValue{literal=QUOTED_VALUE, value='value1'}, LiteralValue{literal=QUOTED_VALUE, value='value2'}]}]}]}";
+        Assert.assertEquals(expected, tqlElement.toString());
+    }
+
+    @Test
+    public void testParseLiteralComparisonMatches() throws Exception {
+        TqlElement tqlElement = doTest("* ~ '[a-z]+@daikon.[a-z]+'");
+        String expected = "OrExpression{expressions=[AndExpression{expressions=[FieldMatchesRegex{field='AllFields{}', regex='[a-z]+@daikon.[a-z]+'}]}]}";
+        Assert.assertEquals(expected, tqlElement.toString());
+    }
+
+    @Test
+    public void testParseLiteralComparisonContains() throws Exception {
+        TqlElement tqlElement = doTest("* contains 'value1'");
+        String expected = "OrExpression{expressions=[AndExpression{expressions=[FieldContainsExpression{field='AllFields{}', value='value1'}]}]}";
+        Assert.assertEquals(expected, tqlElement.toString());
+    }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
There were a few cases missing for support of "*" (all fields wildcard). This PR fixes the following limitations:
* Fix support of "*" when using "in" clause.
* Fix support of "*" when using "~" (regex match) clause.
* Fix support of "*" when using "contains" clause.

**What is the chosen solution to this problem?**
Fix the issues without breaking everything else :).

**Link to the JIRA issue**
Loosely related to implementation https://jira.talendforge.org/browse/TDP-4346.
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request