### PR TITLE
feat(TDP-5153): add method getSupportedFormats

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
+++ b/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
@@ -3,6 +3,8 @@ package org.talend.daikon.number;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -210,6 +212,17 @@ public class BigDecimalParser {
      */
     private static BigDecimal toBigDecimal(Number number) {
         return new BigDecimal(number.toString());
+    }
+
+    /**
+     * Get the supported decimal formats.
+     * <p>
+     * Useful to check if a number is supported and can be parsed.
+     * @return the list of supported Formats
+     */
+    public static List<DecimalFormat> getSupportedFormats() {
+        return Arrays.asList(US_DECIMAL_PATTERN, EU_DECIMAL_PATTERN, EU_PERCENTAGE_DECIMAL_PATTERN, US_PERCENTAGE_DECIMAL_PATTERN, //
+                US_SCIENTIFIC_DECIMAL_PATTERN, EU_SCIENTIFIC_DECIMAL_PATTERN);
     }
 
 }

--- a/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
+++ b/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
@@ -112,7 +112,7 @@ public class BigDecimalParser {
         }
     }
 
-    protected static DecimalFormatSymbols guessSeparators(String from) {
+    public static DecimalFormatSymbols guessSeparators(String from) {
         final DecimalFormatSymbols toReturn = DecimalFormatSymbols.getInstance(Locale.US);
 
         /*

--- a/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
+++ b/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
@@ -24,7 +24,7 @@ public class BigDecimalParser {
     private static final Pattern STARTS_WITH_DECIMAL_SEPARATOR_PATTERN = Pattern
             .compile("^[(-]?(?:\\d{3,}|\\d{0})([,.])\\d+[)]?");
 
-    private static final Pattern FEW_GROUP_SEP_PATTERN = Pattern.compile("^[(-]?\\d+([.,\\h']\\d{3}){2,}[)]?");
+    private static final Pattern FEW_GROUP_SEP_PATTERN = Pattern.compile("^[(-]?\\d+([.,\\h'])\\d{3}(\\1\\d{3})+[)]?");
 
     private static final Pattern TWO_DIFFERENT_SEPARATORS_PATTERN = Pattern.compile(".*\\d+([.\\h'])\\d+([,.])\\d+[)]?");
 

--- a/daikon/src/test/java/org/talend/daikon/number/BigDecimalParserTest.java
+++ b/daikon/src/test/java/org/talend/daikon/number/BigDecimalParserTest.java
@@ -3,7 +3,9 @@ package org.talend.daikon.number;
 import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
+import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.List;
 import java.util.Locale;
 
 import org.junit.After;
@@ -204,6 +206,12 @@ public class BigDecimalParserTest {
         assertGuessSeparators("45,5555", ',', '.');
         assertGuessSeparators("45.5555", '.', ',');
         assertGuessSeparators("45" + ((char) 160) + "555,5", ',', ((char) 160)); // char(160) is non-breaking space
+    }
+
+    @Test
+    public void testGetSupportedFormats() {
+        List<DecimalFormat> supportedFormats = BigDecimalParser.getSupportedFormats();
+        assertEquals(6, supportedFormats.size());
     }
 
     private void assertGuessSeparators(String value, char expectedDecimalSeparator, char expectedGroupingSeparator) {

--- a/daikon/src/test/java/org/talend/daikon/number/BigDecimalParserTest.java
+++ b/daikon/src/test/java/org/talend/daikon/number/BigDecimalParserTest.java
@@ -209,6 +209,12 @@ public class BigDecimalParserTest {
     }
 
     @Test
+    public void testGuessSeparatorsTDP5153() {
+        assertGuessSeparators("5 555,555", ',', ' ');
+        assertGuessSeparators("5.555,555", ',', '.');
+    }
+
+    @Test
     public void testGetSupportedFormats() {
         List<DecimalFormat> supportedFormats = BigDecimalParser.getSupportedFormats();
         assertEquals(6, supportedFormats.size());


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 We need to get the supported decimal formats in tdp, and also the method guessSeparators().

**What is the chosen solution to this problem?**
 The solution is to return the list of constants from the class BigDecimalParser and to make guessSeparators() public. 

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-5153
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
