### PR TITLE
fix(TDS-3653): escape special characters for mongo regex

### DIFF
--- a/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
+++ b/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
@@ -18,6 +18,8 @@ public class ASTVisitor implements IASTVisitor<Object> {
 
     public static final String MONGO_REGEX_IGNORE_CASE_OPTION = "i";
 
+    public static final String MONGO_ESCAPE_PATTERN = "[\\.\\^\\$\\*\\+\\?\\(\\)\\[\\{\\\\\\|]";
+
     private boolean isNegation = false;
 
     @Override
@@ -203,7 +205,7 @@ public class ASTVisitor implements IASTVisitor<Object> {
     public Object visit(FieldContainsExpression elt) {
         String options = elt.isCaseSensitive() ? "" : MONGO_REGEX_IGNORE_CASE_OPTION;
         String fieldName = (String) elt.getField().accept(this);
-        String value = elt.getValue();
+        String value = elt.getValue().replaceAll(MONGO_ESCAPE_PATTERN, "\\\\$0");
         if (!isNegation)
             return Criteria.where(fieldName).regex(value, options);
         return Criteria.where(fieldName).not().regex(value, options);
@@ -278,7 +280,7 @@ public class ASTVisitor implements IASTVisitor<Object> {
                 break;
             default:
                 // Special characters for PCRE syntax (used by mongoDB for regex) need to be escaped.
-                sb.append(String.valueOf(c).replaceAll("[\\.\\^\\$\\*\\+\\?\\(\\)\\[\\{\\\\\\|]", "\\\\$0"));
+                sb.append(String.valueOf(c).replaceAll(MONGO_ESCAPE_PATTERN, "\\\\$0"));
                 break;
             }
         }

--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Abstract.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Abstract.java
@@ -36,7 +36,8 @@ public abstract class TestMongoCriteria_Abstract {
 
     private final static Map<String, Double> RECORDS = Collections.unmodifiableMap(Stream
             .of(new AbstractMap.SimpleEntry<>("ghassen", 30d), new AbstractMap.SimpleEntry<>("Ghassen", 31.2d),
-                    new AbstractMap.SimpleEntry<>("Benoit", 29d), new AbstractMap.SimpleEntry<>("Benoit 2eme", 28.8d))
+                    new AbstractMap.SimpleEntry<>("Benoit", 29d), new AbstractMap.SimpleEntry<>("Benoit 2eme", 28.8d),
+                    new AbstractMap.SimpleEntry<>("invalid+*name", 42d))
             .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue)));
 
     private static MongoTemplate mongoTemplate;

--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Boolean.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Boolean.java
@@ -17,8 +17,9 @@ public class TestMongoCriteria_Boolean extends TestMongoCriteria_Abstract {
         Criteria expectedCriteria = Criteria.where("isGoodBoy").is(true);
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
-        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(2, records.size());
         Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("ghassen")).count());
+        Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("invalid+*name")).count());
     }
 
     @Test
@@ -52,8 +53,9 @@ public class TestMongoCriteria_Boolean extends TestMongoCriteria_Abstract {
         Criteria expectedCriteria = Criteria.where("isGoodBoy").ne(false);
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
-        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(2, records.size());
         Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("ghassen")).count());
+        Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("invalid+*name")).count());
     }
 
 }

--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Contain.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Contain.java
@@ -58,7 +58,7 @@ public class TestMongoCriteria_Contain extends TestMongoCriteria_Abstract {
         Criteria expectedCriteria = Criteria.where("name").regex("");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
-        Assert.assertEquals(4, records.size());
+        Assert.assertEquals(5, records.size());
     }
 
     @Test
@@ -79,5 +79,15 @@ public class TestMongoCriteria_Contain extends TestMongoCriteria_Abstract {
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(1, records.size());
         Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("Ghassen")).count());
+    }
+
+    @Test
+    public void testParseFieldContainsValue8() throws Exception {
+        Criteria criteria = doTest("name contains 'd+*'");
+        Criteria expectedCriteria = Criteria.where("name").regex("d\\+\\*");
+        Assert.assertEquals(expectedCriteria, criteria);
+        List<Record> records = this.getRecords(criteria);
+        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("invalid+*name")).count());
     }
 }

--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_ContainsIgnoreCase.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_ContainsIgnoreCase.java
@@ -58,7 +58,7 @@ public class TestMongoCriteria_ContainsIgnoreCase extends TestMongoCriteria_Abst
         Criteria expectedCriteria = Criteria.where("name").regex("");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
-        Assert.assertEquals(4, records.size());
+        Assert.assertEquals(5, records.size());
     }
 
     @Test
@@ -81,5 +81,15 @@ public class TestMongoCriteria_ContainsIgnoreCase extends TestMongoCriteria_Abst
         Assert.assertEquals(2, records.size());
         Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("ghassen")).count());
         Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("Ghassen")).count());
+    }
+
+    @Test
+    public void testParseFieldContainsIgnoreCaseValue8() throws Exception {
+        Criteria criteria = doTest("name containsIgnoreCase 'D+*'");
+        Criteria expectedCriteria = Criteria.where("name").regex("D\\+\\*");
+        Assert.assertEquals(expectedCriteria, criteria);
+        List<Record> records = this.getRecords(criteria);
+        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(1, records.stream().filter(r -> r.getName().equals("invalid+*name")).count());
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
When using TQL contains or containsIgnoreCase keywords, with search strings which contains special characters (+*,...), the TQL query fails. Because special characters must be escaped before applying a mongo regex.
This escape step was already done when calling the mongo $where operator, to perform regex on numeric fields, but was not done for text fields. This PR aims at escaping special characters for all regex queries.
 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDS-3653
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
