### PR TITLE
fix(TDP-4665): add talend prefix for properties names

### DIFF
--- a/daikon-spring/daikon-spring-zipkin/pom.xml
+++ b/daikon-spring/daikon-spring-zipkin/pom.xml
@@ -9,29 +9,39 @@
 
     <artifactId>daikon-spring-zipkin</artifactId>
 
+    <properties>
+        <spring-boot-dependencies.version>1.5.14.RELEASE</spring-boot-dependencies.version>
+        <spring-cloud-dependencies.version>Edgware.SR3</spring-cloud-dependencies.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring-cloud-dependencies.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
-        <dependency>
-            <groupId>io.zipkin.reporter2</groupId>
-            <artifactId>zipkin-sender-kafka11</artifactId>
-            <version>2.6.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>${spring.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-            <version>${spring.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>1.5.3.RELEASE</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.reporter2</groupId>
+            <artifactId>zipkin-sender-kafka11</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/EnableZipkinKafkaSender.java
+++ b/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/EnableZipkinKafkaSender.java
@@ -1,0 +1,15 @@
+package org.talend.daikon.zipkin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Import(ZipkinKafkaSenderConfiguration.class)
+public @interface EnableZipkinKafkaSender {
+
+}

--- a/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/ZipkinKafkaProperties.java
+++ b/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/ZipkinKafkaProperties.java
@@ -1,0 +1,33 @@
+package org.talend.daikon.zipkin;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "talend.zipkin.kafka")
+public class ZipkinKafkaProperties {
+
+    /**
+     * Kafka Topic
+     */
+    private String topic = "zipkin";
+
+    /**
+     * Broker dedicated to the infrastructure log events.
+     */
+    private String bootstrapServers;
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+
+    public void setBootstrapServers(String bootstrapServers) {
+        this.bootstrapServers = bootstrapServers;
+    }
+}

--- a/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/ZipkinKafkaSenderConfiguration.java
+++ b/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/ZipkinKafkaSenderConfiguration.java
@@ -1,47 +1,47 @@
 package org.talend.daikon.zipkin;
 
-import org.apache.kafka.common.serialization.ByteArraySerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import zipkin2.reporter.Sender;
-import zipkin2.reporter.kafka11.KafkaSender;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import zipkin2.reporter.Sender;
+import zipkin2.reporter.kafka11.KafkaSender;
+
 /**
  * Configures the zipkin kafka sender for another kafka broker than the functional broker.
- * spring.zipkin.kafka.bootstrapServers stores the broker dedicated to the infrastructure log events.
+ * @see ZipkinKafkaProperties
+ * @see KafkaSender
  */
 @Configuration
 @ConditionalOnClass(ByteArraySerializer.class)
-@ConditionalOnMissingBean(Sender.class)
-@ConditionalOnProperty(value = "spring.zipkin.enabled", havingValue = "true")
+@ConditionalOnProperty(value = "spring.zipkin.enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(ZipkinKafkaProperties.class)
 public class ZipkinKafkaSenderConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZipkinKafkaSenderConfiguration.class);
 
-    @Value("${spring.zipkin.kafka.topic:zipkin}")
-    private String topic;
-
-    @Value("${spring.zipkin.kafka.bootstrapServers}")
-    private String bootstrapServers;
-
     @Bean
-    public Sender kafkaSender() {
-        Map<String, Object> properties = new HashMap<>();
+    @ConditionalOnMissingBean
+    public Sender kafkaSender(ZipkinKafkaProperties kafkaProperties) {
+        LOG.info("building zipkin kafka sender with brokers [{}]", kafkaProperties.getBootstrapServers());
+
+        Map<String, Object> properties = new HashMap<>(2);
         properties.put("key.serializer", ByteArraySerializer.class.getName());
         properties.put("value.serializer", ByteArraySerializer.class.getName());
-        properties.put("bootstrap.servers", bootstrapServers);
 
-        LOG.info("building zipkin kafka sender with brokers " + bootstrapServers);
-
-        return KafkaSender.newBuilder().topic(this.topic).overrides(properties).build();
+        return KafkaSender.newBuilder() //
+                .topic(kafkaProperties.getTopic()) //
+                .bootstrapServers(kafkaProperties.getBootstrapServers()) //
+                .overrides(properties) //
+                .build();
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
* Don't use `spring.*` prefix for non spring configuration properties

* Zipkin is enabled by default so the configuration should match even if the `spring.zipkin.enabled` property is not set

* we can't enable/disable the configuration

**What is the chosen solution to this problem?**

* use `talend.*` prefix

* configuration match if the property is missing

* add a `@EnableZipkinKafkaSender`
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/TDP-4665 -->
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
