### PR TITLE
chore(TDQ-15990): Split frequent and rare chinese ideograms

### DIFF
--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Comply.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Comply.java
@@ -133,7 +133,7 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
     public void testParseFieldCompliesPattern13() {
         Criteria criteria = doTest("name complies 'C'");
         Criteria expectedCriteria = Criteria.where("name").regex(
-                "^([\\x{4E00}-\\x{9FEF}]|[\\x{3400}-\\x{4DB5}]|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}])$");
+                "^([\\x{4E00}-\\x{9FEF}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}]|[\\x{3400}-\\x{4DB5}]|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}])$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -156,7 +156,7 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
                         + "([\\x{61}-\\x{7a}]|[\\x{DF}-\\x{F6}]|[\\x{F8}-\\x{FF}]|[\\x{FF41}-\\x{FF5A}]){2} "
                         + "([\\x{AC00}-\\x{D7AF}]) " + "([\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])"
                         + "([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}]) " + "([\\x{3041}-\\x{3096}])" + "h{2} "
-                        + "([\\x{4E00}-\\x{9FEF}]|[\\x{3400}-\\x{4DB5}]|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}])"
+                        + "([\\x{4E00}-\\x{9FEF}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}]|[\\x{3400}-\\x{4DB5}]|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}])"
                         + " !$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPattern.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPattern.java
@@ -29,6 +29,8 @@ public enum CharPattern {
 
     KANJI('C', CharPatternToRegexConstants.KANJI),
 
+    KANJI_RARE('C', CharPatternToRegexConstants.KANJI_RARE),
+
     HANGUL('G', CharPatternToRegexConstants.HANGUL);
 
     private Character replaceChar;

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegex.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegex.java
@@ -36,7 +36,9 @@ public class CharPatternToRegex {
                 break;
 
             case 'C':
-                buildString(stringBuilder, getRegex(CharPatternToRegexConstants.KANJI, isForJavaScript), consecutiveValues);
+                String regexC = buildRegex(getRegex(CharPatternToRegexConstants.KANJI, isForJavaScript),
+                        getRegex(CharPatternToRegexConstants.KANJI_RARE, isForJavaScript));
+                buildString(stringBuilder, regexC, consecutiveValues);
                 break;
             case 'G':
                 buildString(stringBuilder, getRegex(CharPatternToRegexConstants.HANGUL, isForJavaScript), consecutiveValues);

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegexConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegexConstants.java
@@ -24,7 +24,11 @@ public enum CharPatternToRegexConstants {
             "([\\u30A1-\\u30FA\\u31F0-\\u31FF])"),
 
     KANJI(
-            "([\\x{4E00}-\\x{9FEF}]" + "|[\\x{3400}-\\x{4DB5}]" + // Extension A
+            "([\\x{4E00}-\\x{9FEF}]" + "|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}])", // Symbol and punctuation added for TDQ-11343
+            "([\\u4E00-\\u9FEF]" + "|\\u3005|\\u3007|[\\u3021-\\u3029]|[\\u3038-\\u303B])"), // Symbol and punctuation added for TDQ-11343
+
+    KANJI_RARE(
+            "([\\x{3400}-\\x{4DB5}]" + // Extension A
                     "|[\\x{20000}-\\x{2A6D6}]" + // Extension B
                     "|[\\x{2A700}-\\x{2B734}]" + // Extension C
                     "|[\\x{2B740}-\\x{2B81D}]" + // Extension D
@@ -33,10 +37,9 @@ public enum CharPatternToRegexConstants {
                     "|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]" + // Compatibility Ideograph
                     "|[\\x{2F800}-\\x{2FA1D}]" + // Compatibility Ideograph Supplement
                     "|[\\x{2F00}-\\x{2FD5}]" + // KangXi Radicals
-                    "|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}]" + // Radical Supplement
-                    "|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}]" + // Symbol and punctuation added for TDQ-11343
-                    ")", //
-            "([\\u4E00-\\u9FEF]" + "|[\\u3400-\\u4DB5]" + // Extension A
+                    "|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}])" // Radical Supplement
+            ,
+            "([\\u3400-\\u4DB5]" + // Extension A
                     "|[\\ud840-\\ud868][\\udc00-\\udfff]|\\ud869[\\udc00-\\uded6]" + // Extension B
                     "|[\\ud86a-\\ud86c][\\udc00-\\udfff]|\\ud869[\\udf00-\\udfff]|\\ud86d[\\udc00-\\udf34]" + // Extension C
                     "|\\ud86d[\\udf40-\\udfff]|\\ud86e[\\udc00-\\udc1d]" + // Extension D
@@ -45,9 +48,7 @@ public enum CharPatternToRegexConstants {
                     "|[\\uF900-\\uFA6D]|[\\uFA70-\\uFAD9]" + // Compatibility Ideograph
                     "|\\ud87e[\\udc00-\\ude1d]" + // Compatibility Ideograph Supplement
                     "|[\\u2F00}-\\u2FD5]" + // KangXi Radicals
-                    "|[\\u2E80}-\\u2E99]|[\\u2E9B-\\u2EF3]" + // Radical Supplement
-                    "|\\u3005|\\u3007|[\\u3021-\\u3029]|[\\u3038-\\u303B]" + // Symbol and punctuation added for TDQ-11343
-                    ")"),
+                    "|[\\u2E80}-\\u2E99]|[\\u2E9B-\\u2EF3])"), // Radical Supplement),
 
     HANGUL("([\\x{AC00}-\\x{D7AF}])", "([\\uAC00-\\uD7AF])");
 

--- a/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
+++ b/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
@@ -23,11 +23,12 @@ public class CharPatternToRegexTest {
         assertEquals("^([\\x{3041}-\\x{3096}]){3}$", CharPatternToRegex.toRegex("HHH"));
         assertEquals("^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}])$", CharPatternToRegex.toRegex("k"));
         assertEquals("^([\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])$", CharPatternToRegex.toRegex("K"));
-        assertEquals("^([\\x{4E00}-\\x{9FEF}]" + "|[\\x{3400}-\\x{4DB5}]"
-                + "|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]"
-                + "|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]"
-                + "|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}]"
-                + "|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}])$", CharPatternToRegex.toRegex("C"));
+        assertEquals(
+                "^([\\x{4E00}-\\x{9FEF}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}]"
+                        + "|[\\x{3400}-\\x{4DB5}]" + "|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]"
+                        + "|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]"
+                        + "|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}]" + ")$",
+                CharPatternToRegex.toRegex("C"));
         assertEquals("^([\\x{AC00}-\\x{D7AF}])$", CharPatternToRegex.toRegex("G"));
         assertEquals(
                 "^([\\x{61}-\\x{7a}]|[\\x{DF}-\\x{F6}]|[\\x{F8}-\\x{FF}]|[\\x{FF41}-\\x{FF5A}]){4}@"
@@ -46,7 +47,7 @@ public class CharPatternToRegexTest {
         assertEquals("^([\\uFF66-\\uFF6F\\uFF71-\\uFF9D])$", CharPatternToRegex.toJavaScriptRegex("k"));
         assertEquals("^([\\u30A1-\\u30FA\\u31F0-\\u31FF])$", CharPatternToRegex.toJavaScriptRegex("K"));
         assertEquals(
-                "^([\\u4E00-\\u9FEF]|[\\u3400-\\u4DB5]|[\\ud840-\\ud868][\\udc00-\\udfff]|\\ud869[\\udc00-\\uded6]|[\\ud86a-\\ud86c][\\udc00-\\udfff]|\\ud869[\\udf00-\\udfff]|\\ud86d[\\udc00-\\udf34]|\\ud86d[\\udf40-\\udfff]|\\ud86e[\\udc00-\\udc1d]|[\\ud86f-\\ud872][\\udc00-\\udfff]|\\ud86e[\\udc20-\\udfff]|\\ud873[\\udc00-\\udea1]|[\\ud874-\\ud879][\\udc00-\\udfff]|\\ud873[\\udeb0-\\udfff]|\\ud87a[\\udc00-\\udfe0]|[\\uF900-\\uFA6D]|[\\uFA70-\\uFAD9]|\\ud87e[\\udc00-\\ude1d]|[\\u2F00}-\\u2FD5]|[\\u2E80}-\\u2E99]|[\\u2E9B-\\u2EF3]|\\u3005|\\u3007|[\\u3021-\\u3029]|[\\u3038-\\u303B])$",
+                "^([\\u4E00-\\u9FEF]|\\u3005|\\u3007|[\\u3021-\\u3029]|[\\u3038-\\u303B]|[\\u3400-\\u4DB5]|[\\ud840-\\ud868][\\udc00-\\udfff]|\\ud869[\\udc00-\\uded6]|[\\ud86a-\\ud86c][\\udc00-\\udfff]|\\ud869[\\udf00-\\udfff]|\\ud86d[\\udc00-\\udf34]|\\ud86d[\\udf40-\\udfff]|\\ud86e[\\udc00-\\udc1d]|[\\ud86f-\\ud872][\\udc00-\\udfff]|\\ud86e[\\udc20-\\udfff]|\\ud873[\\udc00-\\udea1]|[\\ud874-\\ud879][\\udc00-\\udfff]|\\ud873[\\udeb0-\\udfff]|\\ud87a[\\udc00-\\udfe0]|[\\uF900-\\uFA6D]|[\\uFA70-\\uFAD9]|\\ud87e[\\udc00-\\ude1d]|[\\u2F00}-\\u2FD5]|[\\u2E80}-\\u2E99]|[\\u2E9B-\\u2EF3])$",
                 CharPatternToRegex.toJavaScriptRegex("C"));
         assertEquals("^([\\uAC00-\\uD7AF])$", CharPatternToRegex.toJavaScriptRegex("G"));
         assertEquals(


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 We need to split frequent and rare chinese ideograms, in order to mask a frequent ideogram by a frequent one and a rare one by a rare one
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/TDQ-15990 -->
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
