### PR TITLE
chore(audit/dep) don't use jaxb to create a base64 since dependency is no more there OOTB

### DIFF
--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/http/HttpEventSender.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/http/HttpEventSender.java
@@ -6,10 +6,10 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.Charset;
+import java.util.Base64;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import javax.xml.bind.DatatypeConverter;
 
 /**
  *
@@ -146,7 +146,7 @@ public class HttpEventSender {
 
     private String getAuthorizationHeader() {
         byte[] authData = (username + ':' + password).getBytes(encoding);
-        return "Basic " + DatatypeConverter.printBase64Binary(authData);
+        return "Basic " + Base64.getEncoder().encodeToString(authData);
     }
 
     private class LogSender implements Runnable {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

jaxb is no more available in the JVM so we can't rely on it - and don't want to add that dep.
 
**What is the chosen solution to this problem?**

Use standard Base64 API
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
