### PR TITLE
fix(logs): Make the KeyValuePair per logger

### DIFF
--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/Log4j2JSONLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/Log4j2JSONLayout.java
@@ -1,13 +1,7 @@
 
 package org.talend.daikon.logging.event.layout;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
-import java.nio.charset.Charset;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.Map;
-
+import net.minidev.json.JSONObject;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
@@ -19,7 +13,12 @@ import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.talend.daikon.logging.event.field.HostData;
 import org.talend.daikon.logging.event.field.LayoutFields;
 
-import net.minidev.json.JSONObject;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.nio.charset.Charset;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Log4j2 JSON Layout
@@ -30,8 +29,6 @@ import net.minidev.json.JSONObject;
 @Plugin(name = "Log4j2JSONLayout", category = "Core", elementType = "layout", printObject = true)
 public class Log4j2JSONLayout extends AbstractStringLayout {
 
-    private static final Map<String, String> ADDITIONAL_ATTRIBUTES = new HashMap<>();
-
     private boolean locationInfo;
 
     private boolean hostInfo;
@@ -39,13 +36,14 @@ public class Log4j2JSONLayout extends AbstractStringLayout {
     private String customUserFields;
 
     private Map<String, String> metaFields = new HashMap<>();
+    private Map<String, String> additionalAttributes = new HashMap<>();
 
     protected Log4j2JSONLayout(final Boolean locationInfo, final Boolean hostInfo, final Charset charset,
             final Map<String, String> additionalLogAttributes) {
         super(charset);
         setLocationInfo(locationInfo);
         setHostInfo(hostInfo);
-        Log4j2JSONLayout.ADDITIONAL_ATTRIBUTES.putAll(additionalLogAttributes);
+        additionalAttributes.putAll(additionalLogAttributes);
     }
 
     /**
@@ -103,7 +101,7 @@ public class Log4j2JSONLayout extends AbstractStringLayout {
         HostData host = new HostData();
 
         // Extract and add fields from log4j2 config, if defined
-        LayoutUtils.addUserFields(ADDITIONAL_ATTRIBUTES, userFieldsEvent);
+        LayoutUtils.addUserFields(additionalAttributes, userFieldsEvent);
 
         Map<String, String> mdc = LayoutUtils.processMDCMetaFields(loggingEvent.getContextData().toMap(), logstashEvent,
                 metaFields);

--- a/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/Log4j2JSONLayoutTest.java
+++ b/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/layout/Log4j2JSONLayoutTest.java
@@ -1,9 +1,5 @@
 package org.talend.daikon.logging.layout;
 
-import java.nio.charset.Charset;
-import java.util.Collections;
-import java.util.Map;
-
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -11,25 +7,39 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.ContextDataFactory;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.core.layout.AbstractStringLayout;
+import org.apache.logging.log4j.core.util.KeyValuePair;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.SimpleMessage;
 import org.apache.logging.log4j.util.StringMap;
 import org.talend.daikon.logging.event.layout.Log4j2JSONLayout;
 
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.Map;
+
 public class Log4j2JSONLayoutTest extends AbstractLayoutTest {
 
+    // /!\/!\/!\/!\/!\/!\/!\
     // do not remove this line - it has the side effect of initializing log4j2.xml contents
-    // aka user attributes before running the tests
-    // useful to check that Log4j2JSONLayout handles userAttributes set in log4j2.xml.
+    //
+    // However the user defined attributes as KeyValuePair are per-instance basis.
+    // This means that when calling the `createLayout` method the properties should be
+    // passed otherwise the user variables are not taken into account
     private static final Logger LOGGER = LogManager.getLogger(Log4j2JSONLayoutTest.class);
 
     @Override
     protected String log(Object event, LogDetails logDetails) {
+        KeyValuePair[] scimAdditionalProps = new KeyValuePair[1];
+        scimAdditionalProps[0] = new KeyValuePair("application_user", "SCIM");
+        KeyValuePair[] idpAdditionalProps = new KeyValuePair[1];
+        idpAdditionalProps[0] = new KeyValuePair("application_user", "IDP");
 
-        AbstractStringLayout layout = Log4j2JSONLayout.createLayout(logDetails.isLocationInfo(), // location
-                true, true, true, true, false, Charset.defaultCharset(), null);
+        AbstractStringLayout scimLayout = Log4j2JSONLayout.createLayout(logDetails.isLocationInfo(), // location
+                true, true, true, true, false, Charset.defaultCharset(), scimAdditionalProps);
+        AbstractStringLayout idpLayout = Log4j2JSONLayout.createLayout(logDetails.isLocationInfo(), // location
+                true, true, true, true, false, Charset.defaultCharset(), idpAdditionalProps);
 
-        return layout.toSerializable((LogEvent) event);
+        return scimLayout.toSerializable((LogEvent) event);
     }
 
     @Override

--- a/daikon-logging/logging-event-layout/src/test/resources/log4j2.xml
+++ b/daikon-logging/logging-event-layout/src/test/resources/log4j2.xml
@@ -11,6 +11,7 @@
       </Log4j2JSONLayout>
     </File>
   </appenders>
+
   <loggers>
     <root level="DEBUG">
       <appender-ref ref="Console"/>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

The `KeyValuePair` defined in the log4j2.xml are defined as static in the layout. 
This leads anyone having defined two appenders with a variable named in the same way to get always the value defined in the last initialized appender.
 
**What is the chosen solution to this problem?**

By removing the static modifier for the `additional attributes`, each logger now has its own pairs and each appender can use the same key rather than having to use different ones.
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
