### PR TITLE
feat: use markers to dynamically populate some custom info

### DIFF
--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONLayout.java
@@ -208,7 +208,7 @@ public class LogbackJSONLayout extends JsonLayout<ILoggingEvent> {
     private String mergeUserFields(String... fields) {
         String merged = Stream.of(fields).filter(Objects::nonNull).filter(StringUtils::isNotEmpty)
                 .collect(Collectors.joining(","));
-        return merged.isEmpty() ? null : merged;
+        return (merged != null && merged.isEmpty()) ? null : merged;
     }
 
     private String dateFormat(long timestamp) {

--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONLayout.java
@@ -2,12 +2,15 @@ package org.talend.daikon.logging.event.layout;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.RuntimeMXBean;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
+import ch.qos.logback.classic.spi.LoggingEvent;
+import ch.qos.logback.core.net.SyslogOutputStream;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Marker;
 import org.talend.daikon.logging.event.field.HostData;
 import org.talend.daikon.logging.event.field.LayoutFields;
 
@@ -55,10 +58,10 @@ public class LogbackJSONLayout extends JsonLayout<ILoggingEvent> {
         HostData host = new HostData();
 
         // Extract and add fields from log4j config, if defined
-        if (getUserFields() != null) {
-            String userFlds = getUserFields();
-            LayoutUtils.addUserFields(userFlds, userFieldsEvent);
-        }
+        String userFldsFromParam = getUserFields();
+        // Extract and add fields from markers, if defined
+        String userFldsFromMarker = getUserFieldsFromMarker(loggingEvent);
+        LayoutUtils.addUserFields(mergeUserFields(userFldsFromParam, userFldsFromMarker), userFieldsEvent);
 
         Map<String, String> mdc = LayoutUtils.processMDCMetaFields(loggingEvent.getMDCPropertyMap(), logstashEvent, metaFields);
 
@@ -166,6 +169,46 @@ public class LogbackJSONLayout extends JsonLayout<ILoggingEvent> {
             return null;
         }
         return ste[0];
+    }
+
+    /**
+     * Iterate over the logging event marker children, and concatenate them in a single string.
+     *
+     * @param event the logging event
+     * @return a string that contains the marker children, separated by 'commas'
+     */
+    private String getUserFieldsFromMarker(final ILoggingEvent event) {
+        Marker customFieldsMarker = LayoutUtils.findCustomFieldsMarker(event.getMarker(), new HashSet<>());
+        if (customFieldsMarker != null) {
+            Spliterator<Marker> markers = Spliterators.spliteratorUnknownSize(customFieldsMarker.iterator(), Spliterator.NONNULL);
+            return StreamSupport.stream(markers, false).map(Marker::getName).collect(Collectors.joining(","));
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Merges a list of user fields into a single one.
+     *
+     * {{{
+     * field1: prop11:value11,prop12:value12
+     * field2: prop21:value21,prop22:value22
+     * }}}
+     *
+     * will result in:
+     *
+     * {{{
+     * prop11:value11,prop12:value12,prop21:value21,prop22:value22
+     * }}}
+     *
+     *
+     * @param fields the list of user fields
+     * @return a single user fields property, in which fields are separated by a comma.
+     */
+    private String mergeUserFields(String... fields) {
+        String merged = Stream.of(fields).filter(Objects::nonNull).filter(StringUtils::isNotEmpty)
+                .collect(Collectors.joining(","));
+        return merged.isEmpty() ? null : merged;
     }
 
     private String dateFormat(long timestamp) {

--- a/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/AbstractLayoutTest.java
+++ b/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/AbstractLayoutTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Marker;
 import org.talend.daikon.logging.event.field.LayoutFields;
 import org.talend.daikon.logging.event.layout.LayoutUtils;
 
@@ -178,6 +179,8 @@ public abstract class AbstractLayoutTest {
 
         private Map<String, String> mdc = new HashMap<>();
 
+        private Marker marker;
+
         public LogDetails(Class clazz) {
             this.className = clazz.getName();
             this.methodName = "newEvent";
@@ -271,6 +274,14 @@ public abstract class AbstractLayoutTest {
 
         public void setMdc(Map<String, String> mdc) {
             this.mdc = mdc;
+        }
+
+        public Marker getMarker() {
+            return marker;
+        }
+
+        public void setMarker(Marker marker) {
+            this.marker = marker;
         }
     }
 

--- a/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/LayoutUtilsTest.java
+++ b/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/LayoutUtilsTest.java
@@ -1,16 +1,18 @@
 package org.talend.daikon.logging.layout;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import net.minidev.json.JSONObject;
 import org.junit.Test;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+import org.talend.daikon.logging.event.field.LayoutFields;
 import org.talend.daikon.logging.event.layout.LayoutUtils;
+
+import static org.junit.Assert.*;
 
 /**
  *
@@ -54,5 +56,58 @@ public class LayoutUtilsTest {
         assertFalse(logstashEvent.containsKey("mdctest"));
         assertFalse(logstashEvent.containsKey("metatest"));
         assertFalse(logstashEvent.containsKey("customtest"));
+    }
+
+    @Test
+    public void testFindCustomFieldsMarker_emptyTree() {
+        assertNull(LayoutUtils.findCustomFieldsMarker(null, new HashSet<>()));
+    }
+
+    @Test
+    public void testFindCustomFieldsMarker_markerNotFound() {
+        assertNull(LayoutUtils.findCustomFieldsMarker(createMarker(null), new HashSet<>()));
+    }
+
+    @Test
+    public void testFindCustomFieldsMarker_markerFound() {
+        Marker customFieldsMarker = MarkerFactory.getMarker(LayoutFields.CUSTOM_INFO);
+        assertEquals(customFieldsMarker, LayoutUtils.findCustomFieldsMarker(createMarker(customFieldsMarker), new HashSet<>()));
+    }
+
+    @Test
+    public void testFindCustomFieldsMarker_markerNotFoundInfiniteLoop() {
+        assertNull(LayoutUtils.findCustomFieldsMarker(createAutoReferencedMarker(), new HashSet<>()));
+    }
+
+    private Marker createMarker(Marker customMarker) {
+        Marker level_0 = MarkerFactory.getDetachedMarker("level_0");
+        Marker level_1_marker_1_from_0 = MarkerFactory.getDetachedMarker("level_1_marker_1_from_0");
+        Marker level_1_marker_2_from_0 = MarkerFactory.getDetachedMarker("level_1_marker_2_from_0");
+        Marker level_1_marker_3_from_0 = MarkerFactory.getDetachedMarker("level_1_marker_3_from_0");
+        Marker level_2_marker_1_from_1 = MarkerFactory.getDetachedMarker("level_2_marker_1_from_1");
+        Marker level_2_marker_1_from_2 = MarkerFactory.getDetachedMarker("level_2_marker_1_from_2");
+        Marker level_2_marker_2_from_2 = customMarker != null ? customMarker
+                : MarkerFactory.getDetachedMarker("level_2_marker_2_from_2");
+        Marker level_2_marker_1_from_3 = MarkerFactory.getDetachedMarker("level_2_marker_1_from_3");
+        level_0.add(level_1_marker_1_from_0);
+        level_0.add(level_1_marker_2_from_0);
+        level_0.add(level_1_marker_3_from_0);
+        level_1_marker_1_from_0.add(level_2_marker_1_from_1);
+        level_1_marker_2_from_0.add(level_2_marker_1_from_2);
+        level_1_marker_2_from_0.add(level_2_marker_2_from_2);
+        level_1_marker_3_from_0.add(level_2_marker_1_from_3);
+        return level_0;
+    }
+
+    private Marker createAutoReferencedMarker() {
+        Marker level_0 = MarkerFactory.getDetachedMarker("level_0");
+        Marker level_1 = MarkerFactory.getDetachedMarker("level_1");
+        Marker level_2 = MarkerFactory.getDetachedMarker("level_2");
+        Marker level_3 = MarkerFactory.getDetachedMarker("level_3");
+        level_0.add(level_1);
+        level_1.add(level_2);
+        level_2.add(level_0);
+        level_2.add(level_3);
+        return level_0;
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
Using MDC in play applications is not straighforward and even not safe (see the `Limitation of the default implementation of the MDC` section in http://yanns.github.io/posts/2/). The way we might use it would be very intrusive in the code, by wrapping our logging events with the `MDC.put` and `MDC.clean`. Not ideal.

**What is the chosen solution to this problem?**

In order to workaround that limitation, the play documentation advices to use the markers of the logging events, to enrich the log messages (https://www.playframework.com/documentation/2.6.x/ScalaLogging#Using-Markers-and-Marker-Contexts).

This PR comes with the ability to enrich the customInfo field, with additional fields that might arrive as part of the logging event markers.
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
