### PR TITLE
TDKN-214 - Update Jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         </talend_releases>
         <pushChanges>false</pushChanges>
         <jackson.1x.version>1.9.14-TALEND</jackson.1x.version>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <jackson.version.annotations>2.9.0</jackson.version.annotations>
         <slf4j.version>1.7.25</slf4j.version>
         <log4j1.version>1.2.17</log4j1.version>
@@ -52,7 +52,6 @@
         <guava.version>21</guava.version>
         <spring-core.version>4.3.20.RELEASE</spring-core.version>
         <spring-data-mongodb.version>1.8.2.RELEASE</spring-data-mongodb.version>
-        <jackson.version>2.9.5</jackson.version>
         <aspectjweaver.version>1.8.9</aspectjweaver.version>
         <commons-lang.version>2.6</commons-lang.version>
         <spring-aop.version>4.3.6.RELEASE</spring-aop.version>


### PR DESCRIPTION
The daikon root pom has a (duplicate) dependency on Jackson 2.9.5. We should update to the latest 2.9.8 as there are several security advisories in effect against 2.9.5. For example:

https://nvd.nist.gov/vuln/detail/CVE-2018-19360

https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-14721