### PR TITLE
fix Readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,16 @@ http://www.talend.com
 This repository contains commonly used classes that are expected to be shared across all Talend products.
 here is the folder description:
 
-_Modules_                                               |_Description_                             
--------------------------------------------------------|------------------------------------------
-[daikon](daikon)                                        |*The core library with a restricted set of dependencies. It contains Avro, i18n, Properties, UI-specs, Exception, Sandbox classloader handling classes among things* 
-[daikon-content-service](daikon-content-service)        |*Spring Abstraction for handling content resources on multiple filesystem like local or S3*
-[daikon-logging](daikon-logging)                        |*Json Layout for all loggers to used for cloud projects and it's associated documentation*
-[daikon-service](daikon-service)                        |*Provides spring services utilities such as abstracting the access to local or remote service and Enuciate documentation generation*
-[daikon-spring](daikon-spring)                          |*Spring specific classes that can be shared by projects, like multitenant for mongoDB or @RequiresAuthority for simple permission check*
-[daikon-tql](daikon-tql)                                |*Talend Query Language, simple query language for java and javascript with a MongoDB implementation*
-[daikon-audit](daikon-audit)                            |*Library which provides a facade for recording audit events*
-[poc](poc)                                              |*module use to store experiments and POCs like the CQRS one*
-[reporting](reporting)                                  |*Internal module used to aggregate jacoco converage reports and send them to codacy during the deploy phase*
+_Modules_                                                     |_Description_                             
+--------------------------------------------------------------|------------------------------------------
+[daikon](daikon)                                              |*The core library with a restricted set of dependencies. It contains Avro, i18n, Properties, UI-specs, Exception, Sandbox classloader handling classes among things* 
+[daikon-content-service](daikon-spring/daikon-content-service)|*Spring Abstraction for handling content resources on multiple filesystem like local or S3*
+[daikon-logging](daikon-logging)                              |*Json Layout for all loggers to used for cloud projects and it's associated documentation*
+[daikon-spring](daikon-spring)                                |*Spring specific classes that can be shared by projects, like multitenant for mongoDB or @RequiresAuthority for simple permission check*
+[daikon-tql](daikon-tql)                                      |*Talend Query Language, simple query language for java and javascript with a MongoDB implementation*
+[daikon-audit](daikon-audit)                                  |*Library which provides a facade for recording audit events*
+[poc](poc)                                                    |*module use to store experiments and POCs like the CQRS one*
+[reporting](reporting)                                        |*Internal module used to aggregate jacoco converage reports and send them to codacy during the deploy phase*
 
 
 ## Support
@@ -43,7 +42,7 @@ For code formatting, please use the configuration file and setup for Eclipse or 
 
 ## License
 
-Copyright (c) 2006-2017 Talend
+Copyright (c) 2006-2019 Talend
 
 Licensed under the [Apache Licence v2](https://www.apache.org/licenses/LICENSE-2.0.txt)
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
Dead link in the readme.

**What is the chosen solution to this problem?**
 
Change content-service link and remove daikon-service.

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
