### PR TITLE
feat(TFD-6171) : add kafka headers support

### DIFF
--- a/daikon-messages/messages-model/pom.xml
+++ b/daikon-messages/messages-model/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <avro.version>1.8.1</avro.version>
-        <kafka-client.version>0.10.0.0</kafka-client.version>
+        <kafka-client.version>1.1.1</kafka-client.version>
     </properties>
 
     <build>

--- a/daikon-messages/messages-model/src/main/java/org/talend/daikon/messages/utils/HeadersUtils.java
+++ b/daikon-messages/messages-model/src/main/java/org/talend/daikon/messages/utils/HeadersUtils.java
@@ -1,0 +1,34 @@
+package org.talend.daikon.messages.utils;
+
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.talend.daikon.messages.MessageHeader;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Kafka headers helpers
+ */
+public class HeadersUtils {
+
+    /**
+     * Map @{MessageHeader} into a list of Kafka @{org.apache.kafka.common.header.Header}
+     * @param messageHeader Daikon message header
+     * @return List of Kafka headers
+     */
+    public static List<Header> generateKafkaHeaders(MessageHeader messageHeader) {
+        List<Header> headers = new ArrayList<>();
+
+        headers.add(new RecordHeader("correlationId", messageHeader.getCorrelationId().getBytes()));
+        headers.add(new RecordHeader("id", messageHeader.getId().getBytes()));
+        headers.add(new RecordHeader("name", messageHeader.getName().getBytes()));
+        headers.add(new RecordHeader("securityToken", messageHeader.getSecurityToken().getBytes()));
+        headers.add(new RecordHeader("tenantId", messageHeader.getTenantId().getBytes()));
+        headers.add(new RecordHeader("timestamp", messageHeader.getTimestamp().toString().getBytes()));
+        headers.add(new RecordHeader("userId", messageHeader.getUserId().getBytes()));
+        headers.add(new RecordHeader("type", messageHeader.getType().toString().getBytes()));
+
+        return headers;
+    }
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
The current MessageHeader is intended to be included in the kafka's value as a separate field, and the current Kafka clients version doesn't support Kafka headers.

**What is the chosen solution to this problem?**
 Bump Kafka clients version to 1.1.1 and add a helper method to generate Kafka message headers from Daikon message header.

The Kafka headers can be used to do filtering/routing before deserializing the whole message.

Tests and doc to follow up soon.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TFD-6171
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
