### PR TITLE
fix(DEVOPS-1729): Fix distribution management for daikon-spring-mongo

### DIFF
--- a/daikon-spring/daikon-spring-mongo/pom.xml
+++ b/daikon-spring/daikon-spring-mongo/pom.xml
@@ -16,6 +16,7 @@
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<talend_snapshots_deployment>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</talend_snapshots_deployment>
 		<spring-core.version>4.3.4.RELEASE</spring-core.version>
 		<spring-data-mongodb.version>1.8.2.RELEASE</spring-data-mongodb.version>
 		<jackson.version>2.9.4</jackson.version>
@@ -65,16 +66,16 @@
             <version>21.0</version>
         </dependency>
     </dependencies>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>talend_nexus_deployment</id>
-            <url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceSnapshot/</url>
-        </snapshotRepository>
-        <repository>
-            <id>talend_nexus_deployment</id>
-            <url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
-        </repository>
-    </distributionManagement>
+	<distributionManagement>
+		<snapshotRepository>
+			<id>talend_nexus_deployment</id>
+			<url>${talend_snapshots_deployment}</url>
+		</snapshotRepository>
+		<repository>
+			<id>talend_nexus_deployment</id>
+			<url>https://artifacts-oss.talend.com/nexus/content/repositories/TalendOpenSourceRelease/</url>
+		</repository>
+	</distributionManagement>
     <pluginRepositories>
         <pluginRepository>
             <id>com.springsource.repository.bundles.release</id>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

There was a hardcoded repository URL in `daikon-spring-mongo` that was pushing branch build to Talend's snapshot repository. This was causing build instability for apps that depends on `daikon-spring-mongo` because it could bring branch version into app build.

**What is the chosen solution to this problem?**
 
Use the property changed by CI (${talend_snapshots_deployment}) to select Nexus repository.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/DEVOPS-1729
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request