### PR TITLE
fix(TDP-5779): Update Spring Sleuth configuration for Span creation

### DIFF
--- a/daikon-messages/messages-model-spring-support/src/main/java/org/talend/daikon/messages/spring/consumer/ExecutionContextUpdaterConfiguration.java
+++ b/daikon-messages/messages-model-spring-support/src/main/java/org/talend/daikon/messages/spring/consumer/ExecutionContextUpdaterConfiguration.java
@@ -12,28 +12,21 @@
 // ============================================================================
 package org.talend.daikon.messages.spring.consumer;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.talend.daikon.messages.header.consumer.*;
+import org.talend.daikon.messages.header.consumer.CorrelationIdSetter;
+import org.talend.daikon.messages.header.consumer.ExecutionContextUpdater;
+import org.talend.daikon.messages.header.consumer.ExecutionContextUpdaterImpl;
+import org.talend.daikon.messages.header.consumer.SecurityTokenSetter;
+import org.talend.daikon.messages.header.consumer.TenantIdSetter;
+import org.talend.daikon.messages.header.consumer.UserIdSetter;
 
 @Configuration
 public class ExecutionContextUpdaterConfiguration {
 
-    @Autowired
-    private CorrelationIdSetter correlationIdSetter;
-
-    @Autowired
-    private TenantIdSetter tenantIdSetter;
-
-    @Autowired
-    private SecurityTokenSetter securityTokenSetter;
-
-    @Autowired
-    private UserIdSetter userIdSetter;
-
     @Bean
-    public ExecutionContextUpdater executionContextUpdater() {
+    public ExecutionContextUpdater executionContextUpdater(CorrelationIdSetter correlationIdSetter, TenantIdSetter tenantIdSetter,
+            SecurityTokenSetter securityTokenSetter, UserIdSetter userIdSetter) {
         return new ExecutionContextUpdaterImpl(correlationIdSetter, tenantIdSetter, userIdSetter, securityTokenSetter);
     }
 

--- a/daikon-messages/messages-model-spring-support/src/main/java/org/talend/daikon/messages/spring/consumer/sleuth/SpringSleuthSettersConfiguration.java
+++ b/daikon-messages/messages-model-spring-support/src/main/java/org/talend/daikon/messages/spring/consumer/sleuth/SpringSleuthSettersConfiguration.java
@@ -12,7 +12,6 @@
 // ============================================================================
 package org.talend.daikon.messages.spring.consumer.sleuth;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.cloud.sleuth.Span;
 import org.springframework.cloud.sleuth.Tracer;
@@ -25,18 +24,20 @@ import org.talend.daikon.messages.header.consumer.CorrelationIdSetter;
 public class SpringSleuthSettersConfiguration {
 
     @Bean
-    public CorrelationIdSetter correlationIdSetter(@Autowired final Tracer tracer) {
+    public CorrelationIdSetter correlationIdSetter(Tracer tracer) {
         return new CorrelationIdSetter() {
 
             @Override
             public void setCurrentCorrelationId(String correlationId) {
                 long spanId = 0;
+                String name = "";
                 Span currentSpan = tracer.getCurrentSpan();
                 if (currentSpan != null) {
                     spanId = currentSpan.getSpanId();
+                    name = currentSpan.getName();
                 }
                 long traceId = Span.hexToId(correlationId, 0);
-                Span span = Span.builder().traceId(traceId).spanId(spanId).shared(true).build();
+                Span span = Span.builder().name(name).traceId(traceId).spanId(spanId).shared(true).build();
                 tracer.continueSpan(span);
             }
         };


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

The current Sleuth configuration use the correlation ID as traceId for the span but without re-use the current span name (which is a mandatory field)

**What is the chosen solution to this problem?**

Use the current span name value for the new span name
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5779
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
