### PR TITLE
feat(TDKN-229): Add more tql client operators

### DIFF
--- a/daikon-tql/daikon-tql-client/README.md
+++ b/daikon-tql/daikon-tql-client/README.md
@@ -163,6 +163,7 @@ TQL symbol               |Client class
 `quality`                |`Quality`
 `=`                      |`Equal`
 `>`                      |`GreaterThan`
+`>=`                     |`GreaterThanOrEqual`
 `<`                      |`LessThan`
 
 They are accessible via the `Operators` named export and can be serialized to TQL expressions :

--- a/daikon-tql/daikon-tql-client/README.md
+++ b/daikon-tql/daikon-tql-client/README.md
@@ -165,6 +165,7 @@ TQL symbol               |Client class
 `>`                      |`GreaterThan`
 `>=`                     |`GreaterThanOrEqual`
 `<`                      |`LessThan`
+`<=`                     |`LessThanOrEqual`
 
 They are accessible via the `Operators` named export and can be serialized to TQL expressions :
 

--- a/daikon-tql/daikon-tql-client/README.md
+++ b/daikon-tql/daikon-tql-client/README.md
@@ -167,6 +167,7 @@ TQL symbol               |Client class
 `>=`                     |`GreaterThanOrEqual`
 `<`                      |`LessThan`
 `<=`                     |`LessThanOrEqual`
+`in`                     |`In`
 
 They are accessible via the `Operators` named export and can be serialized to TQL expressions :
 

--- a/daikon-tql/daikon-tql-client/README.md
+++ b/daikon-tql/daikon-tql-client/README.md
@@ -162,6 +162,7 @@ TQL symbol               |Client class
 `between`                |`Between`
 `quality`                |`Quality`
 `=`                      |`Equal`
+`!=`                     |`Unequal`
 `>`                      |`GreaterThan`
 `>=`                     |`GreaterThanOrEqual`
 `<`                      |`LessThan`

--- a/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/greater-than-or-equal.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/greater-than-or-equal.spec.js
@@ -1,0 +1,24 @@
+import { GreaterThanOrEqual } from '..';
+
+describe('greater than or equal', () => {
+	it('should create a new greater than or equal operator', () => {
+		const test = new GreaterThanOrEqual('f1', 666);
+
+		expect(test.field).toBe('f1');
+		expect(test.operand).toBe(666);
+	});
+
+	it('should be convertible to a valid TQL query', () => {
+		const test = new GreaterThanOrEqual('f1', 666);
+
+		expect(test.serialize()).toBe('(f1 >= 666)');
+	});
+
+	it('should not allow empty operand', () => {
+		const test = new GreaterThanOrEqual('f1');
+
+		expect(() => {
+			test.serialize();
+		}).toThrow('>= does not allow empty.');
+	});
+});

--- a/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/greater-than.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/greater-than.spec.js
@@ -13,4 +13,12 @@ describe('greater than', () => {
 
 		expect(test.serialize()).toBe('(f1 > 666)');
 	});
+
+	it('should not allow empty operand', () => {
+		const test = new GreaterThan('f1');
+
+		expect(() => {
+			test.serialize();
+		}).toThrow('> does not allow empty.');
+	});
 });

--- a/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/in.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/in.spec.js
@@ -1,0 +1,33 @@
+import { In } from '..';
+
+describe('in', () => {
+	it('should create a new in operator', () => {
+		const test = new In('f1', [666, 777]);
+
+		expect(test.serialize()).toBe('(f1 in [666, 777])');
+	});
+
+	it('should accept multiple values', () => {
+		const test = new In('f1', [555, 666, 777, 888, 999]);
+
+		expect(test.serialize()).toBe('(f1 in [555, 666, 777, 888, 999])');
+	});
+
+	it('should wrap string value in simple quotes', () => {
+		const test = new In('f1', ['666', '777']);
+
+		expect(test.serialize()).toBe("(f1 in ['666', '777'])");
+	});
+
+	it('should accept operand with only one value', () => {
+		const test = new In('f1', [666]);
+
+		expect(test.serialize()).toBe('(f1 in [666])');
+	});
+
+	it('should accept operand with only one value not in an array', () => {
+		const test = new In('f1', 666);
+
+		expect(test.serialize()).toBe('(f1 in [666])');
+	});
+});

