### PR TITLE
fix(TDP-4665): daikon-spring-zipkin should include zipkin-sender-kafka

### DIFF
--- a/daikon-spring/daikon-spring-zipkin/pom.xml
+++ b/daikon-spring/daikon-spring-zipkin/pom.xml
@@ -11,7 +11,6 @@
 
     <properties>
         <spring-boot-dependencies.version>1.5.2.RELEASE</spring-boot-dependencies.version>
-        <spring-cloud-dependencies.version>Edgware.SR3</spring-cloud-dependencies.version>
     </properties>
 
     <dependencyManagement>
@@ -20,13 +19,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot-dependencies.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-dependencies</artifactId>
-                <version>${spring-cloud-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -42,7 +34,7 @@
         <dependency>
             <groupId>io.zipkin.reporter2</groupId>
             <artifactId>zipkin-sender-kafka11</artifactId>
-            <scope>provided</scope>
+            <version>2.1.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

daikon-spring-zipkin use a zipkin kafka reporter which is not provided by the client (like TDP)
 
**What is the chosen solution to this problem?**

the zipkin kafka reporter library should be included in the daikon-spring-zipkin module
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/4665
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
