### PR TITLE
fix(TDKN-198): Add support for list match in TQL -> BeanPredicate con…

### DIFF
--- a/daikon-tql/daikon-tql-bean/pom.xml
+++ b/daikon-tql/daikon-tql-bean/pom.xml
@@ -24,5 +24,9 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
@@ -12,34 +12,60 @@
 
 package org.talend.tql.bean;
 
+import org.apache.commons.lang.ObjectUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.WordUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.talend.tql.model.AllFields;
+import org.talend.tql.model.AndExpression;
+import org.talend.tql.model.ComparisonExpression;
+import org.talend.tql.model.ComparisonOperator;
+import org.talend.tql.model.Expression;
+import org.talend.tql.model.FieldBetweenExpression;
+import org.talend.tql.model.FieldCompliesPattern;
+import org.talend.tql.model.FieldContainsExpression;
+import org.talend.tql.model.FieldInExpression;
+import org.talend.tql.model.FieldIsEmptyExpression;
+import org.talend.tql.model.FieldIsInvalidExpression;
+import org.talend.tql.model.FieldIsValidExpression;
+import org.talend.tql.model.FieldMatchesRegex;
+import org.talend.tql.model.FieldReference;
+import org.talend.tql.model.LiteralValue;
+import org.talend.tql.model.NotExpression;
+import org.talend.tql.model.OrExpression;
+import org.talend.tql.model.TqlElement;
+import org.talend.tql.visitor.IASTVisitor;
+
+import java.lang.reflect.Method;
+import java.text.ParseException;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
 import static java.lang.Double.parseDouble;
 import static java.lang.String.valueOf;
 import static java.util.Collections.singleton;
 import static java.util.Optional.of;
 import static java.util.stream.Stream.concat;
 import static org.apache.commons.lang.StringUtils.equalsIgnoreCase;
-
-import java.lang.reflect.Method;
-import java.text.ParseException;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import org.apache.commons.lang.ObjectUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.commons.lang.WordUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.talend.tql.model.*;
-import org.talend.tql.visitor.IASTVisitor;
+import static org.talend.tql.bean.MethodAccessorFactory.build;
 
 /**
  * A {@link IASTVisitor} implementation that generates a {@link Predicate predicate} that allows matching on a
  * <code>T</code> instance.
- * 
+ *
  * @param <T> The bean class.
  */
 public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
@@ -50,19 +76,19 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
 
     private final Deque<String> literals = new ArrayDeque<>();
 
-    private final Deque<Method[]> currentMethods = new ArrayDeque<>();
+    private final Deque<MethodAccessor[]> currentMethods = new ArrayDeque<>();
 
     public BeanPredicateVisitor(Class<T> targetClass) {
         this.targetClass = targetClass;
     }
 