--- a/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/less-than-or-equal.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/less-than-or-equal.spec.js
@@ -1,0 +1,24 @@
+import { LessThanOrEqual } from '..';
+
+describe('less than or equal', () => {
+	it('should create a new less than or equal operator', () => {
+		const test = new LessThanOrEqual('f1', 666);
+
+		expect(test.field).toBe('f1');
+		expect(test.operand).toBe(666);
+	});
+
+	it('should be convertible to a valid TQL query', () => {
+		const test = new LessThanOrEqual('f1', 666);
+
+		expect(test.serialize()).toBe('(f1 <= 666)');
+	});
+
+	it('should not allow empty operand', () => {
+		const test = new LessThanOrEqual('f1');
+
+		expect(() => {
+			test.serialize();
+		}).toThrow('<= does not allow empty.');
+	});
+});

--- a/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/unequal.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/__tests__/unequal.spec.js
@@ -1,0 +1,30 @@
+import { Unequal } from '..';
+
+describe('unequal', () => {
+	it('should create a new unequal operator', () => {
+		const test = new Unequal('f1', 666);
+
+		expect(test.field).toBe('f1');
+		expect(test.operand).toBe(666);
+	});
+
+	it('should be convertible to a valid TQL query', () => {
+		const test = new Unequal('f1', 666);
+
+		expect(test.serialize()).toBe('(f1 != 666)');
+	});
+
+	it('should wrap strings', () => {
+		const test = new Unequal('f1', 'Charles');
+
+		expect(test.serialize()).toBe("(f1 != 'Charles')");
+	});
+
+	it('should not allow empty operand', () => {
+		const test = new Unequal('f1');
+
+		expect(() => {
+			test.serialize();
+		}).toThrow('!= does not allow empty.');
+	});
+});

--- a/daikon-tql/daikon-tql-client/src/converter/operators/greater-than-or-equal.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/greater-than-or-equal.js
@@ -1,0 +1,10 @@
+import Operator from './operator';
+
+/**
+ * Class representing the Greater Than Or Equal operator.
+ * Will be serialized as follows : (field1 >= 42)
+ */
+export default class GreaterThanOrEqual extends Operator {
+	static value = '>=';
+	static hasOperand = true;
+}

