### PR TITLE
feat(TDKN-238): Allow unauthenticated access to Prometheus

### DIFF
--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-security/README.adoc
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-security/README.adoc
@@ -24,6 +24,28 @@ Authorization: Talend token1234
 
 Otherwise you will get a HTTP 403 (Forbidden).
 
+=== Public Prometheus access
+
+Simply run:
+
+```
+$ mvn spring-boot:run -Dspring-boot.run.profiles=public-prometheus
+```
+
+This command will start a Spring Boot application on port 8080. In this setup, all Actuator endpoints are protected by a HTTP authorization token as configured in `application.properties` *except* Prometheus endpoint:
+
+```
+talend.security.token.value=token1234
+```
+
+To call Actuator endpoints, it means the following HTTP header needs to be set to call `GET http://localhost:8080/version`:
+
+```
+Authorization: Talend token1234
+```
+
+But `GET http://localhost:8080/actuator/prometheus` does not require authentication token.
+
 === No token configured
 
 Simply run:

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-security/src/main/resources/application-public-prometheus.properties
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-security/src/main/resources/application-public-prometheus.properties
@@ -1,0 +1,8 @@
+# Expose all Actuator endpoints
+management.endpoints.web.exposure.include=*
+
+# Allow public access to Prometheus
+talend.security.allowPublicPrometheusEndpoint=true
+
+# A simple token value
+talend.security.token.value=token1234

--- a/daikon-spring/daikon-spring-security/README.adoc
+++ b/daikon-spring/daikon-spring-security/README.adoc
@@ -33,6 +33,17 @@ talend.security.token.value=                        # <- Empty value
 #talend.security.token.value=SeCr3tT0keNVa1ue       # <- Undefined/Commented out key
 ```
 
+=== Unauthenticated access to Prometheus endpoint
+
+It is possible to exclude Prometheus metric endpoint from token protected URLs. This is useful in following scenario examples:
+
+* For dev purposes, developers may not want to authenticate their requests to Prometheus (for ease of dev).
+* If Kubernetes setup does not allow to provide authentication headers.
+
+To expose Prometheus endpoint, just add `talend.security.allowPublicPrometheusEndpoint=true` to your application configuration.
+
+NOTE: Please note this setting is not meant for production environments.
+
 == Method access control with `@RequiresAuthority`
 
 The `@RequiresAuthority` annotation allows to mark methods that requires the current user has the permission (*authority*) to execute the method. 

--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
@@ -9,7 +9,14 @@ import javax.servlet.Filter;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.prometheus.PrometheusProperties;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration;
+import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoint;
+import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -23,11 +30,11 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 
 /**
  * A Spring Security configuration class that ensures the Actuator (as well as paths in
- * {@link #ADDITIONAL_PROTECTED_PATHS}) are protected by a token authentication.
+ * {@link #PROTECTED_PATHS}) are protected by a token authentication.
  *
  * @see NoConfiguredTokenFilter When configuration's token value is empty or missing.
  * @see TokenAuthenticationFilter When configuration's token value is present.
- * @see #ADDITIONAL_PROTECTED_PATHS for list of protected paths.
+ * @see #PROTECTED_PATHS for list of protected paths.
  */
 @Configuration
 @EnableWebSecurity
@@ -36,16 +43,25 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TokenSecurityConfiguration.class);
 
+    @Value("${talend.security.allowPublicPrometheusEndpoint:false}")
+    private boolean allowPrometheusUnauthenticatedAccess;
+
+    @Autowired
+    private PathMappedEndpoints actuatorEndpoints;
+
+    @Autowired
+    private WebEndpointProperties webEndpointProperties;
+
     /*
      * Use this field to indicate paths that should be secured by token. It is not a configuration setting at the moment
      * to ensure all applications share same secured endpoints.
      */
-    private static final String[] ADDITIONAL_PROTECTED_PATHS = { "/info", "/actuator/**", "/version" };
+    private static final String[] PROTECTED_PATHS = { "/info", "/version" };
 
     private final Filter tokenAuthenticationFilter;
 
     public TokenSecurityConfiguration(@Value("${talend.security.token.value:}") String token) {
-        final AntPathRequestMatcher[] matchers = Stream.of(ADDITIONAL_PROTECTED_PATHS) //
+        final AntPathRequestMatcher[] matchers = Stream.of(PROTECTED_PATHS) //
                 .map(AntPathRequestMatcher::new) //
                 .toArray(AntPathRequestMatcher[]::new);
         final RequestMatcher protectedPaths = new OrRequestMatcher(new OrRequestMatcher(matchers), toAnyEndpoint());
@@ -60,9 +76,26 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     public void configure(HttpSecurity http) throws Exception {
         ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http.authorizeRequests();
-        registry = registry.requestMatchers(toAnyEndpoint()).hasRole(TokenAuthentication.ROLE);
-        for (String protectedPath : ADDITIONAL_PROTECTED_PATHS) {
+        for (String protectedPath : PROTECTED_PATHS) {
             registry = registry.antMatchers(protectedPath).hasRole(TokenAuthentication.ROLE);
+        }
+        // Configure actuator
+        for (PathMappedEndpoint actuatorEndpoint : actuatorEndpoints) {
+            final String rootPath = actuatorEndpoint.getRootPath();
+            final boolean enforceTokenUsage;
+            if (allowPrometheusUnauthenticatedAccess && "prometheus".equals(rootPath)) {
+                enforceTokenUsage = false;
+                LOGGER.info("======= ALLOW UNAUTHENTICATED ACCESS TO PROMETHEUS (DEV MODE ONLY!) =======");
+            } else {
+                enforceTokenUsage = true;
+            }
+
+            final ExpressionUrlAuthorizationConfigurer<HttpSecurity>.AuthorizedUrl matcher = registry.antMatchers(webEndpointProperties.getBasePath() + "/" + rootPath + "**");
+            if (enforceTokenUsage) {
+                registry = matcher.hasRole(TokenAuthentication.ROLE);
+            } else {
+                registry = matcher.permitAll();
+            }
         }
         registry.and().addFilterAfter(tokenAuthenticationFilter, BasicAuthenticationFilter.class);
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

See https://jira.talendforge.org/browse/TDKN-238 (description part)
 
**What is the chosen solution to this problem?**
 
See https://jira.talendforge.org/browse/TDKN-238 (proposal part)

Feature
* Add `talend.security.allowPublicPrometheusEndpoint` to allow unauthenticated access to Prometheus endpoint (dev mode only, see Jira description).
* Documentation update.
* Example update.

Misc
* (improvement) use `WebEndpointProperties` to propertly secure actuator endpoints in case service configuration changes endpoint base path.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-238
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->