### PR TITLE
TDKN-237 Provide getDefault() method for class org.talend.daikon.security.CryptoHelper on branch maintenance/0.31

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/security/CryptoHelper.java
+++ b/daikon/src/main/java/org/talend/daikon/security/CryptoHelper.java
@@ -130,4 +130,7 @@ public class CryptoHelper {
         }
     }
 
+    public static final CryptoHelper getDefault() {
+        return new CryptoHelper(PASSPHRASE);
+    }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 TDKN-237 Provide getDefault() method for class org.talend.daikon.security.CryptoHelper on branch maintenance/0.31
**What is the chosen solution to this problem?**
 Add getDefault() method 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-237
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 https://jira.talendforge.org/browse/TDKN-237
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
