### PR TITLE
Re-use File object

### DIFF
--- a/daikon-crypto/daikon-signature-verifier/src/main/java/org/talend/daikon/signature/verify/ZipVerifier.java
+++ b/daikon-crypto/daikon-signature-verifier/src/main/java/org/talend/daikon/signature/verify/ZipVerifier.java
@@ -127,7 +127,7 @@ public class ZipVerifier {
         }
         JarFile jarFile = null;
         try {
-            jarFile = new JarFile(filePath);
+            jarFile = new JarFile(file);
             Manifest mainfest = jarFile.getManifest();
             if (mainfest == null) {
                 throw new UnsignedArchiveException("Unsigned archive, missing entry:" + JarFile.MANIFEST_NAME); //$NON-NLS-1$


### PR DESCRIPTION
Just a trivial merge to re-use a File object that we created with JarFile instead of passing in the raw file name.