### PR TITLE
TDKN-251 - Exclude Commons Compress from Avro dependency

### DIFF
--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -28,6 +28,11 @@
 					<groupId>org.codehaus.jackson</groupId>
 					<artifactId>jackson-mapper-asl</artifactId>
 				</exclusion>
+				<!-- Remove this when we upgrade to Avro 1.9.0 -->
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-compress</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<!-- include the avro dependencies manually with fixes for those know CVEs -->
@@ -40,6 +45,12 @@
 			<groupId>org.codehaus.jackson</groupId>
 			<artifactId>jackson-mapper-asl</artifactId>
 			<version>${jackson.1x.version}</version>
+		</dependency>
+        	<!-- include the avro dependency for commons compress -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>${commons-compress.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <logback.version>1.2.3</logback.version>
         <easymock.version>3.5.1</easymock.version>
         <avro.version>1.8.1</avro.version>
+        <commons-compress.version>1.18</commons-compress.version>
         <commons-io.version>2.6</commons-io.version>
         <reactor-core.version>3.1.6.RELEASE</reactor-core.version>
 


### PR DESCRIPTION

The Avro dependency is pulling in an old Commons Compress version which has CVEs associated with it, e.g.:

http://zookeeper.apache.org/security.html#CVE-2019-0201

We need to exclude that dependency and add a dependency on Commons Compress 1.18.0 until we update to Avro 1.9.0.
