### PR TITLE
fix(TDKN-238): disabled csrf for spring security

### DIFF
--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
@@ -73,7 +73,9 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     public void configure(HttpSecurity http) throws Exception {
-        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http.authorizeRequests();
+        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http
+                .csrf().disable()
+                .authorizeRequests();
         for (String protectedPath : PROTECTED_PATHS) {
             registry = registry.antMatchers(protectedPath).hasRole(TokenAuthentication.ROLE);
         }

--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
@@ -54,7 +54,7 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
      * Use this field to indicate paths that should be secured by token. It is not a configuration setting at the moment
      * to ensure all applications share same secured endpoints.
      */
-    private static final String[] PROTECTED_PATHS = { "/info", "/version" };
+    private static final String[] PROTECTED_PATHS = { "/version" };
 
     private final Filter tokenAuthenticationFilter;
 
@@ -73,8 +73,7 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     public void configure(HttpSecurity http) throws Exception {
-        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http
-                .csrf().disable()
+        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http.csrf().disable()
                 .authorizeRequests();
         for (String protectedPath : PROTECTED_PATHS) {
             registry = registry.antMatchers(protectedPath).hasRole(TokenAuthentication.ROLE);
@@ -96,7 +95,7 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
             }
 
             final ExpressionUrlAuthorizationConfigurer<HttpSecurity>.AuthorizedUrl matcher = registry
-                    .antMatchers(webEndpointProperties.getBasePath() + "/" + rootPath + "**");
+                    .antMatchers(webEndpointProperties.getBasePath() + "/" + rootPath + "/**");
             if (enforceTokenUsage) {
                 registry = matcher.hasRole(TokenAuthentication.ROLE);
             } else {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 The spring security policies enforce the usage of a CSRF token which prevent simple POST action in the Actuator or in REST controller.

**What is the chosen solution to this problem?**
The CSRF has been disabled
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/TDKN-238 -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
