### PR TITLE
fix(TDKN-222) : fix audit config appender name parsing (#466)

### DIFF
--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AuditConfigurationMapImpl.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AuditConfigurationMapImpl.java
@@ -26,7 +26,7 @@ public class AuditConfigurationMapImpl extends EnumMap<AuditConfiguration, Objec
             return null;
         }
 
-        final int nameStart = appenderPrefix.length() + 1;
+        final int nameStart = appenderPrefix.length();
         final int nameEnd = configName.indexOf('_', nameStart);
 
         if (nameEnd == -1) {
@@ -94,7 +94,7 @@ public class AuditConfigurationMapImpl extends EnumMap<AuditConfiguration, Objec
         }
         Object value = getValue(config);
         if (value == null && !config.canBeNull()) {
-            throw new IllegalStateException("Value for property " + toString() + " is not set and it has no default value");
+            throw new IllegalStateException("Value for property " + config.toString() + " is not set and it has no default value");
         }
         return clz.cast(value);
     }
@@ -105,7 +105,7 @@ public class AuditConfigurationMapImpl extends EnumMap<AuditConfiguration, Objec
         }
 
         if (containsKey(config)) {
-            throw new IllegalStateException("Parameter " + toString() + " cannot be set twice");
+            throw new IllegalStateException("Parameter " + config.toString() + " cannot be set twice");
         }
 
         put(config, value);

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AuditConfigurationMapImplTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AuditConfigurationMapImplTest.java
@@ -1,0 +1,67 @@
+package org.talend.logging.audit.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.talend.logging.audit.impl.AuditConfiguration.APPENDER_FILE_PATH;
+import static org.talend.logging.audit.impl.AuditConfiguration.APPLICATION_NAME;
+import static org.talend.logging.audit.impl.AuditConfiguration.LOG_APPENDER;
+
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class AuditConfigurationMapImplTest {
+
+    private Properties properties = new Properties();
+
+    @Before
+    public void setUp() {
+        setProperty(LOG_APPENDER, "none");
+        setProperty(APPENDER_FILE_PATH, "/tmp");
+        setProperty(APPLICATION_NAME, "App name");
+    }
+
+    @Test
+    public void validateConfigurationWithValideOne() {
+        AuditConfigurationMap config = AuditConfiguration.loadFromProperties(properties);
+
+        config.validateConfiguration();
+    }
+
+    @Test
+    public void validateConfigurationNotRequiredFilePath() {
+        setProperty(APPENDER_FILE_PATH, null);
+
+        AuditConfigurationMap config = AuditConfiguration.loadFromProperties(properties);
+        config.validateConfiguration();
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void validateConfigurationRequiredFilePath() {
+        setProperty(LOG_APPENDER, "file");
+        setProperty(APPENDER_FILE_PATH, null);
+
+        AuditConfigurationMap config = AuditConfiguration.loadFromProperties(properties);
+        config.validateConfiguration();
+    }
+
+    @Test
+    public void toPropertyTest() {
+        String property = toProperty(APPENDER_FILE_PATH);
+        assertEquals("appender.file.path", property);
+    }
+
+    private void setProperty(AuditConfiguration config, String value) {
+        String key = toProperty(config);
+        if ( value == null ) {
+            properties.remove(key);
+        } else {
+            properties.setProperty(key, value);
+        }
+    }
+
+    private String toProperty(AuditConfiguration config) {
+        return config.name().toLowerCase().replaceAll("_", ".");
+    }
+
+}


### PR DESCRIPTION
Backport of #466

**What is the problem this Pull Request is trying to solve?**
  Fix audit config appender name parsing

**What is the chosen solution to this problem?**
  Fix start index for substring.
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-222
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
