### PR TITLE
wi(TDKN-224): adding getAbsolutePath method and removing location pre…

### DIFF
--- a/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/ContextualPatternResolver.java
+++ b/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/ContextualPatternResolver.java
@@ -7,7 +7,8 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 
 /**
- * A helper for {@link ResourcePatternResolver} in case you want to prefix all locations with the same path. For example, in case
+ * A helper for {@link ResourcePatternResolver} in case you want to prefix all locations with the same path. For
+ * example, in case
  * you want "/file.txt" to be automatically converted to "/path/to/storage/file.txt".
  */
 public class ContextualPatternResolver implements ResourcePatternResolver {

--- a/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/DeletableResource.java
+++ b/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/DeletableResource.java
@@ -1,8 +1,8 @@
 package org.talend.daikon.content;
 
-import org.springframework.core.io.WritableResource;
-
 import java.io.IOException;
+
+import org.springframework.core.io.WritableResource;
 
 /**
  * An extension of Spring's {@link WritableResource} with {@link #delete()} capabilities.
@@ -16,6 +16,7 @@ public interface DeletableResource extends WritableResource {
 
     /**
      * Move given resource to the <code>location</code> given as parameter.
+     * 
      * @param location The new location for the resource
      */
     void move(String location) throws IOException;

--- a/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/DeletableResource.java
+++ b/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/DeletableResource.java
@@ -1,8 +1,8 @@
 package org.talend.daikon.content;
 
-import java.io.IOException;
-
 import org.springframework.core.io.WritableResource;
+
+import java.io.IOException;
 
 /**
  * An extension of Spring's {@link WritableResource} with {@link #delete()} capabilities.
@@ -19,4 +19,13 @@ public interface DeletableResource extends WritableResource {
      * @param location The new location for the resource
      */
     void move(String location) throws IOException;
+
+    /**
+     * Get the full absolute path for the resource
+     *
+     * @return the full absolute path of the resource
+     */
+    default String getAbsolutePath() throws IOException {
+        return getURI().getPath();
+    }
 }