-    private static Object invoke(Object o, Method[] methods) {
+    private static Stream<Object> invoke(Object o, MethodAccessor[] methods) {
         try {
-            Object currentObject = o;
-            for (Method method : methods) {
-                currentObject = method.invoke(currentObject);
+            Set<Object> currentObject = Collections.singleton(o);
+            for (MethodAccessor method : methods) {
+                currentObject = method.getValues(currentObject);
             }
-            return currentObject;
+            return currentObject.stream();
         } catch (Exception e) {
             throw new IllegalArgumentException("Unable to invoke methods on '" + o + "'.", e);
         }
@@ -71,7 +97,7 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
     /**
      * Test a string value against a pattern returned during value analysis.
      *
-     * @param value A string value. May be null.
+     * @param value   A string value. May be null.
      * @param pattern A pattern as returned in value analysis.
      * @return <code>true</code> if value complies, <code>false</code> otherwise.
      */
@@ -123,6 +149,10 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
         return of(predicate).map(Unchecked::new).orElseGet(() -> new Unchecked<>(o -> false));
     }
 
+    private static <T> Predicate<T> anyMatch(MethodAccessor[] getters, Predicate<T> predicate) {
+        return root -> invoke(root, getters).map(o -> (T) o).anyMatch(unchecked(predicate));
+    }
+
     @Override
     public Predicate<T> visit(TqlElement tqlElement) {
         throw new UnsupportedOperationException();
@@ -146,11 +176,11 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
         return null;
     }
 
-    private Method[] getMethods(FieldReference fieldReference) {
+    private MethodAccessor[] getMethods(FieldReference fieldReference) {
         return getMethods(fieldReference.getPath());
     }
 
-    private Method[] getMethods(String field) {
+    private MethodAccessor[] getMethods(String field) {
         StringTokenizer tokenizer = new StringTokenizer(field, ".");
         List<String> methodNames = new ArrayList<>();
         while (tokenizer.hasMoreTokens()) {
@@ -158,12 +188,12 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
         }
 
         Class currentClass = targetClass;
-        LinkedList<Method> methods = new LinkedList<>();
+        LinkedList<MethodAccessor> methods = new LinkedList<>();
         for (String methodName : methodNames) {
             if ("_class".equals(methodName)) {
                 try {
-                    methods.add(Class.class.getMethod("getClass"));
-                    methods.add(Class.class.getMethod("getName"));
+                    methods.add(build(Class.class.getMethod("getClass")));
+                    methods.add(build(Class.class.getMethod("getName")));
                 } catch (NoSuchMethodException e) {
                     throw new IllegalArgumentException("Unable to get methods for class' name.", e);
                 }
@@ -175,7 +205,7 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
                 final int beforeFind = methods.size();
                 for (String getterCandidate : getterCandidates) {
                     try {
-                        methods.add(currentClass.getMethod(getterCandidate));
+                        methods.add(build(currentClass.getMethod(getterCandidate)));
                         break;
                     } catch (Exception e) {
                         LOGGER.debug("Can't find getter '{}'.", field, e);
@@ -188,7 +218,7 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
                 }
             }
         }
-        return methods.toArray(new Method[0]);
+        return methods.toArray(new MethodAccessor[0]);
     }
 
     @Override
@@ -242,7 +272,8 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
         }
     }
 
-    private Predicate<T> getComparisonPredicate(Method[] getters, ComparisonExpression comparisonExpression, Object value) {
+    private Predicate<T> getComparisonPredicate(MethodAccessor[] getters, ComparisonExpression comparisonExpression,
+            Object value) {
         // Standard methods
         final ComparisonOperator operator = comparisonExpression.getOperator();
         switch (operator.getOperator()) {
@@ -263,46 +294,34 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
         }
     }
 
-    private Predicate<T> neq(Object value, Method[] getters) {
-        return unchecked( //
-                o -> !ObjectUtils.equals(invoke(o, getters), value) //
-        );
+    private Predicate<T> neq(Object value, MethodAccessor[] accessors) {
+        return anyMatch(accessors, o -> !ObjectUtils.equals(o, value));
     }
 
-    private Predicate<T> gt(Object value, Method[] getters) {
-        return unchecked( //
-                o -> parseDouble(valueOf(invoke(o, getters))) > parseDouble(valueOf(value)) //
-        );
+    private Predicate<T> gt(Object value, MethodAccessor[] accessors) {
+        return anyMatch(accessors, o -> parseDouble(valueOf(o)) > parseDouble(valueOf(value)));
     }
 
-    private Predicate<T> gte(Object value, Method[] getters) {
-        return unchecked( //
-                o -> parseDouble(valueOf(invoke(o, getters))) >= parseDouble(valueOf(value)) //
-        );
+    private Predicate<T> gte(Object value, MethodAccessor[] accessors) {
+        return anyMatch(accessors, o -> parseDouble(valueOf(o)) >= parseDouble(valueOf(value)));
     }
 
-    private Predicate<T> lt(Object value, Method[] getters) {
-        return unchecked( //
-                o -> parseDouble(valueOf(invoke(o, getters))) < parseDouble(valueOf(value)) //
-        );
+    private Predicate<T> lt(Object value, MethodAccessor[] accessors) {
+        return anyMatch(accessors, o -> parseDouble(valueOf(o)) < parseDouble(valueOf(value)));
     }
 
-    private Predicate<T> lte(Object value, Method[] getters) {
-        return unchecked( //
-                o -> parseDouble(valueOf(invoke(o, getters))) <= parseDouble(valueOf(value)) //
-        );
+    private Predicate<T> lte(Object value, MethodAccessor[] accessors) {
+        return anyMatch(accessors, o -> parseDouble(valueOf(o)) <= parseDouble(valueOf(value)));
     }
 
-    private Predicate<T> eq(Object value, Method[] getters) {
-        return unchecked( //
-                o -> equalsIgnoreCase(valueOf(invoke(o, getters)), valueOf(value)) //
-        );
+    private Predicate<T> eq(Object value, MethodAccessor[] accessors) {
+        return anyMatch(accessors, o -> equalsIgnoreCase(valueOf(o), valueOf(value)));
     }
 
     @Override
     public Predicate<T> visit(FieldInExpression fieldInExpression) {
         fieldInExpression.getField().accept(this);
-        final Method[] methods = currentMethods.pop();
+        final MethodAccessor[] methods = currentMethods.pop();
 
         final LiteralValue[] values = fieldInExpression.getValues();
         if (values.length > 0) {
@@ -320,7 +339,7 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
     @Override
     public Predicate<T> visit(FieldIsEmptyExpression fieldIsEmptyExpression) {
         fieldIsEmptyExpression.getField().accept(this);
-        final Method[] methods = currentMethods.pop();
+        final MethodAccessor[] methods = currentMethods.pop();
         return unchecked(o -> StringUtils.isEmpty(valueOf(invoke(o, methods))));
     }
 
@@ -337,25 +356,25 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
     @Override
     public Predicate<T> visit(FieldMatchesRegex fieldMatchesRegex) {
         fieldMatchesRegex.getField().accept(this);
-        final Method[] methods = currentMethods.pop();
+        final MethodAccessor[] methods = currentMethods.pop();
 
         final Pattern pattern = Pattern.compile(fieldMatchesRegex.getRegex());
-        return unchecked(o -> pattern.matcher(valueOf(invoke(o, methods))).matches());
+        return anyMatch(methods, o -> pattern.matcher(valueOf(o)).matches());
     }
 
     @Override
     public Predicate<T> visit(FieldCompliesPattern fieldCompliesPattern) {
         fieldCompliesPattern.getField().accept(this);
-        final Method[] methods = currentMethods.pop();
+        final MethodAccessor[] methods = currentMethods.pop();
 
         final String pattern = fieldCompliesPattern.getPattern();
-        return unchecked(o -> complies(valueOf(invoke(o, methods)), pattern));
+        return anyMatch(methods, o -> complies(valueOf(o), pattern));
     }
 
     @Override
     public Predicate<T> visit(FieldBetweenExpression fieldBetweenExpression) {
         fieldBetweenExpression.getField().accept(this);
-        final Method[] methods = currentMethods.pop();
+        final MethodAccessor[] methods = currentMethods.pop();
 
         fieldBetweenExpression.getLeft().accept(this);
         fieldBetweenExpression.getRight().accept(this);
@@ -385,9 +404,9 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
     @Override
     public Predicate<T> visit(FieldContainsExpression fieldContainsExpression) {
         fieldContainsExpression.getField().accept(this);
-        final Method[] methods = currentMethods.pop();
+        final MethodAccessor[] methods = currentMethods.pop();
 
-        return unchecked(o -> StringUtils.containsIgnoreCase(valueOf(invoke(o, methods)), fieldContainsExpression.getValue()));
+        return anyMatch(methods, o -> StringUtils.containsIgnoreCase(valueOf(o), fieldContainsExpression.getValue()));
     }
 
     @Override
@@ -398,12 +417,12 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
         return null;
     }
 
-    private void visitClassMethods(Class targetClass, Set<Class> visitedClasses, Method... previous) {
-        List<Method> previousMethods = Arrays.asList(previous);
+    private void visitClassMethods(Class targetClass, Set<Class> visitedClasses, MethodAccessor... previous) {
+        List<MethodAccessor> previousMethods = Arrays.asList(previous);
         for (Method method : targetClass.getMethods()) {
             if (method.getName().startsWith("get") || method.getName().startsWith("is")) {
-                final Method[] path = concat(previousMethods.stream(), Stream.of(method)).collect(Collectors.toList())
-                        .toArray(new Method[0]);
+                final MethodAccessor[] path = concat(previousMethods.stream(), Stream.of(build(method)))
+                        .toArray(MethodAccessor[]::new);
                 currentMethods.push(path);
 
                 // Recursively get methods to nested classes (and prevent infinite recursions).

--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/IterableMethodAccessor.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/IterableMethodAccessor.java
@@ -1,0 +1,43 @@
+package org.talend.tql.bean;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * A {@link MethodAccessor} implementation to handle method that returns an {@link Iterable}.
+ *
+ * @see UnaryMethodAccessor
+ */
+class IterableMethodAccessor implements MethodAccessor {
+
+    private final Method method;
+
+    IterableMethodAccessor(Method method) {
+        this.method = method;
+    }
+
+    @Override
+    public Set<Object> getValues(Set<Object> o) {
+        return o.stream().flatMap(value -> {
+            try {
+                return StreamSupport.stream(((Iterable<Object>) method.invoke(value)).spliterator(), false);
+            } catch (Exception e) {
+                throw new UnsupportedOperationException("Not able to retrieve values", e);
+            }
+        }).collect(Collectors.toSet());
+
+    }
+
+    @Override
+    public Class getReturnType() {
+        try {
+            final ParameterizedType returnType = (ParameterizedType) method.getGenericReturnType();
+            return Class.forName(returnType.getActualTypeArguments()[0].getTypeName());
+        } catch (ClassNotFoundException e) {
+            throw new UnsupportedOperationException("Can't find collection return type '" + method + "'.");
+        }
+    }
+}

--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/MethodAccessor.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/MethodAccessor.java
@@ -1,0 +1,26 @@
+package org.talend.tql.bean;
+
+import java.util.Set;
+
+/**
+ * A utility to access method return objects and encapsulate different behaviors to apply in case of iterable values or
+ * unary values.
+ *
+ * @see MethodAccessorFactory
+ */
+interface MethodAccessor {
+
+    /**
+     * Apply the method on <b>all</b> input values and return all the values returned by method invocations on <code>o</code>.
+     *
+     * @param o All the values to apply.
+     * @return A new {@link Set} that contains values of method invocations on <code>o</code>.
+     */
+    Set<Object> getValues(Set<Object> o);
+
+    /**
+     * @return The class of the element returned by method. For Iterable based accessors, this should return the Iterable
+     * item type instead of the Iterable itself.
+     */
+    Class getReturnType();
+}

--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/MethodAccessorFactory.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/MethodAccessorFactory.java
@@ -1,0 +1,20 @@
+package org.talend.tql.bean;
+
+import java.lang.reflect.Method;
+
+/**
+ * A factory for {@link MethodAccessor} that selects the right implementation based on {@link Method#getReturnType()}.
+ */
+class MethodAccessorFactory {
+
+    private MethodAccessorFactory() {
+    }
+
+    static MethodAccessor build(Method method) {
+        if (Iterable.class.isAssignableFrom(method.getReturnType())) {
+            return new IterableMethodAccessor(method);
+        } else {
+            return new UnaryMethodAccessor(method);
+        }
+    }
+}

--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/UnaryMethodAccessor.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/UnaryMethodAccessor.java
@@ -1,0 +1,35 @@
+package org.talend.tql.bean;
+
+import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A {@link MethodAccessor} implementation to handle method that returns a single value (not an {@link Iterable}).
+ *
+ * @see IterableMethodAccessor
+ */
+class UnaryMethodAccessor implements MethodAccessor {
+
+    private final Method method;
+
+    UnaryMethodAccessor(Method method) {
+        this.method = method;
+    }
+
+    @Override
+    public Set<Object> getValues(Set<Object> o) {
+        return o.stream().map(value -> {
+            try {
+                return method.invoke(value);
+            } catch (Exception e) {
+                throw new UnsupportedOperationException("Not able to retrieve values", e);
+            }
+        }).collect(Collectors.toSet());
+    }
+
+    @Override
+    public Class getReturnType() {
+        return method.getReturnType();
+    }
+}

--- a/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
+++ b/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
@@ -3,6 +3,8 @@ package org.talend.tql.bean;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 
 import org.junit.Test;
@@ -314,6 +316,18 @@ public class BeanPredicateVisitorTest {
     }
 
     @Test
+    public void equalsShouldMatchBeanOnList() throws Exception {
+        // given
+        final Expression query = Tql.parse("nestedBeans.nestedValue = 'nested'");
+
+        // when
+        final Predicate<Bean> predicate = query.accept(new BeanPredicateVisitor<>(Bean.class));
+
+        // then
+        assertTrue(predicate.test(bean));
+    }
+
+    @Test
     public void equalsShouldMatchBeanOnNested() throws Exception {
         // given
         final Expression query = Tql.parse("nested.nestedValue = 'nested'");
@@ -360,6 +374,10 @@ public class BeanPredicateVisitorTest {
 
     // Test class
     public static class Bean {
+
+        public List<NestedBean> getNestedBeans() {
+            return Arrays.asList(new NestedBean(), new NestedBean());
+        }
 
         public String getValue() {
             return "value";

--- a/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
+++ b/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.junit.Test;
 import org.talend.tql.model.Expression;
 import org.talend.tql.parser.Tql;
@@ -372,6 +373,18 @@ public class BeanPredicateVisitorTest {
         query.accept(new BeanPredicateVisitor<>(Bean.class));
     }
 
+    @Test
+    public void shouldMatchOnJsonPropertyName() {
+        // given
+        final Expression query = Tql.parse("aDifferentName = 'myValue'");
+
+        // when
+        final Predicate<Bean> predicate = query.accept(new BeanPredicateVisitor<>(Bean.class));
+
+        // then
+        assertTrue(predicate.test(bean));
+    }
+
     // Test class
     public static class Bean {
 
@@ -389,6 +402,16 @@ public class BeanPredicateVisitorTest {
 
         public NestedBean getNested() {
             return new NestedBean();
+        }
+
+        @JsonProperty("aDifferentName")
+        public String getMyValue() {
+            return "myValue";
+        }
+
+        @JsonProperty("aDifferentName")
+        public void setMyValue() {
+            // No code needed, just to ensure setters are not detected.
         }
     }
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
This PR fixes 2 issues:
1) Support for Iterable<T> getters in the predicates (in case part of the field name contains List<T> elements)
2) Use of @JsonProperty to find getter instead of rely on getter name convention (name match still has higher match than annotation's).
 
**What is the chosen solution to this problem?**
1) Code can now match a predicate against several values.
2) When getter is not found by name, try methods with @JsonProperty annotations.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-198
https://jira.talendforge.org/browse/TDKN-199
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request