### PR TITLE
fix(): Delete OperationTypes from header

### DIFF
--- a/daikon-messages/messages-model/src/main/avro/MessageHeader.avsc
+++ b/daikon-messages/messages-model/src/main/avro/MessageHeader.avsc
@@ -50,16 +50,6 @@
       }
     },
     {
-      "name" : "operationType",
-      "doc": "A operation can be either a creation, update, deletion, read",
-      "type" : ["null", {
-        "type": "enum",
-        "name": "OperationTypes",
-        "symbols" : ["CREATION", "DELETION", "UPDATE", "READ"]
-      }],
-      "default": null
-    },
-    {
       "name" : "name",
       "doc" : "The message name - identifies the purpose of the message (e.g. datasetCreated, createUser)",
       "type" : "string"

--- a/daikon-messages/messages-model/src/test/java/org/talend/daikon/messages/header/TestMessageHeaderExtractor.java
+++ b/daikon-messages/messages-model/src/test/java/org/talend/daikon/messages/header/TestMessageHeaderExtractor.java
@@ -26,7 +26,6 @@ import org.junit.rules.ExpectedException;
 import org.talend.daikon.messages.MessageHeader;
 import org.talend.daikon.messages.MessageIssuer;
 import org.talend.daikon.messages.MessageTypes;
-import org.talend.daikon.messages.OperationTypes;
 import org.talend.daikon.messages.header.consumer.MessageHeaderExtractor;
 
 public class TestMessageHeaderExtractor {
@@ -66,8 +65,8 @@ public class TestMessageHeaderExtractor {
 
         IndexedRecord messageHeader = new GenericRecordBuilder(headerSchema).set("id", "My id")
                 .set("correlationId", "Correlation id").set("timestamp", 123L).set("issuer", issuer).set("type", "COMMAND")
-                .set("operationType", OperationTypes.CREATION).set("name", "name").set("tenantId", "tenantId")
-                .set("userId", "userId").set("securityToken", "securityToken").build();
+                .set("name", "name").set("tenantId", "tenantId").set("userId", "userId").set("securityToken", "securityToken")
+                .build();
 
         IndexedRecord message = new GenericRecordBuilder(messageSchema).set("header", messageHeader).set("customField", "ABC")
                 .build();


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

The field OperationTypes  was accidently merged on master. The goal of this PR is to remove it

**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
