### PR TITLE
feat(): make LocalResourceResolver public

### DIFF
--- a/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalDeletableResource.java
+++ b/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalDeletableResource.java
@@ -22,7 +22,7 @@ import org.springframework.core.io.WritableResource;
 import org.talend.daikon.content.DeletableResource;
 import org.talend.daikon.content.ResourceResolver;
 
-class LocalDeletableResource implements DeletableResource {
+public class LocalDeletableResource implements DeletableResource {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(LocalDeletableResource.class);
 
@@ -32,7 +32,7 @@ class LocalDeletableResource implements DeletableResource {
 
     private boolean isDeleted;
 
-    LocalDeletableResource(ResourceResolver resolver, WritableResource resource) {
+    public LocalDeletableResource(ResourceResolver resolver, WritableResource resource) {
         this.resolver = resolver;
         this.resource = resource;
     }

--- a/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalResourceResolver.java
+++ b/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalResourceResolver.java
@@ -5,7 +5,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 import org.talend.daikon.content.AbstractResourceResolver;
 import org.talend.daikon.content.DeletableResource;
 
-class LocalResourceResolver extends AbstractResourceResolver {
+public class LocalResourceResolver extends AbstractResourceResolver {
 
     private String locationPrefix;
 

--- a/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalResourceResolver.java
+++ b/daikon-content-service/local-content-service/src/main/java/org/talend/daikon/content/local/LocalResourceResolver.java
@@ -9,7 +9,7 @@ public class LocalResourceResolver extends AbstractResourceResolver {
 
     private String locationPrefix;
 
-    LocalResourceResolver(ResourcePatternResolver delegate, String locationPrefix) {
+    public LocalResourceResolver(ResourcePatternResolver delegate, String locationPrefix) {
         super(delegate);
         this.locationPrefix = locationPrefix;
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 In TDP we need to wrap LocalResourceResolver/LocalDeletableResource. In order to do that we need that class to be public

**What is the chosen solution to this problem?**
 Make these class public

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
