### PR TITLE
chore(TDQ-15975): Adapt japanese char-pattern with half-width / fullw…

### DIFF
--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Comply.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Comply.java
@@ -96,8 +96,7 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
     @Test
     public void testParseFieldCompliesPattern9() {
         Criteria criteria = doTest("name complies 'h'");
-        Criteria expectedCriteria = Criteria.where("name").regex(
-                "^(\\x{3041}|\\x{3043}|\\x{3045}|\\x{3047}|\\x{3049}|\\x{3063}|\\x{3083}|\\x{3085}|\\x{3087}|\\x{308E}|\\x{3095}|\\x{3096})$");
+        Criteria expectedCriteria = Criteria.where("name").regex("^h$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -106,8 +105,7 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
     @Test
     public void testParseFieldCompliesPattern10() {
         Criteria criteria = doTest("name complies 'H'");
-        Criteria expectedCriteria = Criteria.where("name").regex(
-                "^(\\x{3042}|\\x{3044}|\\x{3046}|\\x{3048}|[\\x{304A}-\\x{3062}]|[\\x{3064}-\\x{3082}]|\\x{3084}|\\x{3086}|[\\x{3088}-\\x{308D}]|[\\x{308F}-\\x{3094}])$");
+        Criteria expectedCriteria = Criteria.where("name").regex("^([\\x{3041}-\\x{3096}])$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -116,8 +114,7 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
     @Test
     public void testParseFieldCompliesPattern11() {
         Criteria criteria = doTest("name complies 'k'");
-        Criteria expectedCriteria = Criteria.where("name").regex(
-                "^(\\x{30A1}|\\x{30A3}|\\x{30A5}|\\x{30A7}|\\x{30A9}|\\x{30C3}|\\x{30E3}|\\x{30E5}|\\x{30E7}|\\x{30EE}|\\x{30F5}|\\x{30F6}|[\\x{31F0}-\\x{31FF}]|[\\x{FF67}-\\x{FF6F}])$");
+        Criteria expectedCriteria = Criteria.where("name").regex("^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}])$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -126,8 +123,7 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
     @Test
     public void testParseFieldCompliesPattern12() {
         Criteria criteria = doTest("name complies 'K'");
-        Criteria expectedCriteria = Criteria.where("name").regex(
-                "^(\\x{30A2}|\\x{30A4}|\\x{30A6}|\\x{30A8}|[\\x{30AA}-\\x{30C2}]|[\\x{30C4}-\\x{30E2}]|\\x{30E4}|\\x{30E6}|[\\x{30E8}-\\x{30ED}]|[\\x{30EF}-\\x{30F4}]|[\\x{30F7}-\\x{30FA}]|\\x{FF66}|[\\x{FF71}-\\x{FF9D}])$");
+        Criteria expectedCriteria = Criteria.where("name").regex("^([\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -154,9 +150,14 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
 
     @Test
     public void testParseFieldCompliesPattern15() {
-        Criteria criteria = doTest("name complies 'Aaa G K Hhh C !'");
-        Criteria expectedCriteria = Criteria.where("name").regex(
-                "^([\\x{41}-\\x{5A}]|[\\x{C0}-\\x{D6}]|[\\x{D8}-\\x{DE}]|[\\x{FF21}-\\x{FF3A}])([\\x{61}-\\x{7a}]|[\\x{DF}-\\x{F6}]|[\\x{F8}-\\x{FF}]|[\\x{FF41}-\\x{FF5A}]){2} ([\\x{AC00}-\\x{D7AF}]) (\\x{30A2}|\\x{30A4}|\\x{30A6}|\\x{30A8}|[\\x{30AA}-\\x{30C2}]|[\\x{30C4}-\\x{30E2}]|\\x{30E4}|\\x{30E6}|[\\x{30E8}-\\x{30ED}]|[\\x{30EF}-\\x{30F4}]|[\\x{30F7}-\\x{30FA}]|\\x{FF66}|[\\x{FF71}-\\x{FF9D}]) (\\x{3042}|\\x{3044}|\\x{3046}|\\x{3048}|[\\x{304A}-\\x{3062}]|[\\x{3064}-\\x{3082}]|\\x{3084}|\\x{3086}|[\\x{3088}-\\x{308D}]|[\\x{308F}-\\x{3094}])(\\x{3041}|\\x{3043}|\\x{3045}|\\x{3047}|\\x{3049}|\\x{3063}|\\x{3083}|\\x{3085}|\\x{3087}|\\x{308E}|\\x{3095}|\\x{3096}){2} ([\\x{4E00}-\\x{9FEF}]|[\\x{3400}-\\x{4DB5}]|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}]) !$");
+        Criteria criteria = doTest("name complies 'Aaa G Kk Hhh C !'");
+        Criteria expectedCriteria = Criteria.where("name")
+                .regex("^([\\x{41}-\\x{5A}]|[\\x{C0}-\\x{D6}]|[\\x{D8}-\\x{DE}]|[\\x{FF21}-\\x{FF3A}])"
+                        + "([\\x{61}-\\x{7a}]|[\\x{DF}-\\x{F6}]|[\\x{F8}-\\x{FF}]|[\\x{FF41}-\\x{FF5A}]){2} "
+                        + "([\\x{AC00}-\\x{D7AF}]) " + "([\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])"
+                        + "([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}]) " + "([\\x{3041}-\\x{3096}])" + "h{2} "
+                        + "([\\x{4E00}-\\x{9FEF}]|[\\x{3400}-\\x{4DB5}]|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}])"
+                        + " !$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPattern.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPattern.java
@@ -21,13 +21,11 @@ public enum CharPattern {
 
     FULLWIDTH_UPPER_LATIN('A', CharPatternToRegexConstants.FULLWIDTH_UPPER_LATIN),
 
-    LOWER_HIRAGANA('h', CharPatternToRegexConstants.LOWER_HIRAGANA),
+    HIRAGANA('H', CharPatternToRegexConstants.HIRAGANA),
 
-    UPPER_HIRAGANA('H', CharPatternToRegexConstants.UPPER_HIRAGANA),
+    HALFWIDTH_KATAKANA('k', CharPatternToRegexConstants.HALFWIDTH_KATAKANA),
 
-    LOWER_KATAKANA('k', CharPatternToRegexConstants.LOWER_KATAKANA),
-
-    UPPER_KATAKANA('K', CharPatternToRegexConstants.UPPER_KATAKANA),
+    FULLWIDTH_KATAKANA('K', CharPatternToRegexConstants.FULLWIDTH_KATAKANA),
 
     KANJI('C', CharPatternToRegexConstants.KANJI),
 

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegex.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegex.java
@@ -23,22 +23,18 @@ public class CharPatternToRegex {
             int codePoint = pattern.codePointAt(pos);
             int consecutiveValues = getConsecutiveCodepoints(codePoint, pattern, pos + 1);
             switch (codePoint) {
-            case 'h':
-                buildString(stringBuilder, getRegex(CharPatternToRegexConstants.LOWER_HIRAGANA, isForJavaScript),
-                        consecutiveValues);
-                break;
             case 'H':
-                buildString(stringBuilder, getRegex(CharPatternToRegexConstants.UPPER_HIRAGANA, isForJavaScript),
-                        consecutiveValues);
+                buildString(stringBuilder, getRegex(CharPatternToRegexConstants.HIRAGANA, isForJavaScript), consecutiveValues);
                 break;
             case 'k':
-                buildString(stringBuilder, getRegex(CharPatternToRegexConstants.LOWER_KATAKANA, isForJavaScript),
+                buildString(stringBuilder, getRegex(CharPatternToRegexConstants.HALFWIDTH_KATAKANA, isForJavaScript),
                         consecutiveValues);
                 break;
             case 'K':
-                buildString(stringBuilder, getRegex(CharPatternToRegexConstants.UPPER_KATAKANA, isForJavaScript),
+                buildString(stringBuilder, getRegex(CharPatternToRegexConstants.FULLWIDTH_KATAKANA, isForJavaScript),
                         consecutiveValues);
                 break;
+
             case 'C':
                 buildString(stringBuilder, getRegex(CharPatternToRegexConstants.KANJI, isForJavaScript), consecutiveValues);
                 break;

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegexConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegexConstants.java
@@ -14,24 +14,14 @@ public enum CharPatternToRegexConstants {
 
     FULLWIDTH_UPPER_LATIN("([\\x{FF21}-\\x{FF3A}])", "([\\uFF21-\\uFF3A])"),
 
-    LOWER_HIRAGANA(
-            "(\\x{3041}|\\x{3043}|\\x{3045}|\\x{3047}|\\x{3049}|\\x{3063}|\\x{3083}|\\x{3085}|\\x{3087}|\\x{308E}|\\x{3095}|\\x{3096})",
-            "([\\u3041\\u3043\\u3045\\u3047\\u3049\\u3063\\u3083\\u3085\\u3087\\u308E\\u3095\\u3096])"),
+    HIRAGANA("([\\x{3041}-\\x{3096}])", "([\\u3041-\\u3096])"),
 
-    UPPER_HIRAGANA(
-            "(\\x{3042}|\\x{3044}|\\x{3046}|\\x{3048}|[\\x{304A}-\\x{3062}]|[\\x{3064}-\\x{3082}]|\\x{3084}|\\x{3086}|[\\x{3088}-\\x{308D}]|[\\x{308F}-\\x{3094}])",
-            "([\\u3042\\u3044\\u3046\\u3048\\u304A-\\u3062\\u3064-\\u3082\\u3084\\u3086\\u3088-\\u308D\\u308F-\\u3094])"),
+    HALFWIDTH_KATAKANA("([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}])", "([\\uFF66-\\uFF6F\\uFF71-\\uFF9D])"),
 
-    LOWER_KATAKANA(
-            "(\\x{30A1}|\\x{30A3}|\\x{30A5}|\\x{30A7}|\\x{30A9}|\\x{30C3}|\\x{30E3}|\\x{30E5}|\\x{30E7}|\\x{30EE}|\\x{30F5}|\\x{30F6}" // FullWidth
-                    + "|[\\x{31F0}-\\x{31FF}]" // Phonetic extension
-                    + "|[\\x{FF67}-\\x{FF6F}])", // HalfWidth
-            "([\\u30A1\\u30A3\\u30A5\\u30A7\\u30A9\\u30C3\\u30E3\\u30E5\\u30E7\\u30EE\\u30F5\\u30F6\\u31F0-\\u31FF\\uFF67-\\uFF6F])"),
-
-    UPPER_KATAKANA(
-            "(\\x{30A2}|\\x{30A4}|\\x{30A6}|\\x{30A8}|[\\x{30AA}-\\x{30C2}]|[\\x{30C4}-\\x{30E2}]|\\x{30E4}|\\x{30E6}|[\\x{30E8}-\\x{30ED}]|[\\x{30EF}-\\x{30F4}]|[\\x{30F7}-\\x{30FA}]" // FullWidth
-                    + "|\\x{FF66}|[\\x{FF71}-\\x{FF9D}])",
-            "([\\u30A2\\u30A4\\u30A6\\u30A8\\u30AA-\\u30C2\\u30C4-\\u30E2\\u30E4\\u30E6\\u30E8-\\u30ED\\u30EF-\\u30F4\\u30F7-\\u30FA\\uFF66\\uFF71-\\uFF9D])"),
+    FULLWIDTH_KATAKANA(
+            "([\\x{30A1}-\\x{30FA}]" // FullWidth
+                    + "|[\\x{31F0}-\\x{31FF}])", // Phonetic extension,
+            "([\\u30A1-\\u30FA\\u31F0-\\u31FF])"),
 
     KANJI(
             "([\\x{4E00}-\\x{9FEF}]" + "|[\\x{3400}-\\x{4DB5}]" + // Extension A

--- a/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
+++ b/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
@@ -19,18 +19,10 @@ public class CharPatternToRegexTest {
         assertEquals("^([\\x{30}-\\x{39}]|[\\x{FF10}-\\x{FF19}]){4}$", CharPatternToRegex.toRegex("9999"));
         assertEquals("^([\\x{41}-\\x{5A}]|[\\x{C0}-\\x{D6}]|[\\x{D8}-\\x{DE}]|[\\x{FF21}-\\x{FF3A}]){2}$",
                 CharPatternToRegex.toRegex("AA"));
-        assertEquals(
-                "^(\\x{3041}|\\x{3043}|\\x{3045}|\\x{3047}|\\x{3049}|\\x{3063}|\\x{3083}|\\x{3085}|\\x{3087}|\\x{308E}|\\x{3095}|\\x{3096})$",
-                CharPatternToRegex.toRegex("h"));
-        assertEquals(
-                "^(\\x{3042}|\\x{3044}|\\x{3046}|\\x{3048}|[\\x{304A}-\\x{3062}]|[\\x{3064}-\\x{3082}]|\\x{3084}|\\x{3086}|[\\x{3088}-\\x{308D}]|[\\x{308F}-\\x{3094}]){3}$",
-                CharPatternToRegex.toRegex("HHH"));
-        assertEquals(
-                "^(\\x{30A1}|\\x{30A3}|\\x{30A5}|\\x{30A7}|\\x{30A9}|\\x{30C3}|\\x{30E3}|\\x{30E5}|\\x{30E7}|\\x{30EE}|\\x{30F5}|\\x{30F6}|[\\x{31F0}-\\x{31FF}]|[\\x{FF67}-\\x{FF6F}])$",
-                CharPatternToRegex.toRegex("k"));
-        assertEquals(
-                "^(\\x{30A2}|\\x{30A4}|\\x{30A6}|\\x{30A8}|[\\x{30AA}-\\x{30C2}]|[\\x{30C4}-\\x{30E2}]|\\x{30E4}|\\x{30E6}|[\\x{30E8}-\\x{30ED}]|[\\x{30EF}-\\x{30F4}]|[\\x{30F7}-\\x{30FA}]|\\x{FF66}|[\\x{FF71}-\\x{FF9D}])$",
-                CharPatternToRegex.toRegex("K"));
+        assertEquals("^h$", CharPatternToRegex.toRegex("h"));
+        assertEquals("^([\\x{3041}-\\x{3096}]){3}$", CharPatternToRegex.toRegex("HHH"));
+        assertEquals("^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}])$", CharPatternToRegex.toRegex("k"));
+        assertEquals("^([\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])$", CharPatternToRegex.toRegex("K"));
         assertEquals("^([\\x{4E00}-\\x{9FEF}]" + "|[\\x{3400}-\\x{4DB5}]"
                 + "|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]"
                 + "|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]"
@@ -49,17 +41,10 @@ public class CharPatternToRegexTest {
         assertEquals("^([\\u0030-\\u0039]|[\\uFF10-\\uFF19]){4}$", CharPatternToRegex.toJavaScriptRegex("9999"));
         assertEquals("^([\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE]|[\\uFF21-\\uFF3A]){2}$",
                 CharPatternToRegex.toJavaScriptRegex("AA"));
-        assertEquals("^([\\u3041\\u3043\\u3045\\u3047\\u3049\\u3063\\u3083\\u3085\\u3087\\u308E\\u3095\\u3096])$",
-                CharPatternToRegex.toJavaScriptRegex("h"));
-        assertEquals(
-                "^([\\u3042\\u3044\\u3046\\u3048\\u304A-\\u3062\\u3064-\\u3082\\u3084\\u3086\\u3088-\\u308D\\u308F-\\u3094]){3}$",
-                CharPatternToRegex.toJavaScriptRegex("HHH"));
-        assertEquals(
-                "^([\\u30A1\\u30A3\\u30A5\\u30A7\\u30A9\\u30C3\\u30E3\\u30E5\\u30E7\\u30EE\\u30F5\\u30F6\\u31F0-\\u31FF\\uFF67-\\uFF6F])$",
-                CharPatternToRegex.toJavaScriptRegex("k"));
-        assertEquals(
-                "^([\\u30A2\\u30A4\\u30A6\\u30A8\\u30AA-\\u30C2\\u30C4-\\u30E2\\u30E4\\u30E6\\u30E8-\\u30ED\\u30EF-\\u30F4\\u30F7-\\u30FA\\uFF66\\uFF71-\\uFF9D])$",
-                CharPatternToRegex.toJavaScriptRegex("K"));
+        assertEquals("^h$", CharPatternToRegex.toJavaScriptRegex("h"));
+        assertEquals("^([\\u3041-\\u3096]){3}$", CharPatternToRegex.toJavaScriptRegex("HHH"));
+        assertEquals("^([\\uFF66-\\uFF6F\\uFF71-\\uFF9D])$", CharPatternToRegex.toJavaScriptRegex("k"));
+        assertEquals("^([\\u30A1-\\u30FA\\u31F0-\\u31FF])$", CharPatternToRegex.toJavaScriptRegex("K"));
         assertEquals(
                 "^([\\u4E00-\\u9FEF]|[\\u3400-\\u4DB5]|[\\ud840-\\ud868][\\udc00-\\udfff]|\\ud869[\\udc00-\\uded6]|[\\ud86a-\\ud86c][\\udc00-\\udfff]|\\ud869[\\udf00-\\udfff]|\\ud86d[\\udc00-\\udf34]|\\ud86d[\\udf40-\\udfff]|\\ud86e[\\udc00-\\udc1d]|[\\ud86f-\\ud872][\\udc00-\\udfff]|\\ud86e[\\udc20-\\udfff]|\\ud873[\\udc00-\\udea1]|[\\ud874-\\ud879][\\udc00-\\udfff]|\\ud873[\\udeb0-\\udfff]|\\ud87a[\\udc00-\\udfe0]|[\\uF900-\\uFA6D]|[\\uFA70-\\uFAD9]|\\ud87e[\\udc00-\\ude1d]|[\\u2F00}-\\u2FD5]|[\\u2E80}-\\u2E99]|[\\u2E9B-\\u2EF3]|\\u3005|\\u3007|[\\u3021-\\u3029]|[\\u3038-\\u303B])$",
                 CharPatternToRegex.toJavaScriptRegex("C"));
@@ -180,30 +165,29 @@ public class CharPatternToRegexTest {
     @Test
     public void hiragana() {
         assertMatches("こんにちは", CharPatternToRegex.toRegex("HHHHH"));
-        assertMatches("っゃゅょゎ", CharPatternToRegex.toRegex("hhhhh"));
-        assertMatches("ぁあいぃうえ", CharPatternToRegex.toRegex("hHHhHH"));
+        assertMatches("っゃゅょゎ", CharPatternToRegex.toRegex("HHHHH"));
+        assertMatches("ぁあいぃうえ", CharPatternToRegex.toRegex("HHHHHH"));
 
         assertJavaScriptMatches("こんにちは", CharPatternToRegex.toJavaScriptRegex("HHHHH"));
-        assertJavaScriptMatches("っゃゅょゎ", CharPatternToRegex.toJavaScriptRegex("hhhhh"));
-        assertJavaScriptMatches("ぁあいぃうえ", CharPatternToRegex.toJavaScriptRegex("hHHhHH"));
+        assertJavaScriptMatches("っゃゅょゎ", CharPatternToRegex.toJavaScriptRegex("HHHHH"));
+        assertJavaScriptMatches("ぁあいぃうえ", CharPatternToRegex.toJavaScriptRegex("HHHHHH"));
     }
 
     @Test
     public void katakana() {
-        assertMatches("ㇾㇿｧｨｩ", CharPatternToRegex.toRegex("kkkkk"));
+        assertMatches("ㇾㇿｧｨｩ", CharPatternToRegex.toRegex("KKkkk"));
         assertMatches("モヤユ", CharPatternToRegex.toRegex("KKK"));
-        assertMatches("モヤユㇿｧ", CharPatternToRegex.toRegex("KKKkk"));
-
-        assertJavaScriptMatches("ㇾㇿｧｨｩ", CharPatternToRegex.toJavaScriptRegex("kkkkk"));
+        assertMatches("モヤユㇿｧ", CharPatternToRegex.toRegex("KKKKk"));
+        assertJavaScriptMatches("ㇾㇿｧｨｩ", CharPatternToRegex.toJavaScriptRegex("KKkkk"));
         assertJavaScriptMatches("モヤユ", CharPatternToRegex.toJavaScriptRegex("KKK"));
-        assertJavaScriptMatches("モヤユㇿｧ", CharPatternToRegex.toJavaScriptRegex("KKKkk"));
+        assertJavaScriptMatches("モヤユㇿｧ", CharPatternToRegex.toJavaScriptRegex("KKKKk"));
     }
 
     @Test
     public void mixedAll() {
-        assertMatches("0aAぁあァア一가", CharPatternToRegex.toRegex("9aAhHkKCG"));
+        assertMatches("0aAぁｨア一가", CharPatternToRegex.toRegex("9aAHkKCG"));
 
-        assertJavaScriptMatches("0aAぁあァア一가", CharPatternToRegex.toJavaScriptRegex("9aAhHkKCG"));
+        assertJavaScriptMatches("0aAあｨア一가", CharPatternToRegex.toJavaScriptRegex("9aAHkKCG"));
     }
 
     @Test


### PR DESCRIPTION
…idth katakana

**What is the problem this Pull Request is trying to solve?**
 We need to adapt character patterns in order to avoid distinction between:
    lower hiragana and upper hiragana
    lower katakana and upper katakana
Meanwhile, we have to do the distinction between halfwidth katakana and fullwidth katakana
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/TDQ-15975 -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
