### PR TITLE
fix(TDKN-233): manage more use cases in BigDecimalParser

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
+++ b/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
@@ -28,7 +28,7 @@ public class BigDecimalParser {
 
     private static final Pattern TWO_DIFFERENT_SEPARATORS_PATTERN = Pattern.compile(".*\\d+([.\\h'])\\d+([,.])\\d+[)]?");
 
-    private static final Pattern CONTAINS_AT_LEAST_ONE_WHITESPACE = Pattern.compile("^[(-]?\\d+(\\h\\d{3})+[)]?");
+    private static final Pattern CONTAINS_AT_LEAST_ONE_WHITESPACE = Pattern.compile("^[(-]?\\d+( \\d{3})+[)]?");
 
     public static final DecimalFormat US_DECIMAL_PATTERN = new DecimalFormat("#,##0.##",
             DecimalFormatSymbols.getInstance(Locale.US));

--- a/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
+++ b/daikon/src/main/java/org/talend/daikon/number/BigDecimalParser.java
@@ -28,6 +28,8 @@ public class BigDecimalParser {
 
     private static final Pattern TWO_DIFFERENT_SEPARATORS_PATTERN = Pattern.compile(".*\\d+([.\\h'])\\d+([,.])\\d+[)]?");
 
+    private static final Pattern CONTAINS_AT_LEAST_ONE_WHITESPACE = Pattern.compile("^[(-]?\\d+(\\h\\d{3})+[)]?");
+
     public static final DecimalFormat US_DECIMAL_PATTERN = new DecimalFormat("#,##0.##",
             DecimalFormatSymbols.getInstance(Locale.US));
 
@@ -168,6 +170,20 @@ public class BigDecimalParser {
             toReturn.setDecimalSeparator(inferDecimalSeparator(groupingSeparator));
         }
 
+        /*
+         * This part checks cases where a whitespace separator is present. In this case, it's probably a
+         * grouping separator.
+         *
+         * Like in 3 254
+         */
+        matcher = CONTAINS_AT_LEAST_ONE_WHITESPACE.matcher(from);
+        if (matcher.matches()) {
+            String firstMatchingGroup = matcher.group(1);
+            final char groupingSeparator = firstMatchingGroup.charAt(0);
+            toReturn.setGroupingSeparator(groupingSeparator);
+            toReturn.setDecimalSeparator(inferDecimalSeparator(groupingSeparator));
+        }
+
         return toReturn;
     }
 
@@ -183,6 +199,7 @@ public class BigDecimalParser {
     private static char inferDecimalSeparator(char groupingSeparator) {
         switch (groupingSeparator) {
         case '.':
+        case ' ':
             return ',';
         default:
             return '.';

--- a/daikon/src/test/java/org/talend/daikon/number/BigDecimalParserTest.java
+++ b/daikon/src/test/java/org/talend/daikon/number/BigDecimalParserTest.java
@@ -181,7 +181,7 @@ public class BigDecimalParserTest {
     @Test
     public void testGuessSeparatorsManyGroupSep() {
         assertGuessSeparators("2.051.045", ',', '.');
-        assertGuessSeparators("2 051 045", '.', ' ');
+        assertGuessSeparators("2 051 045", ',', ' ');
         assertGuessSeparators("2" + ((char) 160) + "051" + ((char) 160) + "045", '.', ((char) 160)); // char(160) is
                                                                                                      // non-breaking space
         assertGuessSeparators("2,051,045", '.', ',');
@@ -214,6 +214,13 @@ public class BigDecimalParserTest {
     public void testGuessSeparatorsTDP5153() {
         assertGuessSeparators("5 555,555", ',', ' ');
         assertGuessSeparators("5.555,555", ',', '.');
+    }
+
+    @Test
+    public void testGuessSeparatorsTDKN233() {
+        assertGuessSeparators("3 000.0", '.', ' ');
+        assertGuessSeparators("3 000", ',', ' ');
+        assertGuessSeparators("111 111 111", ',', ' ');
     }
 
     @Test


### PR DESCRIPTION
* add management of space separators
* fix space management of inferDecimalSeparator
* add TUs
* fix existing TUs

**What is the problem this Pull Request is trying to solve?**
 Have the same management of decimals between TDP and Daikon.
https://docs.oracle.com/cd/E19455-01/806-0169/overview-9/index.html

**What is the chosen solution to this problem?**
Add code to manage more use cases

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-233
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