--- a/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/ResourceResolver.java
+++ b/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/ResourceResolver.java
@@ -19,6 +19,8 @@ public interface ResourceResolver extends ResourcePatternResolver {
     @Override
     DeletableResource getResource(String location);
 
+    String getLocationPrefix();
+
     default void clear(String location) throws IOException {
         Resource[] files = getResources(location);
         for (Resource resource : files) {

--- a/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/ResourceResolver.java
+++ b/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/ResourceResolver.java
@@ -19,8 +19,19 @@ public interface ResourceResolver extends ResourcePatternResolver {
     @Override
     DeletableResource getResource(String location);
 
+    /**
+     * Returning the location prefix of the resource
+     * 
+     * @return the location prefix of the resource
+     */
     String getLocationPrefix();
 
+    /**
+     * Clear all resource according to a location
+     * 
+     * @param location the location
+     * @throws IOException e
+     */
     default void clear(String location) throws IOException {
         Resource[] files = getResources(location);
         for (Resource resource : files) {

--- a/daikon-content-service/content-service-journal-mongo/src/main/java/org/talend/daikon/content/journal/MongoResourceJournalResolver.java
+++ b/daikon-content-service/content-service-journal-mongo/src/main/java/org/talend/daikon/content/journal/MongoResourceJournalResolver.java
@@ -32,8 +32,14 @@ public class MongoResourceJournalResolver implements ResourceJournal {
     @Autowired
     private MongoResourceJournalRepository repository;
 
+    /**
+     * Resource resolver use to get the resource
+     */
+    @Autowired
+    private ResourceResolver resourceResolver;
+
     @Override
-    public void sync(ResourceResolver resourceResolver) {
+    public void sync() {
         if (ready()) {
             LOGGER.warn("Journal is flagged 'ready', consider calling invalidate() first.");
             return;
@@ -44,14 +50,7 @@ public class MongoResourceJournalResolver implements ResourceJournal {
             final DeletableResource[] resources = resourceResolver.getResources("/**");
             for (int i = 0; i < resources.length; i++) {
                 // removing prefix from absolute path
-                String resourceName = resources[i].getAbsolutePath();
-                String locationPrefix = formattingLocationPrefix(resourceResolver.getLocationPrefix(), resourceName);
-
-                if (resourceName.startsWith(locationPrefix)) {
-                    resourceName = resourceName.replaceFirst(locationPrefix, "");
-                }
-
-                add(resourceName);
+                add(resources[i].getAbsolutePath());
                 if (i % 500 == 0) {
                     LOGGER.info("Sync in progress ({}/{})", i, resources.length);
                 }
@@ -65,20 +64,40 @@ public class MongoResourceJournalResolver implements ResourceJournal {
     }
 
     /**
+     * Removing prefix from resourceName
+     *
+     * @param resourceName current resource name
+     * @return the resourceName without the prefix
+     */
+    private String removePrefixFromResourceName(String resourceName) {
+        String locationPrefix = formattingPrefixAccordingToResourceName(resourceName);
+
+        if (resourceName.startsWith(locationPrefix)) {
+            resourceName = resourceName.replaceFirst(locationPrefix, "");
+        }
+
+        return resourceName;
+    }
+
+    /**
      * Formatting prefix according to resourceName.
      * if resourceName is starting by / be sure that locationPrefix is also starting by /
      * if locationPrefix is starting by / and resourceName not remove it
      *
-     * @param locationPrefix current location prefix
      * @param resourceName current resource name
-     * @return
+     * @return the location prefix formatted according to the resourceName
      */
-    private String formattingLocationPrefix(String locationPrefix, String resourceName) {
-        if (resourceName.startsWith("/") && !locationPrefix.startsWith("/")) {
-            locationPrefix = "/" + locationPrefix;
-        } else if (!resourceName.startsWith("/") && locationPrefix.startsWith("/")) {
-            locationPrefix = locationPrefix.substring(1);
+    private String formattingPrefixAccordingToResourceName(String resourceName) {
+        String locationPrefix = resourceResolver.getLocationPrefix();
+        if(StringUtils.isEmpty(locationPrefix)){
+            return "";
         }
+        if (resourceName.startsWith("/") && !locationPrefix.startsWith("/")) {
+            return "/" + locationPrefix;
+        } else if (!resourceName.startsWith("/") && locationPrefix.startsWith("/")) {
+            return locationPrefix.substring(1);
+        }
+
         return locationPrefix;
     }
 
@@ -89,13 +108,13 @@ public class MongoResourceJournalResolver implements ResourceJournal {
             return Stream.empty();
         }
 
-        String patternForMatch = formattingStringToMongoPattern(pattern);
+        String patternForMatch = formattingStringToMongoPattern(removePrefixFromResourceName(pattern));
         return repository.findByNameStartsWith(patternForMatch).stream().map(ResourceJournalEntry::getName);
     }
 
     @Override
     public void clear(String pattern) {
-        String patternForClear = formattingStringToMongoPattern(pattern);
+        String patternForClear = formattingStringToMongoPattern(removePrefixFromResourceName(pattern));
         repository.deleteByNameStartsWith(patternForClear);
         LOGGER.debug("Cleared location '{}'.", patternForClear);
     }
@@ -105,7 +124,7 @@ public class MongoResourceJournalResolver implements ResourceJournal {
         if (StringUtils.isEmpty(location)) {
             return;
         }
-        String savedLocation = updateLocationToAbsolutePath(location);
+        String savedLocation = updateLocationToAbsolutePath(removePrefixFromResourceName(location));
         if (!exist(savedLocation)) {
             repository.save(new ResourceJournalEntry(savedLocation));
         }
@@ -114,26 +133,30 @@ public class MongoResourceJournalResolver implements ResourceJournal {
 
     @Override
     public void remove(String location) {
-        repository.deleteByName(location);
+        repository.deleteByName(removePrefixFromResourceName(location));
         LOGGER.debug("Location '{}' removed from journal.", location);
     }
 
     @Override
     public void move(String source, String target) {
-        ResourceJournalEntry dbResourceJournalEntry = repository.findOne(Example.of(new ResourceJournalEntry(source)));
+        String sourceWithoutPrefix = removePrefixFromResourceName(source);
+        String targetWithoutPrefix = removePrefixFromResourceName(target);
+
+        ResourceJournalEntry dbResourceJournalEntry =
+                repository.findOne(Example.of(new ResourceJournalEntry(sourceWithoutPrefix)));
         if (dbResourceJournalEntry != null) {
-            dbResourceJournalEntry.setName(target);
+            dbResourceJournalEntry.setName(targetWithoutPrefix);
             repository.save(dbResourceJournalEntry);
-            repository.deleteByName(source);
-            LOGGER.debug("Move from '{}' to '{}' recorded in journal.", source, target);
+            repository.deleteByName(sourceWithoutPrefix);
+            LOGGER.debug("Move from '{}' to '{}' recorded in journal.", sourceWithoutPrefix, targetWithoutPrefix);
         } else {
-            LOGGER.warn("Unable to move '{}' to '{}' (not found in journal)", source, target);
+            LOGGER.warn("Unable to move '{}' to '{}' (not found in journal)", sourceWithoutPrefix, targetWithoutPrefix);
         }
     }
 
     @Override
     public boolean exist(String location) {
-        String savedLocation = updateLocationToAbsolutePath(location);
+        String savedLocation = updateLocationToAbsolutePath(removePrefixFromResourceName(location));
         final boolean exist = repository.countByName(savedLocation) > 0L;
         LOGGER.debug("Location check on '{}': {}", location, exist);
         return exist;

--- a/daikon-content-service/content-service-journal-mongo/src/main/java/org/talend/daikon/content/journal/MongoResourceJournalResolver.java
+++ b/daikon-content-service/content-service-journal-mongo/src/main/java/org/talend/daikon/content/journal/MongoResourceJournalResolver.java
@@ -1,5 +1,8 @@
 package org.talend.daikon.content.journal;
 
+import java.io.IOException;
+import java.util.stream.Stream;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,9 +14,6 @@ import org.talend.daikon.content.DeletableResource;
 import org.talend.daikon.content.ResourceResolver;
 import org.talend.daikon.exception.TalendRuntimeException;
 import org.talend.daikon.exception.error.CommonErrorCodes;
-
-import java.io.IOException;
-import java.util.stream.Stream;
 
 /**
  * An implementation of {@link ResourceJournal} that uses a MongoDB database as backend.
@@ -66,8 +66,8 @@ public class MongoResourceJournalResolver implements ResourceJournal {
 
     /**
      * Formatting prefix according to resourceName.
-     *  if resourceName is starting by / be sure that locationPrefix is also starting by /
-     *  if locationPrefix is starting by / and resourceName not remove it
+     * if resourceName is starting by / be sure that locationPrefix is also starting by /
+     * if locationPrefix is starting by / and resourceName not remove it
      *
      * @param locationPrefix current location prefix
      * @param resourceName current resource name

--- a/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/MongoResourceJournalResolverTest.java
+++ b/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/MongoResourceJournalResolverTest.java
@@ -1,7 +1,23 @@
 package org.talend.daikon.content.journal;
 
-import com.github.fakemongo.Fongo;
-import com.mongodb.MongoClient;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,23 +35,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.talend.daikon.content.DeletableResource;
 import org.talend.daikon.content.ResourceResolver;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
+import com.github.fakemongo.Fongo;
+import com.mongodb.MongoClient;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @DataMongoTest
@@ -263,7 +264,8 @@ public class MongoResourceJournalResolverTest {
         final DeletableResource resource2 = mock(DeletableResource.class);
         final DeletableResource resource3 = mock(DeletableResource.class);
         final DeletableResource resource4 = mock(DeletableResource.class);
-        when(resourceResolver.getResources(any())).thenReturn(new DeletableResource[] { resource1, resource2, resource3, resource4 });
+        when(resourceResolver.getResources(any()))
+                .thenReturn(new DeletableResource[] { resource1, resource2, resource3, resource4 });
         when(resourceResolver.getLocationPrefix()).thenReturn("prefix");
 
         when(resource1.getAbsolutePath()).thenReturn("/prefix/resource1");
@@ -289,7 +291,8 @@ public class MongoResourceJournalResolverTest {
         final DeletableResource resource2 = mock(DeletableResource.class);
         final DeletableResource resource3 = mock(DeletableResource.class);
         final DeletableResource resource4 = mock(DeletableResource.class);
-        when(resourceResolver.getResources(any())).thenReturn(new DeletableResource[] { resource1, resource2, resource3, resource4 });
+        when(resourceResolver.getResources(any()))
+                .thenReturn(new DeletableResource[] { resource1, resource2, resource3, resource4 });
         when(resourceResolver.getLocationPrefix()).thenReturn("/prefix");
 
         when(resource1.getAbsolutePath()).thenReturn("/prefix/resource1");

--- a/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/MongoResourceJournalResolverTest.java
+++ b/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/MongoResourceJournalResolverTest.java
@@ -40,7 +40,7 @@ import org.talend.daikon.content.ResourceResolver;
 import com.github.fakemongo.Fongo;
 import com.mongodb.MongoClient;
 
-@ActiveProfiles("test")
+@ActiveProfiles("mock")
 @RunWith(SpringJUnit4ClassRunner.class)
 @DataMongoTest
 @ContextConfiguration

--- a/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/MongoResourceJournalResolverTest.java
+++ b/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/MongoResourceJournalResolverTest.java
@@ -240,15 +240,71 @@ public class MongoResourceJournalResolverTest {
         final DeletableResource resource1 = mock(DeletableResource.class);
         final DeletableResource resource2 = mock(DeletableResource.class);
         when(resourceResolver.getResources(any())).thenReturn(new DeletableResource[] { resource1, resource2 });
+        when(resourceResolver.getLocationPrefix()).thenReturn("");
+
+        when(resource1.getAbsolutePath()).thenReturn("resource1");
+        when(resource2.getAbsolutePath()).thenReturn("resource2");
 
         // When
         resolver.sync(resourceResolver);
 
         // Then
         verify(resourceResolver, times(1)).getResources(eq("/**"));
-        verify(resource1, times(1)).getFilename();
-        verify(resource2, times(1)).getFilename();
+        verify(resource1, times(1)).getAbsolutePath();
+        verify(resource2, times(1)).getAbsolutePath();
         assertTrue(repository.exists(MongoResourceJournalResolver.JOURNAL_READY_MARKER));
+    }
+
+    @Test
+    public void shouldSyncWithResourceResolverAndPrefix1() throws IOException, InterruptedException {
+        // Given
+        final ResourceResolver resourceResolver = mock(ResourceResolver.class);
+        final DeletableResource resource1 = mock(DeletableResource.class);
+        final DeletableResource resource2 = mock(DeletableResource.class);
+        final DeletableResource resource3 = mock(DeletableResource.class);
+        final DeletableResource resource4 = mock(DeletableResource.class);
+        when(resourceResolver.getResources(any())).thenReturn(new DeletableResource[] { resource1, resource2, resource3, resource4 });
+        when(resourceResolver.getLocationPrefix()).thenReturn("prefix");
+
+        when(resource1.getAbsolutePath()).thenReturn("/prefix/resource1");
+        when(resource2.getAbsolutePath()).thenReturn("prefix/resource2");
+        when(resource3.getAbsolutePath()).thenReturn("/unprefix/resource3");
+        when(resource4.getAbsolutePath()).thenReturn("unprefix/resource4");
+
+        // When
+        resolver.sync(resourceResolver);
+
+        // Then
+        assertTrue(resolver.exist("/resource1"));
+        assertTrue(resolver.exist("/resource2"));
+        assertTrue(resolver.exist("/unprefix/resource3"));
+        assertTrue(resolver.exist("/unprefix/resource4"));
+    }
+
+    @Test
+    public void shouldSyncWithResourceResolverAndPrefix2() throws IOException, InterruptedException {
+        // Given
+        final ResourceResolver resourceResolver = mock(ResourceResolver.class);
+        final DeletableResource resource1 = mock(DeletableResource.class);
+        final DeletableResource resource2 = mock(DeletableResource.class);
+        final DeletableResource resource3 = mock(DeletableResource.class);
+        final DeletableResource resource4 = mock(DeletableResource.class);
+        when(resourceResolver.getResources(any())).thenReturn(new DeletableResource[] { resource1, resource2, resource3, resource4 });
+        when(resourceResolver.getLocationPrefix()).thenReturn("/prefix");
+
+        when(resource1.getAbsolutePath()).thenReturn("/prefix/resource1");
+        when(resource2.getAbsolutePath()).thenReturn("prefix/resource2");
+        when(resource3.getAbsolutePath()).thenReturn("/unprefix/resource3");
+        when(resource4.getAbsolutePath()).thenReturn("unprefix/resource4");
+
+        // When
+        resolver.sync(resourceResolver);
+
+        // Then
+        assertTrue(resolver.exist("/resource1"));
+        assertTrue(resolver.exist("/resource2"));
+        assertTrue(resolver.exist("/unprefix/resource3"));
+        assertTrue(resolver.exist("/unprefix/resource4"));
     }
 
     @Test

--- a/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/ResourceResolverTestConfiguration.java
+++ b/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/ResourceResolverTestConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.talend.daikon.content.ResourceResolver;
 
-@Profile("test")
+@Profile("mock")
 @Configuration
 public class ResourceResolverTestConfiguration {
 

--- a/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/ResourceResolverTestConfiguration.java
+++ b/daikon-content-service/content-service-journal-mongo/src/test/java/org/talend/daikon/content/journal/ResourceResolverTestConfiguration.java
@@ -1,0 +1,19 @@
+package org.talend.daikon.content.journal;
+
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.talend.daikon.content.ResourceResolver;
+
+@Profile("test")
+@Configuration
+public class ResourceResolverTestConfiguration {
+
+    @Bean
+    @Primary
+    public ResourceResolver resourceResolver() {
+        return Mockito.mock(ResourceResolver.class);
+    }
+}

--- a/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedResourceResolver.java
+++ b/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedResourceResolver.java
@@ -44,6 +44,11 @@ public class JournalizedResourceResolver implements ResourceResolver {
     }
 
     @Override
+    public String getLocationPrefix() {
+        return delegate.getLocationPrefix();
+    }
+
+    @Override
     public void clear(String location) throws IOException {
         Stream.of(getResources(location)).forEach(deletableResource -> {
             try {

--- a/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/ResourceJournal.java
+++ b/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/ResourceJournal.java
@@ -1,8 +1,8 @@
 package org.talend.daikon.content.journal;
 
-import org.talend.daikon.content.ResourceResolver;
-
 import java.util.stream.Stream;
+
+import org.talend.daikon.content.ResourceResolver;
 
 public interface ResourceJournal {
 
@@ -10,6 +10,7 @@ public interface ResourceJournal {
      * <p>
      * Synchronize the content of this journal with the {@link ResourceResolver} passed as parameter.
      * </p>
+     * 
      * @param resourceResolver The {@link ResourceResolver} to use for synchronization.
      */
     void sync(ResourceResolver resourceResolver);

--- a/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/ResourceJournal.java
+++ b/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/ResourceJournal.java
@@ -2,18 +2,12 @@ package org.talend.daikon.content.journal;
 
 import java.util.stream.Stream;
 
-import org.talend.daikon.content.ResourceResolver;
-
 public interface ResourceJournal {
 
     /**
-     * <p>
-     * Synchronize the content of this journal with the {@link ResourceResolver} passed as parameter.
-     * </p>
-     * 
-     * @param resourceResolver The {@link ResourceResolver} to use for synchronization.
+     * Synchronize the content of this journal
      */
-    void sync(ResourceResolver resourceResolver);
+    void sync();
 
     Stream<String> matches(String pattern);
 

--- a/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/ResourceResolverJournal.java
+++ b/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/ResourceResolverJournal.java
@@ -17,7 +17,7 @@ class ResourceResolverJournal implements ResourceJournal {
     }
 
     @Override
-    public void sync(ResourceResolver resourceResolver) {
+    public void sync() {
         // Nothing to do
     }
 

--- a/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalContentServiceConfiguration.java
+++ b/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalContentServiceConfiguration.java
@@ -43,7 +43,7 @@ public class LocalContentServiceConfiguration implements ContentServiceEnabled {
         final String localPath = environment.getProperty("content-service.store.local.path", StringUtils.EMPTY);
         LOGGER.info("Files stored to '{}'", localPath);
 
-        return new LocalResourceResolver(new ContextualPatternResolver(delegate, localPath));
+        return new LocalResourceResolver(new ContextualPatternResolver(delegate, localPath), localPath);
     }
 
     /**

--- a/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalDeletableResource.java
+++ b/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalDeletableResource.java
@@ -1,12 +1,7 @@
 package org.talend.daikon.content.local;
 
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.WritableResource;
-import org.talend.daikon.content.DeletableResource;
-import org.talend.daikon.content.ResourceResolver;
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 import java.io.File;
 import java.io.IOException;
@@ -19,8 +14,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.WritableResource;
+import org.talend.daikon.content.DeletableResource;
+import org.talend.daikon.content.ResourceResolver;
 
 class LocalDeletableResource implements DeletableResource {
 

--- a/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalDeletableResource.java
+++ b/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalDeletableResource.java
@@ -1,7 +1,12 @@
 package org.talend.daikon.content.local;
 
-import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.WritableResource;
+import org.talend.daikon.content.DeletableResource;
+import org.talend.daikon.content.ResourceResolver;
 
 import java.io.File;
 import java.io.IOException;
@@ -14,13 +19,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.apache.commons.io.FileUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.core.io.Resource;
-import org.springframework.core.io.WritableResource;
-import org.talend.daikon.content.ResourceResolver;
-import org.talend.daikon.content.DeletableResource;
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 class LocalDeletableResource implements DeletableResource {
 
@@ -131,4 +131,5 @@ class LocalDeletableResource implements DeletableResource {
             Files.move(source, target, REPLACE_EXISTING);
         }
     }
+
 }

--- a/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalResourceResolver.java
+++ b/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalResourceResolver.java
@@ -7,8 +7,11 @@ import org.talend.daikon.content.DeletableResource;
 
 class LocalResourceResolver extends AbstractResourceResolver {
 
-    LocalResourceResolver(ResourcePatternResolver delegate) {
+    private String locationPrefix;
+
+    LocalResourceResolver(ResourcePatternResolver delegate, String locationPrefix) {
         super(delegate);
+        this.locationPrefix = locationPrefix;
     }
 
     @Override
@@ -16,4 +19,8 @@ class LocalResourceResolver extends AbstractResourceResolver {
         return new LocalDeletableResource(this, writableResource);
     }
 
+    @Override
+    public String getLocationPrefix() {
+        return this.locationPrefix;
+    }
 }

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -1,10 +1,6 @@
 package org.talend.daikon.content.s3;
 
-import static org.talend.daikon.content.s3.LocationUtils.toS3Location;
-import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
-
-import java.io.IOException;
-
+import com.amazonaws.services.s3.AmazonS3;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.core.io.WritableResource;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -12,7 +8,10 @@ import org.talend.daikon.content.AbstractResourceResolver;
 import org.talend.daikon.content.DeletableResource;
 import org.talend.daikon.content.s3.provider.S3BucketProvider;
 
-import com.amazonaws.services.s3.AmazonS3;
+import java.io.IOException;
+
+import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
+import static org.talend.daikon.content.s3.LocationUtils.toS3Location;
 
 class S3ResourceResolver extends AbstractResourceResolver {
 
@@ -50,6 +49,13 @@ class S3ResourceResolver extends AbstractResourceResolver {
                 .append(toS3Location(location)) //
                 .build();
         return super.getResource("s3://" + s3Location);
+    }
+
+    @Override
+    public String getLocationPrefix() {
+        return builder(bucket.getBucketName()) //
+                .append(bucket.getRoot()) //
+                .build();
     }
 
     @Override

--- a/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -1,6 +1,10 @@
 package org.talend.daikon.content.s3;
 
-import com.amazonaws.services.s3.AmazonS3;
+import static org.talend.daikon.content.s3.LocationUtils.toS3Location;
+import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
+
+import java.io.IOException;
+
 import org.apache.commons.lang.StringUtils;
 import org.springframework.core.io.WritableResource;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -8,10 +12,7 @@ import org.talend.daikon.content.AbstractResourceResolver;
 import org.talend.daikon.content.DeletableResource;
 import org.talend.daikon.content.s3.provider.S3BucketProvider;
 
-import java.io.IOException;
-
-import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
-import static org.talend.daikon.content.s3.LocationUtils.toS3Location;
+import com.amazonaws.services.s3.AmazonS3;
 
 class S3ResourceResolver extends AbstractResourceResolver {
 
@@ -60,7 +61,7 @@ class S3ResourceResolver extends AbstractResourceResolver {
 
     @Override
     protected DeletableResource convert(WritableResource writableResource) {
-        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket.getBucketName(),
-                bucket.getRoot());
+        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(),
+                bucket.getBucketName(), bucket.getRoot());
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Currently MongoResourceJournalResolver synchronizes all content without the full path.
For example` /tmp/dataprep/cache/a.txt` will be synchronized as `a.txt`
 
**What is the chosen solution to this problem?**
Getting access to full absolute path and ResourceLocal prefix in order to synchronize correctly the path of the resource.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-224
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
