### PR TITLE
chore(TDKN-247/logs: Bump log4j2 version to 2.11.2

### DIFF
--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/Log4j2JSONLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/Log4j2JSONLayout.java
@@ -36,6 +36,7 @@ public class Log4j2JSONLayout extends AbstractStringLayout {
     private String customUserFields;
 
     private Map<String, String> metaFields = new HashMap<>();
+
     private Map<String, String> additionalAttributes = new HashMap<>();
 
     protected Log4j2JSONLayout(final Boolean locationInfo, final Boolean hostInfo, final Charset charset,
@@ -218,7 +219,7 @@ public class Log4j2JSONLayout extends AbstractStringLayout {
     private void createStackTraceEvent(final JSONObject logstashEvent, final LogEvent loggingEvent) {
         if (loggingEvent.getThrown().getStackTrace() != null) {
             final String[] options = { "full" };
-            final ThrowablePatternConverter converter = ThrowablePatternConverter.newInstance(options);
+            final ThrowablePatternConverter converter = ThrowablePatternConverter.newInstance(configuration, options);
             final StringBuilder sb = new StringBuilder();
             converter.format(loggingEvent, sb);
             final String stackTrace = sb.toString();

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <pax-url-aether.version>2.4.7</pax-url-aether.version>
         <mockito-core.version>2.2.15</mockito-core.version>
         <ch.qos.logback.version>1.1.7</ch.qos.logback.version>
-        <log4j2.version>2.7</log4j2.version>
+        <log4j2.version>2.11.2</log4j2.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <hamcrest-json.version>0.2</hamcrest-json.version>
         <json-path-assert.version>2.2.0</json-path-assert.version>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 As part of the release of the log4j2 version 2.8.2 the signature of the newInstance method of the
[ThrowablePatternConverter](https://github.com/apache/logging-log4j2/commit/0146bbae4a94aee9e92e1ba843f0125075debfdc#diff-4e590f92b3ef7722ecadcef79392a7bcR54) was changed leading to an incompatibility between daikon and application using a
more recent version than the 2.7.

**What is the chosen solution to this problem?**

This commit bumps the version of log4j2 to 2.11.2.
 
**Link to the JIRA issue**
[https://jira.talendforge.org/browse/TDKN-247](https://jira.talendforge.org/browse/TDKN-247)
 
**Breaking change**
Incompatibility with versions prior to version 2.8.2

**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request
