### PR TITLE
feat(TDKN-246): Add `daikon-spring-aks-compat` module

### DIFF
--- a/daikon-spring/daikon-spring-aks-compat/README.adoc
+++ b/daikon-spring/daikon-spring-aks-compat/README.adoc
@@ -1,0 +1,24 @@
+= Daikon Spring - AKS Compatibility
+:toc:
+
+This module provides a set of auto configuration that allows use of AWS cloud... in an Azure context.
+Audience for this module is primarily applications that need to run on AWS and Azure, using same service image.
+
+== Usage
+
+Add dependency to `daikon-spring-aks-compat` in the application module:
+```xml
+<dependency>
+	<groupId>org.talend.daikon</groupId>
+	<artifactId>daikon-spring-aks-compat</artifactId>
+	<version>LATEST</version>
+</dependency>
+```
+
+To turn on Azure compatibility, add the following property to your application configuration:
+```properties
+talend.aks.compatibility=true
+```
+
+NOTE: It is important to note any Spring configuration can be externally configured (using `TALEND_AKS_COMPATIBILITY=true` in environment values). This allows only deployment code to configure AKS compatibility mode (no profile nor application context properties).
+

--- a/daikon-spring/daikon-spring-aks-compat/pom.xml
+++ b/daikon-spring/daikon-spring-aks-compat/pom.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>daikon-spring</artifactId>
+        <groupId>org.talend.daikon</groupId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>daikon-spring-aks-compat</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-aws</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/daikon-spring/daikon-spring-aks-compat/src/main/java/org/talend/spring/aks/compat/AKSCompatibilityConfiguration.java
+++ b/daikon-spring/daikon-spring-aks-compat/src/main/java/org/talend/spring/aks/compat/AKSCompatibilityConfiguration.java
@@ -1,0 +1,25 @@
+package org.talend.spring.aks.compat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.aws.core.env.stack.config.StackNameProvider;
+import org.springframework.cloud.aws.core.env.stack.config.StaticStackNameProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConditionalOnProperty(name = "talend.aks.compatibility", havingValue = "true")
+public class AKSCompatibilityConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AKSCompatibilityConfiguration.class);
+
+    public AKSCompatibilityConfiguration() {
+        LOGGER.info("Enable AKS compatibility configuration for AWS libraries.");
+    }
+
+    @Bean
+    public StackNameProvider stackProvider() {
+        return new StaticStackNameProvider("<aks context>");
+    }
+}

--- a/daikon-spring/daikon-spring-aks-compat/src/main/resources/META-INF/spring.factories
+++ b/daikon-spring/daikon-spring-aks-compat/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.talend.spring.aks.compat.AKSCompatibilityConfiguration

--- a/daikon-spring/daikon-spring-aks-compat/src/test/java/org/talend/spring/aks/compat/AKSCompatibilityConfigurationTest.java
+++ b/daikon-spring/daikon-spring-aks-compat/src/test/java/org/talend/spring/aks/compat/AKSCompatibilityConfigurationTest.java
@@ -1,0 +1,32 @@
+package org.talend.spring.aks.compat;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cloud.aws.core.env.stack.config.StackNameProvider;
+import org.springframework.cloud.aws.core.env.stack.config.StaticStackNameProvider;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = AKSCompatibilityConfiguration.class, //
+        webEnvironment = SpringBootTest.WebEnvironment.NONE, //
+        properties = "talend.aks.compatibility=true")
+public class AKSCompatibilityConfigurationTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    public void shouldUseStaticBeanIdProvider() {
+        // When
+        final StackNameProvider stackNameProvider = context.getBean(StackNameProvider.class);
+
+        // Then
+        assertEquals(StaticStackNameProvider.class, stackNameProvider.getClass());
+        assertEquals("<aks context>", stackNameProvider.getStackName());
+    }
+}

--- a/daikon-spring/pom.xml
+++ b/daikon-spring/pom.xml
@@ -39,5 +39,6 @@
         <module>daikon-content-service</module>
         <module>daikon-spring-examples</module>
         <module>daikon-spring-metrics</module>
+        <module>daikon-spring-aks-compat</module>
     </modules>
 </project>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

See https://jira.talendforge.org/browse/TDKN-246

TL;DR; Provide helper configuration in case AWS libraries are loaded in an Azure context.

**What is the chosen solution to this problem?**
 
* Add new configuration for AKS compatibility mode when AWS libraries are loaded.
* Add documentation for module usage.
* Add configuration test to module.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-246
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request