### PR TITLE
WorkItem(TDKN-213):Daikon exception is not an OSGI plugin (#432)

### DIFF
--- a/daikon-exception/pom.xml
+++ b/daikon-exception/pom.xml
@@ -8,11 +8,16 @@
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>daikon-exception</artifactId>
-	<packaging>jar</packaging>
-
 	<name>Daikon library for handling exception</name>
+	<packaging>bundle</packaging>
 	<url>https://github.com/Talend/daikon</url>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.8</java.version>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
 	<dependencies>
 		<dependency>
 			<groupId>org.slf4j</groupId>
@@ -70,5 +75,53 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
-
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<source>1.8</source>
+					<target>1.8</target>
+					<compilerArguments>
+						<verbose />
+						<bootclasspath>${java.home}/lib/rt.jar</bootclasspath>
+					</compilerArguments>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+				<executions>
+					<execution>
+						<id>bundle-manifest</id>
+						<phase>process-classes</phase>
+						<goals>
+							<goal>manifest</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>bundle-jar</id>
+						<phase>package</phase>
+						<goals>
+							<goal>bundle</goal>
+						</goals>
+						<configuration>
+							<classifier>bundle</classifier>
+							<instructions>
+								<Bundle-SymbolicName>org.talend.daikon.exception</Bundle-SymbolicName>
+								<DynamicImport-Package>*</DynamicImport-Package>
+								<Service-Component>*</Service-Component>
+								<Embed-Transitive>true</Embed-Transitive>
+								<Import-Package>
+									com.fasterxml.*;resolution:=optional,org.apache.*;resolution:=optional,*
+								</Import-Package>
+							</instructions>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
the Exception module is not a bundle on the maintenance branch 0.31

**What is the chosen solution to this problem?**
cherrypicked master fix on the branch to change the pom to make a bundle
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
https://jira.talendforge.org/browse/TDKN-213
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](../CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
