### PR TITLE
chore(TDKN-239): Add Digester to crypto-utils

### DIFF
--- a/daikon-crypto/crypto-utils/README.md
+++ b/daikon-crypto/crypto-utils/README.md
@@ -20,8 +20,7 @@ This library offers utilities for both digest and encryption.
 
 ```java
 public static void main(String[] args) throws Exception {
-    byte[] salt = KeySources.random(16).getKey();
-    Digester digester = new Digester(KeySources.random(16), '-', DigestSources.pbkDf2(salt));
+    Digester digester = new Digester(KeySources.random(16), '-', DigestSources.pbkDf2());
     
     final String digest = digester.digest("tiger");
     System.out.println("digest = " + digest);
@@ -34,7 +33,7 @@ public static void main(String[] args) throws Exception {
 The code above produces this example (the randomized KeySource at the beginning make digest change at each execution).
 
 ```text
-digest = tpiu/qUhFXnpWqyk/QEGEg==-7pk720Mhv2ginUnIwX7vhMYRyzrQNH7hK1/aznsIYsY=
+digest = n/c7e9vGq2v10jlSyHT6Fw==-JVe5Q3cCfDcme16IeRlSwXR6NjbEfXPH4TNP/2Xlid0=
 Validate 'tiger': true
 Validate 'password': false
 ```

--- a/daikon-crypto/crypto-utils/README.md
+++ b/daikon-crypto/crypto-utils/README.md
@@ -21,11 +21,11 @@ This library offers utilities for both digest and encryption.
 ```java
 public static void main(String[] args) throws Exception {
     byte[] salt = KeySources.random(16).getKey();
-    Digester digester = new Digester(DigestSources.pbkDf2(salt));
-
+    Digester digester = new Digester(KeySources.random(16), '-', DigestSources.pbkDf2(salt));
+    
     final String digest = digester.digest("tiger");
     System.out.println("digest = " + digest);
-
+    
     System.out.println("Validate 'tiger': " + digester.validate("tiger", digest));
     System.out.println("Validate 'password': " + digester.validate("password", digest));
 }
