### PR TITLE
feat(TDQ-15966): adapt word pattern for japanese

### DIFF
--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_WordComply.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_WordComply.java
@@ -11,7 +11,7 @@ import java.util.List;
 public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
 
     @Test
-    public void testParseFieldCompliesPattern1() {
+    public void lowerLatin() {
         Criteria criteria = doTest("name wordComplies '[word]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^[\\p{Ll}]{2,}$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -21,7 +21,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern2() {
+    public void upperLatin() {
         Criteria criteria = doTest("name wordComplies '[Word]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^\\p{Lu}[\\p{Ll}]{1,}$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -32,7 +32,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern3() {
+    public void mixedLatin() {
         Criteria criteria = doTest("name wordComplies '[Word] [digit][word]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^\\p{Lu}[\\p{Ll}]{1,} [\\p{Nd}][\\p{Ll}]{2,}$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -42,7 +42,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern4() {
+    public void mixedLatin2() {
         Criteria criteria = doTest("name wordComplies '[Word] [Word]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^\\p{Lu}[\\p{Ll}]{1,} \\p{Lu}[\\p{Ll}]{1,}$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -51,7 +51,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern5() {
+    public void underscore() {
         Criteria criteria = doTest("name wordComplies '[Word]_[Number]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^\\p{Lu}[\\p{Ll}]{1,}_\\[Number\\]$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -60,7 +60,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern6() {
+    public void bracketsAndEmail() {
         Criteria criteria = doTest("name wordComplies '][word]@'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^\\][\\p{Ll}]{2,}@$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -69,7 +69,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern7() {
+    public void caseSensitiveWord() {
         Criteria criteria = doTest("name wordComplies '[Word] [word] [Word]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^\\p{Lu}[\\p{Ll}]{1,} [\\p{Ll}]{2,} \\p{Lu}[\\p{Ll}]{1,}$",
                 false);
@@ -79,7 +79,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern8() {
+    public void empty() {
         Criteria criteria = doTest("name wordComplies ''");
         Criteria expectedCriteria = Criteria.where("name").is("");
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -88,7 +88,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern9() {
+    public void ideogram() {
         Criteria criteria = doTest("name wordComplies '[Ideogram]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^[\\p{Han}]$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -97,7 +97,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern10() {
+    public void lowerChar() {
         Criteria criteria = doTest("name wordComplies '[char]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^[\\p{Ll}]$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -106,7 +106,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern11() {
+    public void upperChar() {
         Criteria criteria = doTest("name wordComplies '[Char]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^[\\p{Lu}]$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -115,7 +115,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern12() {
+    public void alnum() {
         Criteria criteria = doTest("name wordComplies '[alnum]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^[\\p{Nd}|\\p{Lu}\\p{Ll}]{2,}$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -128,7 +128,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern13() {
+    public void ideogramSeq() {
         Criteria criteria = doTest("name wordComplies '[IdeogramSeq]'");
         Criteria expectedCriteria = getExpectedCriteria("name", "^[\\p{Han}]{2,}$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
@@ -137,16 +137,63 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     }
 
     @Test
-    public void testParseFieldCompliesPattern14() {
-        Criteria criteria = doTest("name wordComplies '[alnum(CJK)]'");
-        Criteria expectedCriteria = getExpectedCriteria("name", "^[\\p{Nd}|\\p{Han}]{2,}$", false);
+    public void hiragana() {
+        Criteria criteria = doTest("name wordComplies '[hira]'");
+        Criteria expectedCriteria = getExpectedCriteria("name", "^([\\x{3041}-\\x{3096}])$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
     }
 
     @Test
-    public void testParseFieldCompliesPattern15() {
+    public void hiraganaSeq() {
+        Criteria criteria = doTest("name wordComplies '[hiraSeq]'");
+        Criteria expectedCriteria = getExpectedCriteria("name", "^([\\x{3041}-\\x{3096}]){2,}$", false);
+        Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
+        List<Record> records = this.getRecords(criteria);
+        Assert.assertEquals(0, records.size());
+    }
+
+    @Test
+    public void katakana() {
+        Criteria criteria = doTest("name wordComplies '[kata]'");
+        Criteria expectedCriteria = getExpectedCriteria("name",
+                "^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}]|[\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])$", false);
+        Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
+        List<Record> records = this.getRecords(criteria);
+        Assert.assertEquals(0, records.size());
+    }
+
+    @Test
+    public void katakanaSeq() {
+        Criteria criteria = doTest("name wordComplies '[kataSeq]'");
+        Criteria expectedCriteria = getExpectedCriteria("name",
+                "^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}]|[\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}]){2,}$", false);
+        Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
+        List<Record> records = this.getRecords(criteria);
+        Assert.assertEquals(0, records.size());
+    }
+
+    @Test
+    public void hangul() {
+        Criteria criteria = doTest("name wordComplies '[hangul]'");
+        Criteria expectedCriteria = getExpectedCriteria("name", "^([\\x{AC00}-\\x{D7AF}])$", false);
+        Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
+        List<Record> records = this.getRecords(criteria);
+        Assert.assertEquals(0, records.size());
+    }
+
+    @Test
+    public void hangulSeq() {
+        Criteria criteria = doTest("name wordComplies '[hangulSeq]'");
+        Criteria expectedCriteria = getExpectedCriteria("name", "^([\\x{AC00}-\\x{D7AF}]){2,}$", false);
+        Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
+        List<Record> records = this.getRecords(criteria);
+        Assert.assertEquals(0, records.size());
+    }
+
+    @Test
+    public void negation() {
         Criteria criteria = doTest("not (name wordComplies '[word]')");
         Criteria expectedCriteria = getExpectedCriteria("name", "^[\\p{Ll}]{2,}$", true);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());

--- a/daikon/src/main/java/org/talend/daikon/pattern/PatternRegexUtils.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/PatternRegexUtils.java
@@ -16,4 +16,10 @@ public class PatternRegexUtils {
         }
         return escaped;
     }
+
+    // Utils to remove middle parenthesis of regexes
+    public static String buildRegex(String pattern1, String pattern2) {
+        return pattern1.substring(0, pattern1.length() - 1) + "|" + pattern2.substring(1);
+    }
+
 }

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegex.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegex.java
@@ -1,5 +1,6 @@
 package org.talend.daikon.pattern.character;
 
+import static org.talend.daikon.pattern.PatternRegexUtils.buildRegex;
 import static org.talend.daikon.pattern.PatternRegexUtils.escapeCharacters;
 
 public class CharPatternToRegex {
@@ -90,8 +91,4 @@ public class CharPatternToRegex {
         return (lastPos - currentPos + 1);
     }
 
-    // Utils to remove middle parenthesis of regexes
-    private static String buildRegex(String pattern1, String pattern2) {
-        return pattern1.substring(0, pattern1.length() - 1) + "|" + pattern2.substring(1);
-    }
 }

--- a/daikon/src/main/java/org/talend/daikon/pattern/word/WordPattern.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/word/WordPattern.java
@@ -1,5 +1,7 @@
 package org.talend.daikon.pattern.word;
 
+import org.talend.daikon.pattern.character.CharPatternToRegexConstants;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -43,9 +45,25 @@ public enum WordPattern {
     IDEOGRAM_SEQUENCE(
             "[IdeogramSeq]",
             "[" + WordPatternToRegexConstants.IDEOGRAM + "]{2,}"),
-    ALPHANUMERIC_CJK(
-            "[alnum(CJK)]",
-            "[" + WordPatternToRegexConstants.DIGIT + "|" + WordPatternToRegexConstants.IDEOGRAM + "]{2,}");
+    HANGUL(
+            "[hangul]",
+            CharPatternToRegexConstants.HANGUL.getRegex()),
+    HANGUL_SEQUENCE(
+            "[hangulSeq]",
+            CharPatternToRegexConstants.HANGUL.getRegex() + "{2,}"),
+    HIRAGANA(
+            "[hira]",
+            CharPatternToRegexConstants.HIRAGANA.getRegex()),
+    HIRAGANA_SEQUENCE(
+            "[hiraSeq]",
+            CharPatternToRegexConstants.HIRAGANA.getRegex() + "{2,}"),
+    KATAKANA(
+            "[kata]",
+            WordPatternToRegexConstants.KATAKANA),
+    KATAKANA_SEQUENCE(
+            "[kataSeq]",
+            WordPatternToRegexConstants.KATAKANA + "{2,}");
+
     // @formatter:on
     private static final Map<String, WordPattern> lookup = new HashMap<>();
 

--- a/daikon/src/main/java/org/talend/daikon/pattern/word/WordPatternToRegexConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/word/WordPatternToRegexConstants.java
@@ -1,5 +1,8 @@
 package org.talend.daikon.pattern.word;
 
+import org.talend.daikon.pattern.PatternRegexUtils;
+import org.talend.daikon.pattern.character.CharPatternToRegexConstants;
+
 class WordPatternToRegexConstants {
 
     // Iso to Character.isDigit
@@ -7,6 +10,9 @@ class WordPatternToRegexConstants {
 
     // almost iso to Character.isIdeographic
     static final String IDEOGRAM = "\\p{script=Han}";
+
+    static final String KATAKANA = PatternRegexUtils.buildRegex(CharPatternToRegexConstants.HALFWIDTH_KATAKANA.getRegex(),
+            CharPatternToRegexConstants.FULLWIDTH_KATAKANA.getRegex());
 
     // Iso to Character.getType(codePoint) == Character.UPPERCASE_LETTER
     static final String UPPER_CHAR = "\\p{Lu}";

--- a/daikon/src/test/java/org/talend/daikon/pattern/word/WordPatternToRegexTest.java
+++ b/daikon/src/test/java/org/talend/daikon/pattern/word/WordPatternToRegexTest.java
@@ -343,25 +343,9 @@ public class WordPatternToRegexTest {
     }
 
     @Test
-    public void chineseAlphanumeric() {
-        final String pattern = "[alnum(CJK)]";
-
-        String regex = WordPatternToRegex.toRegex(pattern, false);
-        assertEquals(regex, WordPatternToRegex.toRegex(pattern, true));
-
-        assertMatches("花木蘭88", regex);
-        assertMatches("花木蘭88袁", regex);
-        assertNoMatches("pony42", regex);
-        assertNoMatches("a", regex);
-        assertNoMatches(".aaa", regex);
-        assertNoMatches("a袁", regex);
-        assertNoMatches("ac袁", regex);
-    }
-
-    @Test
     public void chinese() {
         final String example = "袁 花木蘭88";
-        final String patternNoCase = "[Ideogram] [alnum(CJK)]";
+        final String patternNoCase = "[Ideogram] [IdeogramSeq][number]";
 
         testCaseInsensitivePattern(example, patternNoCase);
 
@@ -384,7 +368,7 @@ public class WordPatternToRegexTest {
     @Test
     public void chineseQuestion() {
         final String example = "不亦1說乎？有";
-        final String pattern = "[alnum(CJK)]？[Ideogram]";
+        final String pattern = "[IdeogramSeq][digit][IdeogramSeq]？[Ideogram]";
 
         testCaseInsensitivePattern(example, pattern);
     }
@@ -392,7 +376,7 @@ public class WordPatternToRegexTest {
     @Test
     public void japaneseAlphanumeric() {
         final String example = "こんにちは123";
-        final String pattern = "こんにちは[alnum]";
+        final String pattern = "[hiraSeq][alnum]";
 
         testCaseInsensitivePattern(example, pattern);
     }
@@ -400,7 +384,7 @@ public class WordPatternToRegexTest {
     @Test
     public void japaneseWord() {
         final String example = "こんにちは";
-        final String pattern = "こんにちは";
+        final String pattern = "[hiraSeq]";
 
         String regex = WordPatternToRegex.toRegex(pattern, false);
         assertMatches(example, regex);
@@ -412,7 +396,7 @@ public class WordPatternToRegexTest {
     @Test
     public void japaneseCJKNoCase() {
         final String example = "日本語123 日本語？你好/Hello!";
-        final String patternNoCase = "[alnum(CJK)] [IdeogramSeq]？[IdeogramSeq]/[word]!";
+        final String patternNoCase = "[IdeogramSeq][number] [IdeogramSeq]？[IdeogramSeq]/[word]!";
         String regex = WordPatternToRegex.toRegex(patternNoCase, false);
         assertMatches(example, regex);
 
@@ -433,10 +417,34 @@ public class WordPatternToRegexTest {
     }
 
     @Test
+    public void japaneseSentence() {
+        final String example = "クリスマスは かぞくと いっしょに すごします。";
+        final String pattern = "[kataSeq][hira] [hiraSeq] [hiraSeq] [hiraSeq]。";
+
+        String regex = WordPatternToRegex.toRegex(pattern, false);
+        assertMatches(example, regex);
+
+        String regexCase = WordPatternToRegex.toRegex(pattern, true);
+        assertMatches(example, regexCase);
+    }
+
+    @Test
+    public void koreanWord() {
+        final String example = "그러던데";
+        final String pattern = "[hangulSeq]";
+
+        String regex = WordPatternToRegex.toRegex(pattern, false);
+        assertMatches(example, regex);
+
+        String regexCase = WordPatternToRegex.toRegex(pattern, true);
+        assertMatches(example, regexCase);
+    }
+
+    @Test
     public void surrogatePair() {
         testCaseInsensitivePattern("𠀐", "[Ideogram]");
         testCaseInsensitivePattern("𠀐𠀑我𠀒𠀓", "[IdeogramSeq]");
-        testCaseInsensitivePattern("𠀐12//𠀑我?𠀑", "[alnum(CJK)]//[IdeogramSeq]?[Ideogram]");
+        testCaseInsensitivePattern("𠀐12//𠀑我?𠀑", "[Ideogram][number]//[IdeogramSeq]?[Ideogram]");
         testCaseInsensitivePattern("𠀐12//𠀑我?𠀑", "[Ideogram][number]//[IdeogramSeq]?[Ideogram]");
     }
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 Hiragana and Katakana are not recognized on Word Pattern 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/TDQ-15966 -->
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
