### PR TITLE
feat(): add ConditionalOnBean condition on TokenSecurityConfiguration

### DIFF
--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
@@ -2,6 +2,10 @@ package org.talend.daikon.security.token;
 
 import static org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest.toAnyEndpoint;
 
+import java.util.List;
+
+import javax.servlet.Filter;
+
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,6 +15,7 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointPr
 import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoint;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -21,9 +26,6 @@ import org.springframework.security.web.authentication.www.BasicAuthenticationFi
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
-
-import javax.servlet.Filter;
-import java.util.List;
 
 /**
  * A Spring Security configuration class that ensures the Actuator (as well as paths in
@@ -36,6 +38,7 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 @Order(1)
+@ConditionalOnBean(PathMappedEndpoints.class)
 public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TokenSecurityConfiguration.class);
@@ -54,10 +57,11 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
     private final List<TokenProtectedPath> additionalProtectedEndpoints;
 
     public TokenSecurityConfiguration(@Value("${talend.security.token.value:}") String token,
-                                      @Autowired List<TokenProtectedPath> additionalProtectedEndpoints) {
+            @Autowired List<TokenProtectedPath> additionalProtectedEndpoints) {
         this.additionalProtectedEndpoints = additionalProtectedEndpoints;
         additionalProtectedEndpoints.add(() -> "/version");
-        final AntPathRequestMatcher[] matchers = additionalProtectedEndpoints.stream() //
+        final AntPathRequestMatcher[] matchers = additionalProtectedEndpoints
+                .stream() //
                 .map(TokenProtectedPath::getProtectedPath) //
                 .map(AntPathRequestMatcher::new) //
                 .toArray(AntPathRequestMatcher[]::new);
@@ -72,8 +76,8 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     public void configure(HttpSecurity http) throws Exception {
-        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http.csrf().disable()
-                .authorizeRequests();
+        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry =
+                http.csrf().disable().authorizeRequests();
         for (TokenProtectedPath protectedPath : additionalProtectedEndpoints) {
             registry = registry.antMatchers(protectedPath.getProtectedPath()).hasRole(TokenAuthentication.ROLE);
         }
@@ -93,8 +97,8 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 enforceTokenUsage = true;
             }
 
-            final ExpressionUrlAuthorizationConfigurer<HttpSecurity>.AuthorizedUrl matcher = registry
-                    .antMatchers(webEndpointProperties.getBasePath() + "/" + rootPath + "/**");
+            final ExpressionUrlAuthorizationConfigurer<HttpSecurity>.AuthorizedUrl matcher =
+                    registry.antMatchers(webEndpointProperties.getBasePath() + "/" + rootPath + "/**");
             if (enforceTokenUsage) {
                 registry = matcher.hasRole(TokenAuthentication.ROLE);
             } else {

--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
@@ -60,8 +60,7 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
             @Autowired List<TokenProtectedPath> additionalProtectedEndpoints) {
         this.additionalProtectedEndpoints = additionalProtectedEndpoints;
         additionalProtectedEndpoints.add(() -> "/version");
-        final AntPathRequestMatcher[] matchers = additionalProtectedEndpoints
-                .stream() //
+        final AntPathRequestMatcher[] matchers = additionalProtectedEndpoints.stream() //
                 .map(TokenProtectedPath::getProtectedPath) //
                 .map(AntPathRequestMatcher::new) //
                 .toArray(AntPathRequestMatcher[]::new);
@@ -76,8 +75,8 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     public void configure(HttpSecurity http) throws Exception {
-        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry =
-                http.csrf().disable().authorizeRequests();
+        ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http.csrf().disable()
+                .authorizeRequests();
         for (TokenProtectedPath protectedPath : additionalProtectedEndpoints) {
             registry = registry.antMatchers(protectedPath.getProtectedPath()).hasRole(TokenAuthentication.ROLE);
         }
@@ -97,8 +96,8 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 enforceTokenUsage = true;
             }
 
-            final ExpressionUrlAuthorizationConfigurer<HttpSecurity>.AuthorizedUrl matcher =
-                    registry.antMatchers(webEndpointProperties.getBasePath() + "/" + rootPath + "/**");
+            final ExpressionUrlAuthorizationConfigurer<HttpSecurity>.AuthorizedUrl matcher = registry
+                    .antMatchers(webEndpointProperties.getBasePath() + "/" + rootPath + "/**");
             if (enforceTokenUsage) {
                 registry = matcher.hasRole(TokenAuthentication.ROLE);
             } else {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Currently TokenSecurityConfiguration fail if no PathMappedEndpoints exist. We need to load this configuration class only when PathMappedEndpoints are defined

**What is the chosen solution to this problem?**
Add a ConditionalOnBean condition on the configuration class
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
