### PR TITLE
feat(TDKN-245): Allow host info configuration from code

### DIFF
--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AuditConfiguration.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AuditConfiguration.java
@@ -22,6 +22,7 @@ public enum AuditConfiguration {
     SERVICE_NAME(String.class, ""),
     INSTANCE_NAME(String.class, ""),
     LOCATION(Boolean.class, Boolean.FALSE),
+    HOST(Boolean.class, Boolean.TRUE),
     LOG_APPENDER(LogAppendersSet.class),
     APPENDER_FILE_PATH(String.class),
     APPENDER_FILE_MAXSIZE(Long.class, 52428800L),

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AuditConfigurationTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AuditConfigurationTest.java
@@ -27,6 +27,7 @@ public class AuditConfigurationTest {
         assertEquals("testLogger", AuditConfiguration.ROOT_LOGGER.getString(config));
 
         assertEquals(Boolean.TRUE, AuditConfiguration.LOCATION.getBoolean(config));
+        assertEquals(Boolean.TRUE, AuditConfiguration.HOST.getBoolean(config));
         assertEquals(PropagateExceptions.ALL,
                 AuditConfiguration.PROPAGATE_APPENDER_EXCEPTIONS.getValue(config, PropagateExceptions.class));
 

--- a/daikon-audit/audit-common/src/test/resources/test.audit.properties
+++ b/daikon-audit/audit-common/src/test/resources/test.audit.properties
@@ -6,6 +6,7 @@ service.name=${test.service.name.property:DefaultServiceName}
 instance.name=${Path}
 
 location=true
+host=true
 
 propagate.appender.exceptions=all
 

--- a/daikon-audit/audit-log4j1/src/main/java/org/talend/logging/audit/log4j1/Log4j1Configurer.java
+++ b/daikon-audit/audit-log4j1/src/main/java/org/talend/logging/audit/log4j1/Log4j1Configurer.java
@@ -164,6 +164,7 @@ public final class Log4j1Configurer {
         Log4jJSONLayout layout = new Log4jJSONLayout();
 
         layout.setLocationInfo(AuditConfiguration.LOCATION.getBoolean(config));
+        layout.setHostInfo(AuditConfiguration.HOST.getBoolean(config));
         layout.setMetaFields(metaFields);
 
         return layout;

--- a/daikon-audit/audit-logback/src/main/java/org/talend/logging/audit/logback/LogbackConfigurer.java
+++ b/daikon-audit/audit-logback/src/main/java/org/talend/logging/audit/logback/LogbackConfigurer.java
@@ -10,7 +10,6 @@ import ch.qos.logback.core.ConsoleAppender;
 import ch.qos.logback.core.Layout;
 import ch.qos.logback.core.encoder.Encoder;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
-import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
 import ch.qos.logback.core.util.FileSize;
@@ -185,6 +184,7 @@ public final class LogbackConfigurer {
         LogbackJSONLayout layout = new LogbackJSONLayout();
 
         layout.setLocationInfo(AuditConfiguration.LOCATION.getBoolean(config));
+        layout.setHostInfo(AuditConfiguration.HOST.getBoolean(config));
         layout.setMetaFields(metaFields);
         layout.setAddEventUuid(false);
         layout.setContext(loggerContext);


### PR DESCRIPTION


**What is the problem this Pull Request is trying to solve?**
 
Following TDKN-245, some users may want to configure host information for Audit properties instead of direct from the logger implementation configuration.

**What is the chosen solution to this problem?**
 
This PR adds a "host" configuration (similar to "location" configuration) that allows to configure host information display.

With this change, daikon-audit allows both host information display configuration from programmatic access *and* file based configuration.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-245
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request