--- a/daikon-tql/daikon-tql-client/src/converter/operators/in.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/in.js
@@ -7,7 +7,7 @@ import Operator, {
  * Class representing the In operator.
  * Will be serialized as follows : (field1 in [42, 76])
  */
-export default class Between extends Operator {
+export default class In extends Operator {
 	static value = 'in';
 	static hasOperand = true;
 

--- a/daikon-tql/daikon-tql-client/src/converter/operators/in.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/in.js
@@ -1,0 +1,30 @@
+import Operator, {
+	isDefined,
+	wrap,
+} from './operator';
+
+/**
+ * Class representing the In operator.
+ * Will be serialized as follows : (field1 in [42, 76])
+ */
+export default class Between extends Operator {
+	static value = 'in';
+	static hasOperand = true;
+
+	serialize() {
+		if (!isDefined(this.operand)) {
+			throw new Error(`${this.constructor.value} does not allow empty.`);
+		}
+
+		const operandAsArray = (
+			Array.isArray(this.operand)
+				? this.operand
+				: [this.operand]
+		);
+
+		const operandAsArrayFormatted = operandAsArray
+			.map(value => wrap(value));
+
+		return `(${this.field} ${this.constructor.value} [${operandAsArrayFormatted.join(', ')}])`;
+	}
+}

--- a/daikon-tql/daikon-tql-client/src/converter/operators/index.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/index.js
@@ -5,6 +5,7 @@ import ContainsIgnoreCase from './containsIgnoreCase';
 import Complies from './complies';
 import WordComplies from './wordComplies';
 import GreaterThan from './greater-than';
+import GreaterThanOrEqual from './greater-than-or-equal';
 import LessThan from './less-than';
 import Valid from './valid';
 import Invalid from './invalid';
@@ -19,6 +20,7 @@ export {
 	Complies,
 	WordComplies,
 	GreaterThan,
+	GreaterThanOrEqual,
 	LessThan,
 	Valid,
 	Invalid,

--- a/daikon-tql/daikon-tql-client/src/converter/operators/index.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/index.js
@@ -7,6 +7,7 @@ import WordComplies from './wordComplies';
 import GreaterThan from './greater-than';
 import GreaterThanOrEqual from './greater-than-or-equal';
 import LessThan from './less-than';
+import LessThanOrEqual from './less-than-or-equal';
 import Valid from './valid';
 import Invalid from './invalid';
 import Between from './between';
@@ -22,6 +23,7 @@ export {
 	GreaterThan,
 	GreaterThanOrEqual,
 	LessThan,
+	LessThanOrEqual,
 	Valid,
 	Invalid,
 	Between,

--- a/daikon-tql/daikon-tql-client/src/converter/operators/index.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/index.js
@@ -1,5 +1,6 @@
 import Empty from './empty';
 import Equal from './equal';
+import Unequal from './unequal';
 import Contains from './contains';
 import ContainsIgnoreCase from './containsIgnoreCase';
 import Complies from './complies';
@@ -16,6 +17,7 @@ import Quality from './quality';
 export {
 	Empty,
 	Equal,
+	Unequal,
 	Contains,
 	ContainsIgnoreCase,
 	Complies,

--- a/daikon-tql/daikon-tql-client/src/converter/operators/index.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/index.js
@@ -13,6 +13,7 @@ import Valid from './valid';
 import Invalid from './invalid';
 import Between from './between';
 import Quality from './quality';
+import In from './in';
 
 export {
 	Empty,
@@ -30,4 +31,5 @@ export {
 	Invalid,
 	Between,
 	Quality,
+	In,
 };

--- a/daikon-tql/daikon-tql-client/src/converter/operators/less-than-or-equal.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/less-than-or-equal.js
@@ -1,0 +1,10 @@
+import Operator from './operator';
+
+/**
+ * Class representing the Less Than Or Equal operator.
+ * Will be serialized as follows : (field1 <= 42)
+ */
+export default class LessThanOrEqual extends Operator {
+	static value = '<=';
+	static hasOperand = true;
+}

--- a/daikon-tql/daikon-tql-client/src/converter/operators/operator.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/operator.js
@@ -7,11 +7,11 @@ function isString(value) {
 	return typeof value === 'string';
 }
 
-function wrap(value) {
+export function wrap(value) {
 	return isString(value) ? `'${value}'` : value;
 }
 
-function isDefined(value) {
+export function isDefined(value) {
 	return value != null && value !== '';
 }
 

--- a/daikon-tql/daikon-tql-client/src/converter/operators/unequal.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/unequal.js
@@ -1,0 +1,11 @@
+import Operator from './operator';
+
+/**
+ * Class representing the Unequal operator.
+ * Will be serialized as follows : (field1 != 42)
+ * Text values will be automatically wrapped : (field1 != 'Talend')
+ */
+export default class Unequal extends Operator {
+	static value = '!=';
+	static hasOperand = true;
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
`in`, `lessThanOrEqual`, `greaterThanOrEqual`, `unequal` operators not existing in the client lib.

**What is the chosen solution to this problem?**
Add the implementation for each of them.

**Link to the JIRA issue**

https://jira.talendforge.org/browse/TDKN-229
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