@@ -34,7 +34,7 @@ public static void main(String[] args) throws Exception {
 The code above produces this example (the randomized KeySource at the beginning make digest change at each execution).
 
 ```text
-digest = j ���]��>e��e�B0����}"����76�-+��hnn���N��<�Ԡ.KkZ�\����ݍG
+digest = tpiu/qUhFXnpWqyk/QEGEg==-7pk720Mhv2ginUnIwX7vhMYRyzrQNH7hK1/aznsIYsY=
 Validate 'tiger': true
 Validate 'password': false
 ```

--- a/daikon-crypto/crypto-utils/README.md
+++ b/daikon-crypto/crypto-utils/README.md
@@ -18,8 +18,26 @@ This library offers utilities for both digest and encryption.
 
 ## Digest
 
+```java
+public static void main(String[] args) throws Exception {
+    byte[] salt = KeySources.random(16).getKey();
+    Digester digester = new Digester(DigestSources.pbkDf2(salt));
 
+    final String digest = digester.digest("tiger");
+    System.out.println("digest = " + digest);
 
+    System.out.println("Validate 'tiger': " + digester.validate("tiger", digest));
+    System.out.println("Validate 'password': " + digester.validate("password", digest));
+}
+```
+
+The code above produces this example (the randomized KeySource at the beginning make digest change at each execution).
+
+```text
+digest = j ���]��>e��e�B0����}"����76�-+��hnn���N��<�Ԡ.KkZ�\����ݍG
+Validate 'tiger': true
+Validate 'password': false
+```
 
 ### Encryption
 

--- a/daikon-crypto/crypto-utils/README.md
+++ b/daikon-crypto/crypto-utils/README.md
@@ -14,6 +14,15 @@ $> mvn install
 
 ## Usage
 
+This library offers utilities for both digest and encryption.
+
+## Digest
+
+
+
+
+### Encryption
+
 The main entry point for this module is the class `Encryption`. It needs as input:
 
 * A `KeySource`: the key that will be used to initialize the encryption algorithm. This is a critical piece of configuration: it cannot be a constant but it must be a value application must be able to find again (in case of an application restart, for example).

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/CipherSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/CipherSources.java
@@ -1,8 +1,6 @@
 package org.talend.daikon.crypto;
 
 import java.security.Key;
-import java.util.Base64;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.crypto.Cipher;
@@ -13,12 +11,6 @@ import javax.crypto.spec.SecretKeySpec;
  * A helper class to provide common {@link CipherSource} implementations.
  */
 public class CipherSources {
-
-    private static final Function<byte[], String> BASE64_ENCODER = bytes -> Base64.getEncoder().encodeToString(bytes);
-
-    private static final Function<byte[], byte[]> BASE64_DECODER = bytes -> Base64.getDecoder().decode(bytes);
-
-    private static final String ENCODING = "UTF-8";
 
     // Here to ensure helper-style access to methods
     private CipherSources() {
@@ -47,14 +39,14 @@ public class CipherSources {
 
             @Override
             public String encrypt(KeySource source, String data) throws Exception {
-                final byte[] encryptedBytes = get(source, Cipher.ENCRYPT_MODE).doFinal(data.getBytes(ENCODING));
-                return BASE64_ENCODER.apply(encryptedBytes);
+                final byte[] encryptedBytes = get(source, Cipher.ENCRYPT_MODE).doFinal(data.getBytes(EncodingUtils.ENCODING));
+                return EncodingUtils.BASE64_ENCODER.apply(encryptedBytes);
             }
 
             @Override
             public String decrypt(KeySource source, String data) throws Exception {
-                final byte[] bytes = BASE64_DECODER.apply(data.getBytes());
-                return new String(get(source, Cipher.DECRYPT_MODE).doFinal(bytes), ENCODING);
+                final byte[] bytes = EncodingUtils.BASE64_DECODER.apply(data.getBytes());
+                return new String(get(source, Cipher.DECRYPT_MODE).doFinal(bytes), EncodingUtils.ENCODING);
             }
         };
     }
@@ -80,7 +72,7 @@ public class CipherSources {
 
             @Override
             public String encrypt(KeySource source, String data) throws Exception {
-                final byte[] dataBytes = data.getBytes(ENCODING);
+                final byte[] dataBytes = data.getBytes(EncodingUtils.ENCODING);
                 final byte[] iv = KeySources.random(ivLength).getKey();
 
                 final Cipher cipher = get(source, Cipher.ENCRYPT_MODE, iv);
@@ -90,18 +82,18 @@ public class CipherSources {
                 System.arraycopy(iv, 0, encryptedBytes, 0, ivLength);
                 System.arraycopy(encryptedData, 0, encryptedBytes, ivLength, encryptedData.length);
 
-                return BASE64_ENCODER.apply(encryptedBytes);
+                return EncodingUtils.BASE64_ENCODER.apply(encryptedBytes);
             }
 
             @Override
             public String decrypt(KeySource source, String data) throws Exception {
-                final byte[] encryptedBytes = BASE64_DECODER.apply(data.getBytes(ENCODING));
+                final byte[] encryptedBytes = EncodingUtils.BASE64_DECODER.apply(data.getBytes(EncodingUtils.ENCODING));
 
                 final byte[] iv = new byte[ivLength];
                 System.arraycopy(encryptedBytes, 0, iv, 0, ivLength);
 
                 final Cipher cipher = get(source, Cipher.DECRYPT_MODE, iv);
-                return new String(cipher.doFinal(encryptedBytes, ivLength, encryptedBytes.length - ivLength), ENCODING);
+                return new String(cipher.doFinal(encryptedBytes, ivLength, encryptedBytes.length - ivLength), EncodingUtils.ENCODING);
             }
         };
     }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/CipherSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/CipherSources.java
@@ -73,7 +73,8 @@ public class CipherSources {
                 System.arraycopy(encryptedBytes, 0, iv, 0, ivLength);
 
                 final Cipher cipher = get(source, Cipher.DECRYPT_MODE, iv);
-                return new String(cipher.doFinal(encryptedBytes, ivLength, encryptedBytes.length - ivLength), EncodingUtils.ENCODING);
+                return new String(cipher.doFinal(encryptedBytes, ivLength, encryptedBytes.length - ivLength),
+                        EncodingUtils.ENCODING);
             }
         };
     }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/EncodingUtils.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/EncodingUtils.java
@@ -1,0 +1,16 @@
+package org.talend.daikon.crypto;
+
+import java.util.Base64;
+import java.util.function.Function;
+
+public class EncodingUtils {
+
+    public static final Function<byte[], String> BASE64_ENCODER = bytes -> Base64.getEncoder().encodeToString(bytes);
+
+    public static final Function<byte[], byte[]> BASE64_DECODER = bytes -> Base64.getDecoder().decode(bytes);
+
+    public static final String ENCODING = "UTF-8";
+
+    private EncodingUtils() {
+    }
+}

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/KeySources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/KeySources.java
@@ -17,6 +17,14 @@ public class KeySources {
     }
 
     /**
+     * @return A {@link KeySource} implementation that returns a empty key. This can be helpful to disable salt in
+     * {@link org.talend.daikon.crypto.digest.Digester}.
+     */
+    public static KeySource empty() {
+        return () -> new byte[0];
+    }
+
+    /**
      * <p>
      * Returns a {@link KeySource} that generates a random key using {@link SecureRandom#getInstanceStrong()}.
      * </p>
@@ -96,7 +104,8 @@ public class KeySources {
      * @see System#getProperty(String)
      */
     public static KeySource systemProperty(String systemProperty) {
-        return () -> Optional.ofNullable(System.getProperty(systemProperty)) //
+        return () -> Optional
+                .ofNullable(System.getProperty(systemProperty)) //
                 .orElseThrow(() -> new IllegalArgumentException("System property '" + systemProperty + "' not found")) //
                 .getBytes();
     }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/KeySources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/KeySources.java
