### PR TITLE
feat(TPSVC-5042) Tlnd application identifiers used by Talend services

### DIFF
--- a/daikon-messages/messages-model/src/main/avro/MessageHeader.avsc
+++ b/daikon-messages/messages-model/src/main/avro/MessageHeader.avsc
@@ -24,7 +24,7 @@
         "fields": [
           {
             "name": "application",
-            "doc" : "Application identifier (e.g TDP, TDC, Streams ...)",
+            "doc" : "Application identifier (TDP, TDC, DSS ...). The application identifiers are defined in the class org.talend.daikon.messages.TalendApplication",
             "type": "string"
           },
           {

--- a/daikon-messages/messages-model/src/main/java/org/talend/daikon/messages/TalendApplication.java
+++ b/daikon-messages/messages-model/src/main/java/org/talend/daikon/messages/TalendApplication.java
@@ -1,0 +1,72 @@
+package org.talend.daikon.messages;
+
+/**
+ * Constants for Talend application identifiers used across Talend (AccountService, Provisioning services, Portal, License
+ * Manager...).
+ */
+public class TalendApplication {
+
+    /**
+     * Talend ESB
+     */
+    public static final String ESB = "ESB";
+
+    /**
+     * Talend iPaas
+     */
+    public static final String TIPAAS = "TIPAAS";
+
+    /**
+     * Master Data Management
+     */
+    public static final String MDM = "MDM";
+
+    /**
+     * Talend Studio
+     */
+    public static final String STUDIO = "STUDIO";
+
+    /**
+     * Talend Administration Center
+     */
+    public static final String TAC = "TAC";
+
+    /**
+     * Talend Data Preparation
+     */
+    public static final String TDP = "TDP";
+
+    /**
+     * Talend Data Quality
+     */
+    public static final String TDQ = "TDQ";
+
+    /**
+     * Talend Data Stewardship
+     */
+    public static final String TDS = "TDS";
+
+    /**
+     * DataStreams
+     */
+    public static final String DSS = "DSS";
+
+    /**
+     * Talend Management Console
+     */
+    public static final String TMC = "TMC";
+
+    /**
+     * Talend Data Catalog
+     */
+    public static final String TDC = "TDC";
+
+    /**
+     * Only used for testing purposes
+     */
+    public static final String TEST = "TEST";
+
+    private TalendApplication() {
+        // No intention to instantiate this class
+    }
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Talend application and services need to use common application identifiers when they exchange messages (also when doing synchronous calls actually).
 
**What is the chosen solution to this problem?**
AccountService defines a list of app identifiers used already by the License manager and Provisioning Service too. In the current pull request, the list is moved in daikon-messages to be available for all services.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-3954
https://jira.talendforge.org/browse/TPSVC-5042

**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
