### PR TITLE
feat(TDQ-15748): use TDQ tool in bean predicate visitor

### DIFF
--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
@@ -41,6 +41,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.WordUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.talend.daikon.pattern.character.CharPatternToRegex;
 import org.talend.daikon.pattern.word.WordPatternToRegex;
 import org.talend.tql.model.*;
 import org.talend.tql.visitor.IASTVisitor;
@@ -85,47 +86,7 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
      * @return <code>true</code> if value complies, <code>false</code> otherwise.
      */
     private static boolean complies(String value, String pattern) {
-        if (value == null && pattern == null) {
-            return true;
-        }
-        if (value == null) {
-            return false;
-        }
-        // Character based patterns
-        if (StringUtils.containsAny(pattern, new char[] { 'A', 'a', '9' })) {
-            if (value.length() != pattern.length()) {
-                return false;
-            }
-            final char[] valueArray = value.toCharArray();
-            final char[] patternArray = pattern.toCharArray();
-            for (int i = 0; i < valueArray.length; i++) {
-                if (patternArray[i] == 'A') {
-                    if (!Character.isUpperCase(valueArray[i])) {
-                        return false;
-                    }
-                } else if (patternArray[i] == 'a') {
-                    if (!Character.isLowerCase(valueArray[i])) {
-                        return false;
-                    }
-                } else if (patternArray[i] == '9') {
-                    if (!Character.isDigit(valueArray[i])) {
-                        return false;
-                    }
-                } else {
-                    if (valueArray[i] != patternArray[i]) {
-                        return false;
-                    }
-                }
-            }
-        } else {
-            final DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
-            try {
-                formatter.toFormat().parseObject(value);
-            } catch (ParseException e) {
-                return false;
-            }
-        }
-        return true;
+        return value != null && pattern != null && value.matches(CharPatternToRegex.toRegex(pattern));
     }
 
     private static boolean wordComplies(String value, String pattern) {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Solve the divergence between different TQL *complies* implementations and delegate it to the TDQ-15748
 
**What is the chosen solution to this problem?**
Use CharPatternToRegex from TDQ instead of the erronous custom complies implementation.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/15748
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
