### PR TITLE
fix(TDP-4668) daikon spring zipkin conditions

### DIFF
--- a/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/ZipkinKafkaSenderConfiguration.java
+++ b/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/ZipkinKafkaSenderConfiguration.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,7 +24,7 @@ import zipkin2.reporter.kafka11.KafkaSender;
  */
 @Configuration
 @ConditionalOnClass(ByteArraySerializer.class)
-@ConditionalOnProperty(value = "spring.zipkin.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnProperty(value = "spring.zipkin.enabled", havingValue = "true")
 @EnableConfigurationProperties(ZipkinKafkaProperties.class)
 public class ZipkinKafkaSenderConfiguration {
 
@@ -31,16 +32,22 @@ public class ZipkinKafkaSenderConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public Sender kafkaSender(ZipkinKafkaProperties kafkaProperties) {
-        LOG.info("building zipkin kafka sender with brokers [{}]", kafkaProperties.getBootstrapServers());
+    public Sender kafkaSender(ZipkinKafkaProperties zipkinKafkaProperties, KafkaProperties kafkaProperties) {
+        String bootstrapServers = zipkinKafkaProperties.getBootstrapServers();
+
+        if (bootstrapServers == null) {
+            bootstrapServers = String.join(",", kafkaProperties.getBootstrapServers());
+        }
+
+        LOG.info("building zipkin kafka sender with brokers [{}]", bootstrapServers);
 
         Map<String, Object> properties = new HashMap<>(2);
         properties.put("key.serializer", ByteArraySerializer.class.getName());
         properties.put("value.serializer", ByteArraySerializer.class.getName());
 
         return KafkaSender.newBuilder() //
-                .topic(kafkaProperties.getTopic()) //
-                .bootstrapServers(kafkaProperties.getBootstrapServers()) //
+                .topic(zipkinKafkaProperties.getTopic()) //
+                .bootstrapServers(bootstrapServers) //
                 .overrides(properties) //
                 .build();
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

Do not load the Zipkin Configuration if the property `spring.zipkin.enabled` is not set to `true`.
 
**What is the chosen solution to this problem?**
 
Same solution than TDS:

* https://github.com/Talend/data-stewardship/blob/2fe91b0dcf73fbec28e0dd8c5102a516ab6528e0/data-stewardship-backend/data-history-service/src/main/java/org/talend/datasteward/util/HistoryZipkinKafkaSenderConfiguration.java#L26

**Link to the JIRA issue**
https://jira.talendforge.org/browse/4668
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
