### PR TITLE
chore(release): made docker build for messages demo optional

### DIFF
--- a/daikon-messages/messages-demo/demo-listener/pom.xml
+++ b/daikon-messages/messages-demo/demo-listener/pom.xml
@@ -24,26 +24,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.3.3</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <repository>${project.groupId}/${project.artifactId}</repository>
-                    <tag>latest</tag>
-                    <buildArgs>
-                        <ARTIFACT>${project.build.finalName}.jar</ARTIFACT>
-                    </buildArgs>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -91,5 +71,36 @@
             <artifactId>kafka-avro-serializer</artifactId>
         </dependency>
     </dependencies>
-
+ <profiles>
+        <profile>
+            <id>docker</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>1.3.3</version>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <repository>${project.groupId}/${project.artifactId}</repository>
+                            <tag>latest</tag>
+                            <buildArgs>
+                                <ARTIFACT>${project.build.finalName}.jar</ARTIFACT>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/daikon-messages/messages-demo/demo-producer/pom.xml
+++ b/daikon-messages/messages-demo/demo-producer/pom.xml
@@ -68,26 +68,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <version>1.3.3</version>
-                <executions>
-                    <execution>
-                        <id>default</id>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <repository>${project.groupId}/${project.artifactId}</repository>
-                    <tag>latest</tag>
-                    <buildArgs>
-                        <ARTIFACT>${project.build.finalName}.jar</ARTIFACT>
-                    </buildArgs>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 
@@ -135,6 +115,38 @@
             <artifactId>kafka-avro-serializer</artifactId>
         </dependency>
     </dependencies>
+    <profiles>
+        <profile>
+            <id>docker</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.spotify</groupId>
+                        <artifactId>dockerfile-maven-plugin</artifactId>
+                        <version>1.3.3</version>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <repository>${project.groupId}/${project.artifactId}</repository>
+                            <tag>latest</tag>
+                            <buildArgs>
+                                <ARTIFACT>${project.build.finalName}.jar</ARTIFACT>
+                            </buildArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 
 </project>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
A docker image is build for demo projects which is not usefull at all and also fail on mac machine because of the spotify maven plugin 

**What is the chosen solution to this problem?**
Docker build was made optional using a -Pdocker maven option. (The build on mac will still fail).

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
