### PR TITLE
Adding a new KeySource implementation for pbkdf2

### DIFF
--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -1,14 +1,9 @@
 package org.talend.daikon.crypto.digest;
 
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.KeySpec;
-
-import javax.crypto.SecretKeyFactory;
-import javax.crypto.spec.PBEKeySpec;
-
 import org.apache.commons.codec.digest.DigestUtils;
 import org.talend.daikon.crypto.EncodingUtils;
+import org.talend.daikon.crypto.KeySource;
+import org.talend.daikon.crypto.KeySources;
 
 /**
  * A collection of {@link DigestSource} helpers to ease use of {@link Digester}.
@@ -48,15 +43,12 @@ public class DigestSources {
      */
     public static DigestSource pbkDf2() {
         return (value, salt) -> {
-            if (salt == null || salt.length == 0) {
-                throw new IllegalArgumentException("Cannot use pbkDf2 with empty or null salt.");
-            }
+            KeySource keySource = KeySources.pbkDf2(value, salt, 256);
             try {
-                KeySpec spec = new PBEKeySpec(value.toCharArray(), salt, 65536, 256);
-                SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
-                final byte[] bytes = factory.generateSecret(spec).getEncoded();
-                return EncodingUtils.BASE64_ENCODER.apply(bytes);
-            } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+                return EncodingUtils.BASE64_ENCODER.apply(keySource.getKey());
+            } catch (IllegalArgumentException | IllegalStateException e) {
+                throw e;
+            } catch (Exception e) {
                 throw new IllegalStateException("Unable to digest value.", e);
             }
         };

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/CipherSourcesTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/CipherSourcesTest.java
@@ -23,6 +23,11 @@ public class CipherSourcesTest {
     }
 
     @Test
+    public void shouldRoundtripPBKDF2() throws Exception {
+        assertRoundTrip(CipherSources.getDefault(), KeySources.pbkDf2("DataPrepIsSoCool", KeySources.random(16).getKey(), 256));
+    }
+
+    @Test
     public void shouldGenerateDifferentValuesWithDefault() throws Exception {
         final CipherSource source = CipherSources.getDefault();
         final String encrypt1 = source.encrypt(KeySources.machineUID(16), "String");
@@ -122,6 +127,10 @@ public class CipherSourcesTest {
     }
 
     private void assertRoundTrip(CipherSource cipherSource) throws Exception {
+        assertRoundTrip(cipherSource, KeySources.machineUID(16));
+    }
+
+    private void assertRoundTrip(CipherSource cipherSource, KeySource keySource) throws Exception {
         final Encryption encryption = new Encryption(KeySources.machineUID(16), cipherSource);
 
         // when

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/KeySourcesTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/KeySourcesTest.java
@@ -27,6 +27,11 @@ public class KeySourcesTest {
         assertSource(KeySources.fixedKey("DataPrepIsSoCool"));
     }
 
+    @Test
+    public void shouldGenerateFromPBKDF2() throws Exception {
+        assertSource(KeySources.pbkDf2("DataPrepIsSoCool", KeySources.random(16).getKey(), 256));
+    }
+
     @Test(expected = IllegalArgumentException.class)
     public void shouldNotGenerateFromMissingSystemProperty() throws Exception {
         assertSource(KeySources.systemProperty("missingSystemProperty"));


### PR DESCRIPTION
Deriving a key from a password and salt using PBKDF2 will likely be required by various Talend libraries.