@@ -104,8 +104,7 @@ public class KeySources {
      * @see System#getProperty(String)
      */
     public static KeySource systemProperty(String systemProperty) {
-        return () -> Optional
-                .ofNullable(System.getProperty(systemProperty)) //
+        return () -> Optional.ofNullable(System.getProperty(systemProperty)) //
                 .orElseThrow(() -> new IllegalArgumentException("System property '" + systemProperty + "' not found")) //
                 .getBytes();
     }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSource.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSource.java
@@ -3,5 +3,5 @@ package org.talend.daikon.crypto.digest;
 @FunctionalInterface
 public interface DigestSource {
 
-    String digest(String value);
+    String digest(String value, byte[] salt);
 }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSource.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSource.java
@@ -1,0 +1,7 @@
+package org.talend.daikon.crypto.digest;
+
+@FunctionalInterface
+public interface DigestSource {
+
+    String digest(String value);
+}

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -3,7 +3,6 @@ package org.talend.daikon.crypto.digest;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
-import java.util.Arrays;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
@@ -27,8 +26,9 @@ public class DigestSources {
             if (salt == null || salt.length == 0) {
                 return EncodingUtils.BASE64_ENCODER.apply(dataDigest);
             } else {
-                byte[] result = new byte[salt.length + dataDigest.length];
-                System.arraycopy(DigestUtils.sha256(salt), 0, result, 0, salt.length);
+                final byte[] digestedSalt = DigestUtils.sha256(salt);
+                final byte[] result = new byte[digestedSalt.length + dataDigest.length];
+                System.arraycopy(digestedSalt, 0, result, 0, digestedSalt.length);
                 System.arraycopy(dataDigest, 0, result, salt.length, dataDigest.length);
                 return EncodingUtils.BASE64_ENCODER.apply(result);
             }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -1,0 +1,10 @@
+package org.talend.daikon.crypto.digest;
+
+import org.apache.commons.codec.digest.DigestUtils;
+
+public class DigestSources {
+
+    public static DigestSource sha256() {
+        return DigestUtils::sha256Hex;
+    }
+}

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -1,6 +1,5 @@
 package org.talend.daikon.crypto.digest;
 
-import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
@@ -19,10 +18,10 @@ import org.talend.daikon.crypto.EncodingUtils;
 public class DigestSources {
 
     /**
-     * @return A simple SHA256 digest for simplistic use cases (not recommended, see {@link #pbkDf2(byte[])}).
+     * @return A simple SHA256 digest for simplistic use cases (not recommended, see {@link #pbkDf2()}).
      */
     public static DigestSource sha256() {
-        return DigestUtils::sha256Hex;
+        return (data, salt) -> DigestUtils.sha256Hex(data);
     }
 
     /**
@@ -34,11 +33,10 @@ public class DigestSources {
      * As recommendation, you may initialize a salt using {@link org.talend.daikon.crypto.KeySources#random(int)}.
      * </p>
      *
-     * @param salt The salt to be used to digest value.
      * @return A {@link DigestSource} implementation using PBKDF2 and provided <code>salt</code>
      */
-    public static DigestSource pbkDf2(byte[] salt) {
-        return value -> {
+    public static DigestSource pbkDf2() {
+        return (value, salt) -> {
             try {
                 KeySpec spec = new PBEKeySpec(value.toCharArray(), salt, 65536, 256);
                 SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -3,6 +3,7 @@ package org.talend.daikon.crypto.digest;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.KeySpec;
+import java.util.Arrays;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
@@ -21,7 +22,17 @@ public class DigestSources {
      * @return A simple SHA256 digest for simplistic use cases (not recommended, see {@link #pbkDf2()}).
      */
     public static DigestSource sha256() {
-        return (data, salt) -> DigestUtils.sha256Hex(data);
+        return (data, salt) -> {
+            final byte[] dataDigest = DigestUtils.sha256(data);
+            if (salt == null || salt.length == 0) {
+                return EncodingUtils.BASE64_ENCODER.apply(dataDigest);
+            } else {
+                byte[] result = new byte[salt.length + dataDigest.length];
+                System.arraycopy(salt, 0, result, 0, salt.length);
+                System.arraycopy(dataDigest, 0, result, salt.length, dataDigest.length);
+                return EncodingUtils.BASE64_ENCODER.apply(result);
+            }
+        };
     }
 
     /**

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -29,7 +29,7 @@ public class DigestSources {
                 final byte[] digestedSalt = DigestUtils.sha256(salt);
                 final byte[] result = new byte[digestedSalt.length + dataDigest.length];
                 System.arraycopy(digestedSalt, 0, result, 0, digestedSalt.length);
-                System.arraycopy(dataDigest, 0, result, salt.length, dataDigest.length);
+                System.arraycopy(dataDigest, 0, result, digestedSalt.length, dataDigest.length);
                 return EncodingUtils.BASE64_ENCODER.apply(result);
             }
         };

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -57,7 +57,7 @@ public class DigestSources {
                 final byte[] bytes = factory.generateSecret(spec).getEncoded();
                 return EncodingUtils.BASE64_ENCODER.apply(bytes);
             } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
-                throw new IllegalStateException("Unable digest value.", e);
+                throw new IllegalStateException("Unable to digest value.", e);
             }
         };
     }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -28,7 +28,7 @@ public class DigestSources {
                 return EncodingUtils.BASE64_ENCODER.apply(dataDigest);
             } else {
                 byte[] result = new byte[salt.length + dataDigest.length];
-                System.arraycopy(salt, 0, result, 0, salt.length);
+                System.arraycopy(DigestUtils.sha256(salt), 0, result, 0, salt.length);
                 System.arraycopy(dataDigest, 0, result, salt.length, dataDigest.length);
                 return EncodingUtils.BASE64_ENCODER.apply(result);
             }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -48,6 +48,9 @@ public class DigestSources {
      */
     public static DigestSource pbkDf2() {
         return (value, salt) -> {
+            if (salt == null || salt.length == 0) {
+                throw new IllegalArgumentException("Cannot use pbkDf2 with empty or null salt.");
+            }
             try {
                 KeySpec spec = new PBEKeySpec(value.toCharArray(), salt, 65536, 256);
                 SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -9,6 +9,7 @@ import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.talend.daikon.crypto.EncodingUtils;
 
 /**
  * A collection of {@link DigestSource} helpers to ease use of {@link Digester}.
@@ -30,7 +31,7 @@ public class DigestSources {
      * having multiple {@link Digester} in your code.
      * </p>
      * <p>
-     * As recommandation, you may initialize a salt using {@link org.talend.daikon.crypto.KeySources#random(int)}.
+     * As recommendation, you may initialize a salt using {@link org.talend.daikon.crypto.KeySources#random(int)}.
      * </p>
      *
      * @param salt The salt to be used to digest value.
@@ -41,7 +42,8 @@ public class DigestSources {
             try {
                 KeySpec spec = new PBEKeySpec(value.toCharArray(), salt, 65536, 256);
                 SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-                return new String(factory.generateSecret(spec).getEncoded(), StandardCharsets.UTF_8);
+                final byte[] bytes = factory.generateSecret(spec).getEncoded();
+                return EncodingUtils.BASE64_ENCODER.apply(bytes);
             } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                 throw new IllegalStateException("Unable digest value.", e);
             }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -1,10 +1,51 @@
 package org.talend.daikon.crypto.digest;
 
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
+
 import org.apache.commons.codec.digest.DigestUtils;
 
+/**
+ * A collection of {@link DigestSource} helpers to ease use of {@link Digester}.
+ *
+ * @see Digester
+ */
 public class DigestSources {
 
+    /**
+     * @return A simple SHA256 digest for simplistic use cases (not recommended, see {@link #pbkDf2(byte[])}).
+     */
     public static DigestSource sha256() {
         return DigestUtils::sha256Hex;
     }
+
+    /**
+     * <p>
+     * Returns a PBKDF2 (with Hmac SHA256) digester. Please note <code>salt</code> must remain the same if you plan on
+     * having multiple {@link Digester} in your code.
+     * </p>
+     * <p>
+     * As recommandation, you may initialize a salt using {@link org.talend.daikon.crypto.KeySources#random(int)}.
+     * </p>
+     *
+     * @param salt The salt to be used to digest value.
+     * @return A {@link DigestSource} implementation using PBKDF2 and provided <code>salt</code>
+     */
+    public static DigestSource pbkDf2(byte[] salt) {
+        return value -> {
+            try {
+                KeySpec spec = new PBEKeySpec(value.toCharArray(), salt, 65536, 256);
+                SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+                return new String(factory.generateSecret(spec).getEncoded(), StandardCharsets.UTF_8);
+            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                throw new IllegalStateException("Unable digest value.", e);
+            }
+        };
+    }
+
 }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 
 import static java.lang.String.valueOf;
 import static java.util.Arrays.stream;
-import static java.util.stream.Collectors.joining;
 
 /**
  * This class provides a helper class to:
@@ -32,8 +31,8 @@ public class Digester {
     private static final int[] FORBIDDEN_DELIMITERS = { '/', '=' };
 
     /**
-     * Creates a Digester using a {@link KeySources#random(int)} and "-" as delimiter for separating salt and digested
-     * value.
+     * Creates a Digester using a 16 byte length random key (see {@link KeySources#random(int)}) and "-" as delimiter
+     * for separating salt and digested value.
      * 
      * @param digestSource The {@link DigestSource} implementation to digest values.
      * @see DigestSources
@@ -104,6 +103,11 @@ public class Digester {
             return (digestSource.digest(value, new byte[0])).equals(digest);
         }
         try {
+            if (digest.indexOf(delimiter) < 0) {
+                // Digest is expected to have delimiter in it: don't return what the expected delimiter is in the
+                // exception message to prevent giving information about expected delimiter to caller.
+                throw new IllegalArgumentException("No delimiter found in digest.");
+            }
             final String saltBase64 = StringUtils.substringBefore(digest, valueOf(delimiter));
             final byte[] salt = decode(saltBase64.getBytes(EncodingUtils.ENCODING));
             return (saltBase64 + delimiter + digestSource.digest(value, salt)).equals(digest);

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
@@ -1,9 +1,18 @@
 package org.talend.daikon.crypto.digest;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.lang3.StringUtils;
 import org.talend.daikon.crypto.KeySource;
 import org.talend.daikon.crypto.KeySources;
 
+/**
+ * This class provides a helper class to:
+ * <ul>
+ * <li>digest a given string.</li>
+ * <li>validate (compare) a plain value with a previously generated digest.</li>
+ * </ul>
+ */
 public class Digester {
 
     private final DigestSource digestSource;
@@ -12,16 +21,26 @@ public class Digester {
 
     private final String delimiter;
 
+    /**
+     * Creates a Digester using a {@link KeySources#random(int)} and "-" as delimiter for separating salt and digested
+     * value.
+     * 
+     * @param digestSource The {@link DigestSource} implementation to digest values.
+     * @see DigestSources
+     */
     public Digester(DigestSource digestSource) {
-        this(KeySources.random(8), "", digestSource);
+        this(KeySources.random(16), "-", digestSource);
     }
 
-    public Digester(KeySource keySource) {
-        this(keySource, "", DigestSources.sha256());
-    }
-
+    /**
+     * Creates a Digester using provided {@link KeySource} for salt, "-" as salt/value delimiter, and provided
+     * {@link DigestSource}.
+     * 
+     * @param keySource The {@link KeySource} to add salt to digested values.
+     * @param digestSource The {@link DigestSource} implementation to digest values.
+     */
     public Digester(KeySource keySource, DigestSource digestSource) {
-        this(keySource, "", digestSource);
+        this(keySource, "-", digestSource);
     }
 
     public Digester(KeySource keySource, String delimiter, DigestSource digestSource) {
@@ -31,15 +50,29 @@ public class Digester {
     }
 
     private String saltValue(String value, String salt) {
-        return digestSource.digest(salt) + delimiter + digestSource.digest(value);
+        return salt + delimiter + digestSource.digest(salt + value);
     }
 
+    /**
+     * Digest a plain text value and returns a digested value.
+     *
+     * @param value The value to digest.
+     * @return A digested value using salt, delimiter and digested value.
+     * @throws Exception In any digest issue (depends on the implementation of {@link DigestSource} used).
+     */
     public String digest(String value) throws Exception {
-        return saltValue(value, digestSource.digest(new String(keySource.getKey())));
+        return saltValue(value, digestSource.digest(new String(keySource.getKey(), StandardCharsets.UTF_8)));
     }
 
+    /**
+     * Allow to compare a plain text <code>value</code> with a digest.
+     * 
+     * @param value The plain text value.
+     * @param digest The digest to compare with.
+     * @return <code>true</code> if value matches digest, <code>false</code> otherwise.
+     */
     public boolean validate(String value, String digest) {
         String salt = StringUtils.substringBefore(digest, delimiter);
-        return (salt + delimiter + digestSource.digest(value)).equals(digest);
+        return (salt + delimiter + digestSource.digest(salt + value)).equals(digest);
     }
 }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
@@ -1,9 +1,8 @@
 package org.talend.daikon.crypto.digest;
 
-
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.talend.daikon.crypto.KeySource;
+import org.talend.daikon.crypto.KeySources;
 
 public class Digester {
 
@@ -13,14 +12,26 @@ public class Digester {
 
     private final String delimiter;
 
-    public Digester(KeySource keySource, String delimiter) {
+    public Digester(DigestSource digestSource) {
+        this(KeySources.random(8), "", digestSource);
+    }
+
+    public Digester(KeySource keySource) {
+        this(keySource, "", DigestSources.sha256());
+    }
+
+    public Digester(KeySource keySource, DigestSource digestSource) {
+        this(keySource, "", digestSource);
+    }
+
+    public Digester(KeySource keySource, String delimiter, DigestSource digestSource) {
         this.keySource = keySource;
         this.delimiter = delimiter;
-        this.digestSource = DigestUtils::sha256Hex;
+        this.digestSource = digestSource;
     }
 
     private String saltValue(String value, String salt) {
-        return salt + delimiter + digestSource.digest(value);
+        return digestSource.digest(salt) + delimiter + digestSource.digest(value);
     }
 
     public String digest(String value) throws Exception {
@@ -29,7 +40,6 @@ public class Digester {
 
     public boolean validate(String value, String digest) {
         String salt = StringUtils.substringBefore(digest, delimiter);
-        return saltValue(value, salt).equals(digest);
+        return (salt + delimiter + digestSource.digest(value)).equals(digest);
     }
 }
-

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
@@ -5,6 +5,14 @@ import org.talend.daikon.crypto.EncodingUtils;
 import org.talend.daikon.crypto.KeySource;
 import org.talend.daikon.crypto.KeySources;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.lang.String.valueOf;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
 /**
  * This class provides a helper class to:
  * <ul>
@@ -21,6 +29,8 @@ public class Digester {
     private final KeySource keySource;
 
     private final char delimiter;
+
+    private static final int[] FORBIDDEN_DELIMETERS = { '/', '=' };
 
     /**
      * Creates a Digester using a {@link KeySources#random(int)} and "-" as delimiter for separating salt and digested
@@ -45,8 +55,11 @@ public class Digester {
     }
 
     public Digester(KeySource keySource, char delimiter, DigestSource digestSource) {
-        if (Character.isLetterOrDigit(delimiter) || delimiter == '=') {
-            throw new IllegalArgumentException("Delimiter cannot be number, letter or '='.");
+        if (Character.isLetterOrDigit(delimiter) || stream(FORBIDDEN_DELIMETERS).anyMatch(c -> c == delimiter)) {
+            final String forbiddenDelimiters = stream(FORBIDDEN_DELIMETERS) //
+                    .mapToObj(i -> valueOf((char) i)) //
+                    .collect(Collectors.joining());
+            throw new IllegalArgumentException("Delimiter cannot be number, letter or '" + forbiddenDelimiters + "'.");
         }
         this.keySource = keySource;
         this.delimiter = delimiter;
@@ -83,7 +96,7 @@ public class Digester {
         if (delimiter == NO_DELIMITER) {
             return (digestSource.digest(value)).equals(digest);
         }
-        String salt = StringUtils.substringBefore(digest, String.valueOf(delimiter));
+        String salt = StringUtils.substringBefore(digest, valueOf(delimiter));
         return (salt + delimiter + digestSource.digest(salt + value)).equals(digest);
     }
 }

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
@@ -1,0 +1,35 @@
+package org.talend.daikon.crypto.digest;
+
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.talend.daikon.crypto.KeySource;
+
+public class Digester {
+
+    private final DigestSource digestSource;
+
+    private final KeySource keySource;
+
+    private final String delimiter;
+
+    public Digester(KeySource keySource, String delimiter) {
+        this.keySource = keySource;
+        this.delimiter = delimiter;
+        this.digestSource = DigestUtils::sha256Hex;
+    }
+
+    private String saltValue(String value, String salt) {
+        return salt + delimiter + digestSource.digest(value);
+    }
+
+    public String digest(String value) throws Exception {
+        return saltValue(value, digestSource.digest(new String(keySource.getKey())));
+    }
+
+    public boolean validate(String value, String digest) {
+        String salt = StringUtils.substringBefore(digest, delimiter);
+        return saltValue(value, salt).equals(digest);
+    }
+}
+

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Digester.java
@@ -105,8 +105,8 @@ public class Digester {
         }
         try {
             final String saltBase64 = StringUtils.substringBefore(digest, valueOf(delimiter));
-            byte[] salt = decode(saltBase64.getBytes(EncodingUtils.ENCODING));
-            return (encode(salt) + delimiter + digestSource.digest(value, salt)).equals(digest);
+            final byte[] salt = decode(saltBase64.getBytes(EncodingUtils.ENCODING));
+            return (saltBase64 + delimiter + digestSource.digest(value, salt)).equals(digest);
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
         }

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigestSourcesTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigestSourcesTest.java
@@ -16,7 +16,7 @@ public class DigestSourcesTest {
         final String digest = DigestSources.sha256().digest(data, KeySources.fixedKey("abcd1234").getKey());
 
         // Then
-        assertEquals("YWJjZDEyMzTIG36TBiw+3zjgPRtgPlyVMhJAo7BDDZ6176QavT7/Eg==", digest);
+        assertEquals("6c7nGrky/ejIG36TBiw+3zjgPRtgPlyVMhJAo7BDDZ6176QavT7/Eg==", digest);
     }
 
     @Test

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigestSourcesTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigestSourcesTest.java
@@ -1,0 +1,65 @@
+package org.talend.daikon.crypto.digest;
+
+import org.junit.Test;
+import org.talend.daikon.crypto.KeySources;
+
+import static org.junit.Assert.*;
+
+public class DigestSourcesTest {
+
+    @Test
+    public void shouldUseSaltInSha256() throws Exception {
+        // Given
+        final String data = "value to digest";
+
+        // When
+        final String digest = DigestSources.sha256().digest(data, KeySources.fixedKey("abcd1234").getKey());
+
+        // Then
+        assertEquals("YWJjZDEyMzTIG36TBiw+3zjgPRtgPlyVMhJAo7BDDZ6176QavT7/Eg==", digest);
+    }
+
+    @Test
+    public void shouldNotUseSaltInSha256() {
+        // Given
+        final String data = "value to digest";
+
+        // When
+        final String digest1 = DigestSources.sha256().digest(data, null);
+        final String digest2 = DigestSources.sha256().digest(data, new byte[0]);
+
+        // Then
+        assertEquals(digest1, digest2);
+        assertEquals("yBt+kwYsPt844D0bYD5clTISQKOwQw2ete+kGr0+/xI=", digest1);
+    }
+
+    @Test
+    public void cannotUsePbkDf2WithoutSalt() {
+        // When
+        try {
+            DigestSources.pbkDf2().digest("value", null);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+
+        try {
+            DigestSources.pbkDf2().digest("value", new byte[0]);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void shouldUseSaltInPbkDf2() throws Exception {
+        // Given
+        final String data = "value to digest";
+
+        // When
+        final String digest = DigestSources.pbkDf2().digest(data, KeySources.fixedKey("abcd1234").getKey());
+
+        // Then
+        assertEquals("jAPuCXK/9TVMcpzqkS32je+dTE6FnTVAVH1d6FnMoy4=", digest);
+    }
+}

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigestSourcesTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigestSourcesTest.java
@@ -16,7 +16,7 @@ public class DigestSourcesTest {
         final String digest = DigestSources.sha256().digest(data, KeySources.fixedKey("abcd1234").getKey());
 
         // Then
-        assertEquals("6c7nGrky/ejIG36TBiw+3zjgPRtgPlyVMhJAo7BDDZ6176QavT7/Eg==", digest);
+        assertEquals("6c7nGrky/ehjM40Ivk3p3+OeoEm9r7NCzmWexUULaa7IG36TBiw+3zjgPRtgPlyVMhJAo7BDDZ6176QavT7/Eg==", digest);
     }
 
     @Test

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
@@ -1,6 +1,8 @@
 package org.talend.daikon.crypto.digest;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -8,10 +10,29 @@ import org.talend.daikon.crypto.KeySources;
 
 public class DigesterTest {
 
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailWithInvalidDelimiter() {
+        new Digester(KeySources.empty(), '1', DigestSources.sha256());
+    }
+
+    @Test
+    public void shouldDigestValueWithNoSalt() throws Exception {
+        // given
+        final String value = "myPassword";
+
+        // when
+        Digester digester = new Digester(KeySources.empty(), Digester.NO_DELIMITER, DigestSources.sha256());
+        final String digest = digester.digest(value);
+        final String directDigest = DigestSources.sha256().digest(value);
+
+        // then
+        assertArrayEquals(digest.getBytes(), directDigest.getBytes());
+    }
+
     @Test
     public void shouldDigestValue() throws Exception {
         // given
-        String value = "myPassword";
+        final String value = "myPassword";
 
         // when
         Digester digester = new Digester(KeySources.random(16), DigestSources.sha256());
@@ -44,10 +65,12 @@ public class DigesterTest {
         final byte[] salt = KeySources.random(16).getKey();
         Digester digester1 = new Digester(KeySources.random(16), DigestSources.pbkDf2(salt));
         Digester digester2 = new Digester(KeySources.random(16), DigestSources.pbkDf2(salt));
-        final String digest = digester1.digest(value);
+        final String digest1 = digester1.digest(value);
+        final String digest2 = digester2.digest(value);
 
         // then
-        assertTrue(digester2.validate("myPassword", digest));
-        assertFalse(digester2.validate("MyPassword", digest));
+        assertTrue(digester2.validate("myPassword", digest1));
+        assertFalse(digester2.validate("MyPassword", digest1));
+        assertNotEquals(digest1, digest2);
     }
 }

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
@@ -23,7 +23,7 @@ public class DigesterTest {
         // when
         Digester digester = new Digester(KeySources.empty(), Digester.NO_DELIMITER, DigestSources.sha256());
         final String digest = digester.digest(value);
-        final String directDigest = DigestSources.sha256().digest(value);
+        final String directDigest = DigestSources.sha256().digest(value, new byte[0]);
 
         // then
         assertArrayEquals(digest.getBytes(), directDigest.getBytes());
@@ -52,6 +52,7 @@ public class DigesterTest {
         final String digest = digester.digest(value);
 
         // then
+        System.out.println(digest);
         assertTrue(digester.validate("myPassword", digest));
         assertFalse(digester.validate("MyPassword", digest));
     }
@@ -62,9 +63,8 @@ public class DigesterTest {
         String value = "myPassword";
 
         // when
-        final byte[] salt = KeySources.random(16).getKey();
-        Digester digester1 = new Digester(KeySources.random(16), DigestSources.pbkDf2(salt));
-        Digester digester2 = new Digester(KeySources.random(16), DigestSources.pbkDf2(salt));
+        Digester digester1 = new Digester(KeySources.random(16), DigestSources.pbkDf2());
+        Digester digester2 = new Digester(KeySources.random(16), DigestSources.pbkDf2());
         final String digest1 = digester1.digest(value);
         final String digest2 = digester2.digest(value);
 

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
@@ -92,7 +92,8 @@ public class DigesterTest {
         final String digest = digester.digest(value);
 
         // Modify the 'salt' part
-        final byte[] tamperedSalt = StringUtils.substringBefore(digest, String.valueOf(delimiter)).getBytes(EncodingUtils.ENCODING);
+        final byte[] tamperedSalt = StringUtils.substringBefore(digest, String.valueOf(delimiter))
+                .getBytes(EncodingUtils.ENCODING);
         for (int i = 0; i < tamperedSalt.length; i++) {
             tamperedSalt[i]++;
         }
@@ -116,7 +117,8 @@ public class DigesterTest {
         final String digest = digester.digest(value);
 
         // Modify the 'salted digest' part
-        final byte[] tamperedDigest = StringUtils.substringAfter(digest, String.valueOf(delimiter)).getBytes(EncodingUtils.ENCODING);
+        final byte[] tamperedDigest = StringUtils.substringAfter(digest, String.valueOf(delimiter))
+                .getBytes(EncodingUtils.ENCODING);
         for (int i = 0; i < tamperedDigest.length; i++) {
             tamperedDigest[i]++;
         }

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
@@ -138,12 +138,19 @@ public class DigesterTest {
         final char delimiter = '-';
 
         // when
-        Digester digester = new Digester(KeySources.random(16), delimiter, DigestSources.pbkDf2());
+        Digester digester = new Digester(KeySources.random(16), delimiter, DigestSources.sha256());
         final String digest = digester.digest(value);
-        final String tampered = StringUtils.substringAfter(digest, String.valueOf(delimiter));
+        final String tampered = delimiter + StringUtils.substringAfter(digest, String.valueOf(delimiter));
 
         // then
         assertTrue(digester.validate(value, digest));
         assertFalse(digester.validate(value, tampered));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldCheckDelimiterInDigestOnValidate() {
+        // when
+        Digester digester = new Digester(KeySources.fixedKey("abcd1234"), '-', DigestSources.sha256());
+        digester.validate("myPassword", "digest that do not contain delimiter");
     }
 }

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
@@ -14,7 +14,7 @@ public class DigesterTest {
         String value = "myPassword";
 
         // when
-        Digester digester = new Digester(KeySources.random(8), "-", DigestSources.sha256());
+        Digester digester = new Digester(KeySources.random(16), DigestSources.sha256());
         final String digest = digester.digest(value);
 
         // then
@@ -27,7 +27,7 @@ public class DigesterTest {
         String value = "myPassword";
 
         // when
-        Digester digester = new Digester(KeySources.random(8), "-", DigestSources.sha256());
+        Digester digester = new Digester(KeySources.random(16), DigestSources.sha256());
         final String digest = digester.digest(value);
 
         // then
@@ -41,8 +41,9 @@ public class DigesterTest {
         String value = "myPassword";
 
         // when
-        Digester digester1 = new Digester(KeySources.random(8), "-", DigestSources.sha256());
-        Digester digester2 = new Digester(KeySources.random(8), "-", DigestSources.sha256());
+        final byte[] salt = KeySources.random(16).getKey();
+        Digester digester1 = new Digester(KeySources.random(16), DigestSources.pbkDf2(salt));
+        Digester digester2 = new Digester(KeySources.random(16), DigestSources.pbkDf2(salt));
         final String digest = digester1.digest(value);
 
         // then

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
@@ -14,7 +14,7 @@ public class DigesterTest {
         String value = "myPassword";
 
         // when
-        Digester digester = new Digester(KeySources.random(8), "-");
+        Digester digester = new Digester(KeySources.random(8), "-", DigestSources.sha256());
         final String digest = digester.digest(value);
 
         // then
@@ -27,7 +27,7 @@ public class DigesterTest {
         String value = "myPassword";
 
         // when
-        Digester digester = new Digester(KeySources.random(8), "-");
+        Digester digester = new Digester(KeySources.random(8), "-", DigestSources.sha256());
         final String digest = digester.digest(value);
 
         // then
@@ -41,8 +41,8 @@ public class DigesterTest {
         String value = "myPassword";
 
         // when
-        Digester digester1 = new Digester(KeySources.random(8), "-");
-        Digester digester2 = new Digester(KeySources.random(8), "-");
+        Digester digester1 = new Digester(KeySources.random(8), "-", DigestSources.sha256());
+        Digester digester2 = new Digester(KeySources.random(8), "-", DigestSources.sha256());
         final String digest = digester1.digest(value);
 
         // then

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigesterTest.java
@@ -1,0 +1,52 @@
+package org.talend.daikon.crypto.digest;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.talend.daikon.crypto.KeySources;
+
+public class DigesterTest {
+
+    @Test
+    public void shouldDigestValue() throws Exception {
+        // given
+        String value = "myPassword";
+
+        // when
+        Digester digester = new Digester(KeySources.random(8), "-");
+        final String digest = digester.digest(value);
+
+        // then
+        assertTrue(digest.contains("-"));
+    }
+
+    @Test
+    public void shouldValidateValue() throws Exception {
+        // given
+        String value = "myPassword";
+
+        // when
+        Digester digester = new Digester(KeySources.random(8), "-");
+        final String digest = digester.digest(value);
+
+        // then
+        assertTrue(digester.validate("myPassword", digest));
+        assertFalse(digester.validate("MyPassword", digest));
+    }
+
+    @Test
+    public void shouldValidateValueWithDifferentDigester() throws Exception {
+        // given
+        String value = "myPassword";
+
+        // when
+        Digester digester1 = new Digester(KeySources.random(8), "-");
+        Digester digester2 = new Digester(KeySources.random(8), "-");
+        final String digest = digester1.digest(value);
+
+        // then
+        assertTrue(digester2.validate("myPassword", digest));
+        assertFalse(digester2.validate("MyPassword", digest));
+    }
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
Provide a way to digest a value using a salt.

**What is the chosen solution to this problem?**
 
Digest a value using "(salt, delimiter, value) -> (salt + delimiter + sha256(value))" as result (instead of a single `value -> sha256(value)`).

**Link to the JIRA issue**

https://jira.talendforge.org/browse/TDKN-239
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->