### PR TITLE
fix(TDQ-15964): handle special japanese characters in char-patterns

### DIFF
--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Comply.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Comply.java
@@ -105,7 +105,7 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
     @Test
     public void testParseFieldCompliesPattern10() {
         Criteria criteria = doTest("name complies 'H'");
-        Criteria expectedCriteria = Criteria.where("name").regex("^([\\x{3041}-\\x{3096}])$");
+        Criteria expectedCriteria = Criteria.where("name").regex("^([\\x{3041}-\\x{3096}]|\\x{309D}|\\x{309E}|\\x{30FC})$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -114,7 +114,7 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
     @Test
     public void testParseFieldCompliesPattern11() {
         Criteria criteria = doTest("name complies 'k'");
-        Criteria expectedCriteria = Criteria.where("name").regex("^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}])$");
+        Criteria expectedCriteria = Criteria.where("name").regex("^([\\x{FF66}-\\x{FF9D}])$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -123,7 +123,8 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
     @Test
     public void testParseFieldCompliesPattern12() {
         Criteria criteria = doTest("name complies 'K'");
-        Criteria expectedCriteria = Criteria.where("name").regex("^([\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])$");
+        Criteria expectedCriteria = Criteria.where("name")
+                .regex("^([\\x{30A1}-\\x{30FA}]|\\x{30FD}|\\x{30FE}|[\\x{31F0}-\\x{31FF}]|\\x{30FC})$");
         Assert.assertEquals(expectedCriteria, criteria);
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -154,8 +155,9 @@ public class TestMongoCriteria_Comply extends TestMongoCriteria_Abstract {
         Criteria expectedCriteria = Criteria.where("name")
                 .regex("^([\\x{41}-\\x{5A}]|[\\x{C0}-\\x{D6}]|[\\x{D8}-\\x{DE}]|[\\x{FF21}-\\x{FF3A}])"
                         + "([\\x{61}-\\x{7a}]|[\\x{DF}-\\x{F6}]|[\\x{F8}-\\x{FF}]|[\\x{FF41}-\\x{FF5A}]){2} "
-                        + "([\\x{AC00}-\\x{D7AF}]) " + "([\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])"
-                        + "([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}]) " + "([\\x{3041}-\\x{3096}])" + "h{2} "
+                        + "([\\x{AC00}-\\x{D7AF}]) "
+                        + "([\\x{30A1}-\\x{30FA}]|\\x{30FD}|\\x{30FE}|[\\x{31F0}-\\x{31FF}]|\\x{30FC})"
+                        + "([\\x{FF66}-\\x{FF9D}]) " + "([\\x{3041}-\\x{3096}]|\\x{309D}|\\x{309E}|\\x{30FC})" + "h{2} "
                         + "([\\x{4E00}-\\x{9FEF}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}]|[\\x{3400}-\\x{4DB5}]|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}])"
                         + " !$");
         Assert.assertEquals(expectedCriteria, criteria);

--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_WordComply.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_WordComply.java
@@ -139,7 +139,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     @Test
     public void hiragana() {
         Criteria criteria = doTest("name wordComplies '[hira]'");
-        Criteria expectedCriteria = getExpectedCriteria("name", "^([\\x{3041}-\\x{3096}])$", false);
+        Criteria expectedCriteria = getExpectedCriteria("name", "^([\\x{3041}-\\x{3096}]|\\x{309D}|\\x{309E}|\\x{30FC})$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -148,7 +148,8 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     @Test
     public void hiraganaSeq() {
         Criteria criteria = doTest("name wordComplies '[hiraSeq]'");
-        Criteria expectedCriteria = getExpectedCriteria("name", "^([\\x{3041}-\\x{3096}]){2,}$", false);
+        Criteria expectedCriteria = getExpectedCriteria("name", "^([\\x{3041}-\\x{3096}]|\\x{309D}|\\x{309E}|\\x{30FC}){2,}$",
+                false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -158,7 +159,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     public void katakana() {
         Criteria criteria = doTest("name wordComplies '[kata]'");
         Criteria expectedCriteria = getExpectedCriteria("name",
-                "^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}]|[\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])$", false);
+                "^([\\x{FF66}-\\x{FF9D}]|[\\x{30A1}-\\x{30FA}]|\\x{30FD}|\\x{30FE}|[\\x{31F0}-\\x{31FF}]|\\x{30FC})$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());
@@ -168,7 +169,7 @@ public class TestMongoCriteria_WordComply extends TestMongoCriteria_Abstract {
     public void katakanaSeq() {
         Criteria criteria = doTest("name wordComplies '[kataSeq]'");
         Criteria expectedCriteria = getExpectedCriteria("name",
-                "^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}]|[\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}]){2,}$", false);
+                "^([\\x{FF66}-\\x{FF9D}]|[\\x{30A1}-\\x{30FA}]|\\x{30FD}|\\x{30FE}|[\\x{31F0}-\\x{31FF}]|\\x{30FC}){2,}$", false);
         Assert.assertEquals(expectedCriteria.getCriteriaObject(), criteria.getCriteriaObject());
         List<Record> records = this.getRecords(criteria);
         Assert.assertEquals(0, records.size());

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPattern.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPattern.java
@@ -58,7 +58,7 @@ public enum CharPattern {
     CharPattern(char replace, CharPatternToRegexConstants pattern) {
         replaceChar = replace;
         this.pattern = pattern;
-        buildCharacters(pattern.getRegex());
+        buildCharacters(pattern.getRange());
     }
 
     private void buildCharacters(String pattern) {

--- a/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegexConstants.java
+++ b/daikon/src/main/java/org/talend/daikon/pattern/character/CharPatternToRegexConstants.java
@@ -14,14 +14,19 @@ public enum CharPatternToRegexConstants {
 
     FULLWIDTH_UPPER_LATIN("([\\x{FF21}-\\x{FF3A}])", "([\\uFF21-\\uFF3A])"),
 
-    HIRAGANA("([\\x{3041}-\\x{3096}])", "([\\u3041-\\u3096])"),
+    HIRAGANA(
+            "([\\x{3041}-\\x{3096}]|\\x{309D}|\\x{309E})",
+            "([\\x{3041}-\\x{3096}]|\\x{309D}|\\x{309E}|\\x{30FC})",
+            "([\\u3041-\\u3096]|\\u309D|\\u309E|\\u30FC)"),
 
-    HALFWIDTH_KATAKANA("([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}])", "([\\uFF66-\\uFF6F\\uFF71-\\uFF9D])"),
+    HALFWIDTH_KATAKANA("([\\x{FF66}-\\x{FF9D}])", "([\\uFF66-\\uFF9D])"),
 
     FULLWIDTH_KATAKANA(
-            "([\\x{30A1}-\\x{30FA}]" // FullWidth
-                    + "|[\\x{31F0}-\\x{31FF}])", // Phonetic extension,
-            "([\\u30A1-\\u30FA\\u31F0-\\u31FF])"),
+            "([\\x{30A1}-\\x{30FA}]|\\x{30FD}|\\x{30FE}|[\\x{31F0}-\\x{31FF}])",
+            "([\\x{30A1}-\\x{30FA}]|\\x{30FD}|\\x{30FE}" // FullWidth
+                    + "|[\\x{31F0}-\\x{31FF}]" + // Phonetic extension
+                    "|\\x{30FC})", // KATAKANA-HIRAGANA PROLONGED SOUND MARK
+            "([\\u30A1-\\u30FA\\u31F0-\\u31FF]|\\u30FC\\u30FD\\u30FE)"),
 
     KANJI(
             "([\\x{4E00}-\\x{9FEF}]" + "|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}])", // Symbol and punctuation added for TDQ-11343
@@ -52,13 +57,24 @@ public enum CharPatternToRegexConstants {
 
     HANGUL("([\\x{AC00}-\\x{D7AF}])", "([\\uAC00-\\uD7AF])");
 
+    private String range;
+
     private String regex;
 
     private String javaScriptRegex;
 
     CharPatternToRegexConstants(String regex, String javaScriptRegex) {
+        this(regex, regex, javaScriptRegex);
+    }
+
+    CharPatternToRegexConstants(String range, String regex, String javaScriptRegex) {
+        this.range = range;
         this.regex = regex;
         this.javaScriptRegex = javaScriptRegex;
+    }
+
+    public String getRange() {
+        return range;
     }
 
     public String getRegex() {

--- a/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
+++ b/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
@@ -20,15 +20,17 @@ public class CharPatternToRegexTest {
         assertEquals("^([\\x{41}-\\x{5A}]|[\\x{C0}-\\x{D6}]|[\\x{D8}-\\x{DE}]|[\\x{FF21}-\\x{FF3A}]){2}$",
                 CharPatternToRegex.toRegex("AA"));
         assertEquals("^h$", CharPatternToRegex.toRegex("h"));
-        assertEquals("^([\\x{3041}-\\x{3096}]){3}$", CharPatternToRegex.toRegex("HHH"));
-        assertEquals("^([\\x{FF66}-\\x{FF6F}]|[\\x{FF71}-\\x{FF9D}])$", CharPatternToRegex.toRegex("k"));
-        assertEquals("^([\\x{30A1}-\\x{30FA}]|[\\x{31F0}-\\x{31FF}])$", CharPatternToRegex.toRegex("K"));
+        assertEquals("^([\\x{3041}-\\x{3096}]|\\x{309D}|\\x{309E}|\\x{30FC}){3}$", CharPatternToRegex.toRegex("HHH"));
+        assertEquals("^([\\x{FF66}-\\x{FF9D}])$", CharPatternToRegex.toRegex("k"));
+        assertEquals("^([\\x{30A1}-\\x{30FA}]|\\x{30FD}|\\x{30FE}|[\\x{31F0}-\\x{31FF}]|\\x{30FC})$",
+                CharPatternToRegex.toRegex("K"));
         assertEquals(
                 "^([\\x{4E00}-\\x{9FEF}]|\\x{3005}|\\x{3007}|[\\x{3021}-\\x{3029}]|[\\x{3038}-\\x{303B}]"
                         + "|[\\x{3400}-\\x{4DB5}]" + "|[\\x{20000}-\\x{2A6D6}]|[\\x{2A700}-\\x{2B734}]|[\\x{2B740}-\\x{2B81D}]"
                         + "|[\\x{2B820}-\\x{2CEA1}]|[\\x{2CEB0}-\\x{2EBE0}]|[\\x{F900}-\\x{FA6D}]|[\\x{FA70}-\\x{FAD9}]"
                         + "|[\\x{2F800}-\\x{2FA1D}]|[\\x{2F00}-\\x{2FD5}]|[\\x{2E80}-\\x{2E99}]|[\\x{2E9B}-\\x{2EF3}]" + ")$",
                 CharPatternToRegex.toRegex("C"));
+
         assertEquals("^([\\x{AC00}-\\x{D7AF}])$", CharPatternToRegex.toRegex("G"));
         assertEquals(
                 "^([\\x{61}-\\x{7a}]|[\\x{DF}-\\x{F6}]|[\\x{F8}-\\x{FF}]|[\\x{FF41}-\\x{FF5A}]){4}@"
@@ -43,9 +45,9 @@ public class CharPatternToRegexTest {
         assertEquals("^([\\u0041-\\u005A\\u00C0-\\u00D6\\u00D8-\\u00DE]|[\\uFF21-\\uFF3A]){2}$",
                 CharPatternToRegex.toJavaScriptRegex("AA"));
         assertEquals("^h$", CharPatternToRegex.toJavaScriptRegex("h"));
-        assertEquals("^([\\u3041-\\u3096]){3}$", CharPatternToRegex.toJavaScriptRegex("HHH"));
-        assertEquals("^([\\uFF66-\\uFF6F\\uFF71-\\uFF9D])$", CharPatternToRegex.toJavaScriptRegex("k"));
-        assertEquals("^([\\u30A1-\\u30FA\\u31F0-\\u31FF])$", CharPatternToRegex.toJavaScriptRegex("K"));
+        assertEquals("^([\\u3041-\\u3096]|\\u309D|\\u309E|\\u30FC){3}$", CharPatternToRegex.toJavaScriptRegex("HHH"));
+        assertEquals("^([\\uFF66-\\uFF9D])$", CharPatternToRegex.toJavaScriptRegex("k"));
+        assertEquals("^([\\u30A1-\\u30FA\\u31F0-\\u31FF]|\\u30FC\\u30FD\\u30FE)$", CharPatternToRegex.toJavaScriptRegex("K"));
         assertEquals(
                 "^([\\u4E00-\\u9FEF]|\\u3005|\\u3007|[\\u3021-\\u3029]|[\\u3038-\\u303B]|[\\u3400-\\u4DB5]|[\\ud840-\\ud868][\\udc00-\\udfff]|\\ud869[\\udc00-\\uded6]|[\\ud86a-\\ud86c][\\udc00-\\udfff]|\\ud869[\\udf00-\\udfff]|\\ud86d[\\udc00-\\udf34]|\\ud86d[\\udf40-\\udfff]|\\ud86e[\\udc00-\\udc1d]|[\\ud86f-\\ud872][\\udc00-\\udfff]|\\ud86e[\\udc20-\\udfff]|\\ud873[\\udc00-\\udea1]|[\\ud874-\\ud879][\\udc00-\\udfff]|\\ud873[\\udeb0-\\udfff]|\\ud87a[\\udc00-\\udfe0]|[\\uF900-\\uFA6D]|[\\uFA70-\\uFAD9]|\\ud87e[\\udc00-\\ude1d]|[\\u2F00}-\\u2FD5]|[\\u2E80}-\\u2E99]|[\\u2E9B-\\u2EF3])$",
                 CharPatternToRegex.toJavaScriptRegex("C"));


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 some special japanese characters were not taken into account in char-patterns
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/TDQ-15964 -->
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
