### PR TITLE
feat(TDS-2682): escape '/' for javascript.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/pattern/PatternRegexUtils.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/PatternRegexUtils.java
@@ -4,10 +4,14 @@ public class PatternRegexUtils {
 
     public static final String REGEX_ESCAPE_PATTERN = "[\\.\\^\\$\\*\\+\\?\\(\\)\\[\\]\\{\\}\\\\\\|]";
 
+    public static String escapeCharacters(String current) {
+        return escapeCharacters(current, false);
+    }
+
     public static String escapeCharacters(String current, boolean isForJavaScript) {
         String escaped = current.replaceAll(REGEX_ESCAPE_PATTERN, "\\\\$0");
         // For Javascript, '/' needs also to be escaped
-        if(isForJavaScript) {
+        if (isForJavaScript) {
             escaped = escaped.replaceAll("/", "\\\\$0");
         }
         return escaped;

--- a/daikon/src/main/java/org/talend/daikon/pattern/PatternRegexUtils.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/PatternRegexUtils.java
@@ -4,8 +4,12 @@ public class PatternRegexUtils {
 
     public static final String REGEX_ESCAPE_PATTERN = "[\\.\\^\\$\\*\\+\\?\\(\\)\\[\\]\\{\\}\\\\\\|]";
 
-    public static String escapeCharacters(String current) {
-        return current.replaceAll(REGEX_ESCAPE_PATTERN, "\\\\$0");
+    public static String escapeCharacters(String current, boolean isForJavaScript) {
+        String escaped = current.replaceAll(REGEX_ESCAPE_PATTERN, "\\\\$0");
+        // For Javascript, '/' needs also to be escaped
+        if(isForJavaScript) {
+            escaped = escaped.replaceAll("/", "\\\\$0");
+        }
+        return escaped;
     }
-
 }

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegex.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegex.java
@@ -61,7 +61,7 @@ public class CharPatternToRegex {
                 buildString(stringBuilder, regex9, consecutiveValues);
                 break;
             default:
-                String notRecognized = escapeCharacters(String.valueOf(Character.toChars(codePoint)));
+                String notRecognized = escapeCharacters(String.valueOf(Character.toChars(codePoint)), isForJavaScript);
                 buildString(stringBuilder, notRecognized, consecutiveValues);
                 break;
             }

--- a/daikon/src/main/java/org/talend/daikon/pattern/word/WordPatternToRegex.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/word/WordPatternToRegex.java
@@ -21,7 +21,7 @@ public class WordPatternToRegex {
             WordPattern wordPattern = WordPattern.get(current);
             String regex;
             if (wordPattern == null)
-                regex = escapeCharacters(current);
+                regex = escapeCharacters(current, false);
             else if (caseSensitive)
                 regex = wordPattern.getCaseSensitive();
             else

--- a/daikon/src/main/java/org/talend/daikon/pattern/word/WordPatternToRegex.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/word/WordPatternToRegex.java
@@ -21,7 +21,7 @@ public class WordPatternToRegex {
             WordPattern wordPattern = WordPattern.get(current);
             String regex;
             if (wordPattern == null)
-                regex = escapeCharacters(current, false);
+                regex = escapeCharacters(current);
             else if (caseSensitive)
                 regex = wordPattern.getCaseSensitive();
             else

--- a/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
+++ b/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
@@ -238,6 +238,7 @@ public class CharPatternToRegexTest {
         assertJavaScriptMatches("a]b", CharPatternToRegex.toJavaScriptRegex("a]a"));
         assertJavaScriptMatches("a+b", CharPatternToRegex.toJavaScriptRegex("a+a"));
         assertJavaScriptMatches("a*b", CharPatternToRegex.toJavaScriptRegex("a*a"));
+        assertJavaScriptMatches("a/b", CharPatternToRegex.toJavaScriptRegex("a/a"));
         assertEquals("At least one of the characters [({^+*|\\.?$})] is not well escaped",
                 "^\\[\\(\\{\\^\\+\\*\\|\\\\\\.\\?\\$\\}\\)\\]$", CharPatternToRegex.toJavaScriptRegex("[({^+*|\\.?$})]"));
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 Escape '/' for java script regex
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
