### PR TITLE
feat(TDKN-238): Allow public access to /health

### DIFF
--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
@@ -79,10 +79,14 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
         }
         // Configure actuator
         final PathMappedEndpoint prometheus = actuatorEndpoints.getEndpoint(EndpointId.of("prometheus"));
+        final PathMappedEndpoint health = actuatorEndpoints.getEndpoint(EndpointId.of("health"));
         for (PathMappedEndpoint actuatorEndpoint : actuatorEndpoints) {
             final String rootPath = actuatorEndpoint.getRootPath();
             final boolean enforceTokenUsage;
-            if (allowPrometheusUnauthenticatedAccess && actuatorEndpoint.equals(prometheus)) {
+
+            if (actuatorEndpoint.equals(health)) {
+                enforceTokenUsage = false;
+            } else if (allowPrometheusUnauthenticatedAccess && actuatorEndpoint.equals(prometheus)) {
                 enforceTokenUsage = false;
                 LOGGER.info("======= ALLOW UNAUTHENTICATED ACCESS TO PROMETHEUS (DEV MODE ONLY!) =======");
             } else {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
in `daikon-spring-security` the health endpoint becomes protected with a token.

**What is the chosen solution to this problem?**
 
That's unexpected and prevent proper health checks. This endpoint should be available without authentication.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-238
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
