### PR TITLE
fix(TDKN-232): Remove references to deleted annotations

### DIFF
--- a/daikon-messages/README.md
+++ b/daikon-messages/README.md
@@ -239,8 +239,6 @@ Applications should declare AvroSchemaMessageConverter like this:
 ```
 @Configuration
 @EnableBinding(...)
-@EnableMessagesProducerAutoConfig
-@EnableMessagesConsumerAutoConfig
 public class GlobalKafkaConfiguration {
 
     @Bean


### PR DESCRIPTION

**What is the problem this Pull Request is trying to solve?**

Remove code references to both @EnableMessagesProducerAutoConfig and @EnableMessagesConsumerAutoConfig (both annotation were removed during migration to Spring Boot 2).

**What is the chosen solution to this problem?**

Remove references to classes in documentation.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-232
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
