### PR TITLE
chore(): downgrade kafka client version

### DIFF
--- a/daikon-spring/daikon-spring-zipkin/pom.xml
+++ b/daikon-spring/daikon-spring-zipkin/pom.xml
@@ -10,7 +10,7 @@
     <artifactId>daikon-spring-zipkin</artifactId>
 
     <properties>
-        <spring-boot-dependencies.version>1.5.14.RELEASE</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>1.5.2.RELEASE</spring-boot-dependencies.version>
         <spring-cloud-dependencies.version>Edgware.SR3</spring-cloud-dependencies.version>
     </properties>
 
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>1.0.1</version>
+            <version>0.10.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

Incompatibility between Daikon Kafka client and TDS/TDP Kafka client

**What is the chosen solution to this problem?**
Downgrading kafka client from client in order to use the same everywhere
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
