### PR TITLE
fix(TDKN-209): Add a deterministic hash to the avro schema name.

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/avro/inferrer/JsonSchemaInferrer.java
+++ b/daikon/src/main/java/org/talend/daikon/avro/inferrer/JsonSchemaInferrer.java
@@ -83,7 +83,11 @@ public class JsonSchemaInferrer implements SchemaInferrer<String> {
     public Schema inferSchema(String json) {
         try {
             final JsonNode jsonNode = mapper.readTree(json);
-            return Schema.createRecord("outer_record", null, "org.talend", false, getFields(jsonNode));
+            // Create a nameless temporary record to get a fingerprint from.
+            Schema record = Schema.createRecord(getFields(jsonNode));
+            long fingerprint = SchemaNormalization.parsingFingerprint64(record);
+            return Schema.createRecord(("outer_record" + fingerprint).replace('-', '_'), null, "org.talend", false,
+                    getFields(jsonNode));
         } catch (IOException | TalendRuntimeException e) {
             throw TalendRuntimeException.createUnexpectedException(e.getCause());
         }

--- a/daikon/src/test/java/org/talend/daikon/avro/inferrer/JsonSchemaInferrerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/avro/inferrer/JsonSchemaInferrerTest.java
@@ -16,6 +16,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
 import java.io.IOException;
@@ -661,6 +662,20 @@ public class JsonSchemaInferrerTest {
         // This also ensure that for a given schema, the name is deterministic.
         Schema schema2 = jsonSchemaInferrer.inferSchema(realComplexRecord);
         assertThat(schema, equalTo(schema2));
+    }
+
+    /**
+     * Test {@link JsonSchemaInferrer#inferSchema(String)}
+     *
+     * Check if two schemas are named differently
+     *
+     * @throws IOException
+     */
+    @Test
+    public void testInferSchemaUnicity() throws IOException {
+        Schema schema1 = jsonSchemaInferrer.inferSchema(realComplexRecord);
+        Schema schema2 = jsonSchemaInferrer.inferSchema(jsonArrayOfNull);
+        assertThat(schema1.getName(), is(not(equalTo(schema2.getName()))));
     }
 
     /**

--- a/daikon/src/test/java/org/talend/daikon/avro/inferrer/JsonSchemaInferrerTest.java
+++ b/daikon/src/test/java/org/talend/daikon/avro/inferrer/JsonSchemaInferrerTest.java
@@ -14,6 +14,7 @@ package org.talend.daikon.avro.inferrer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 
@@ -514,6 +515,7 @@ public class JsonSchemaInferrerTest {
     public void testInferSchemaOfRealComplexRecord() throws IOException {
 
         Schema schema = jsonSchemaInferrer.inferSchema(realComplexRecord);
+        assertThat(schema.getName(), is(startsWith("outer_record")));
         List<Schema.Field> fieldList = schema.getFields();
         assertThat(fieldList, hasSize(2));
 
@@ -656,6 +658,7 @@ public class JsonSchemaInferrerTest {
         assertThat(fieldPostalCodeTypes.get(1).getName(), is(equalTo("null")));
 
         // Ensure that the inference is deterministic (generates the same schema twice).
+        // This also ensure that for a given schema, the name is deterministic.
         Schema schema2 = jsonSchemaInferrer.inferSchema(realComplexRecord);
         assertThat(schema, equalTo(schema2));
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
The method inferSchema inside JsonSchemaInferrer will alway create an avro Schema named "outer_record".

This may result in conflict between two different AVRO schema.

**What is the chosen solution to this problem?**
Add an Hash to the schema name. 

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
