### PR TITLE
feat(TFD-6574): Add schemaUri in Message Header spec

### DIFF
--- a/daikon-messages/messages-model/src/main/avro/MessageHeader.avsc
+++ b/daikon-messages/messages-model/src/main/avro/MessageHeader.avsc
@@ -74,6 +74,11 @@
       "doc" : "User's security token",
       "type" : ["null", "string"],
       "secured": true
+    },
+    {
+      "name" : "schemaUri",
+      "doc" : "A link to the schema that the message body adheres to. (e.g. http://org.talend.message/customer-logs/v1)",
+      "type" : ["null", "string"]
     }
   ]
 }

--- a/daikon-messages/messages-model/src/main/java/org/talend/daikon/messages/utils/HeadersUtils.java
+++ b/daikon-messages/messages-model/src/main/java/org/talend/daikon/messages/utils/HeadersUtils.java
@@ -21,15 +21,31 @@ public class HeadersUtils {
     public static List<Header> generateKafkaHeaders(MessageHeader messageHeader) {
         List<Header> headers = new ArrayList<>();
 
-        headers.add(new RecordHeader("correlationId", messageHeader.getCorrelationId().getBytes()));
+        // Required
         headers.add(new RecordHeader("id", messageHeader.getId().getBytes()));
-        headers.add(new RecordHeader("name", messageHeader.getName().getBytes()));
-        headers.add(new RecordHeader("securityToken", messageHeader.getSecurityToken().getBytes()));
-        headers.add(new RecordHeader("tenantId", messageHeader.getTenantId().getBytes()));
         headers.add(new RecordHeader("timestamp", messageHeader.getTimestamp().toString().getBytes()));
-        headers.add(new RecordHeader("userId", messageHeader.getUserId().getBytes()));
+        headers.add(new RecordHeader("issuer.application", messageHeader.getIssuer().getApplication().getBytes()));
+        headers.add(new RecordHeader("issuer.service", messageHeader.getIssuer().getService().getBytes()));
+        headers.add(new RecordHeader("issuer.version", messageHeader.getIssuer().getVersion().getBytes()));
         headers.add(new RecordHeader("type", messageHeader.getType().toString().getBytes()));
+        headers.add(new RecordHeader("name", messageHeader.getName().getBytes()));
+        headers.add(new RecordHeader("correlationId", messageHeader.getCorrelationId().getBytes()));
+
+        // Optional
+        if (messageHeader.getTenantId() != null) {
+            headers.add(new RecordHeader("tenantId", messageHeader.getTenantId().getBytes()));
+        }
+        if (messageHeader.getUserId() != null) {
+            headers.add(new RecordHeader("userId", messageHeader.getUserId().getBytes()));
+        }
+        if (messageHeader.getSecurityToken() != null) {
+            headers.add(new RecordHeader("securityToken", messageHeader.getSecurityToken().getBytes()));
+        }
+        if (messageHeader.getSchemaUri() != null) {
+            headers.add(new RecordHeader("schemaUri", messageHeader.getSchemaUri().getBytes()));
+        }
 
         return headers;
     }
+
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 Add SchemaUri in Message header spec, schemaUri point to a link to the schema that the message body adheres to. (e.g. http://org.talend.message/customer-logs/v1)
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/TFD-6574 -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
