### PR TITLE
Fix : Fix module daikon.scala in pom.xml in daikon

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <module>daikon-audit</module>
       	<module>daikon-i18n</module>
       	<module>daikon-signature-verifier</module>
-        <module>daikon-scala/dynamic-log</module>
+        <module>daikon-scala</module>
     </modules>
     <scm>
       <connection>scm:git:https://github.com/Talend/daikon.git</connection>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
In the pom.xml in daikon, we want just import the package daikon-scala/dynamic-log. When we want to use the library in dataset, there is a problem with the import of dynamic-log.
 
**What is the chosen solution to this problem?**
Import all the package daikon-scala and not just import the package dynamic-log
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
https://jira.talendforge.org/browse/TDC-1373
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
