### PR TITLE
Use 64-bit Maven builder image (reqd by content-service-journal-mongo)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ kind: Pod
 spec:
   containers:
     - name: maven
-      image: jenkinsxio/builder-maven:0.0.319
+      image: jenkinsxio/builder-maven:0.1.211
       command:
       - cat
       tty: true


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 https://github.com/Talend/daikon/pull/434 introduced a dependency that does not support Linux 32-bit

**What is the chosen solution to this problem?**
Update to 64-bit jenkinsxio/builder-maven
 
**Link to the JIRA issue**
None
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
