### PR TITLE
fix(TDP-7278): Do not add matcher on protected path if no one is defined

### DIFF
--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
@@ -15,7 +15,9 @@ import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointPr
 import org.springframework.boot.actuate.endpoint.EndpointId;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoint;
 import org.springframework.boot.actuate.endpoint.web.PathMappedEndpoints;
+import org.springframework.boot.autoconfigure.condition.AllNestedConditions;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -38,7 +40,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 @Configuration
 @EnableWebSecurity
 @Order(1)
-@ConditionalOnBean(PathMappedEndpoints.class)
+@Conditional(TokenSecurityConfiguration.TokenSecurityCondition.class)
 public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TokenSecurityConfiguration.class);
@@ -54,36 +56,28 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final List<TokenProtectedPath> additionalProtectedEndpoints;
 
-    private RequestMatcher protectedPaths;
+    private final RequestMatcher protectedPaths;
 
-    private Filter tokenAuthenticationFilter;
+    private final Filter tokenAuthenticationFilter;
 
     public TokenSecurityConfiguration(@Value("${talend.security.token.value:}") String token,
             @Autowired List<TokenProtectedPath> additionalProtectedEndpoints) {
         this.additionalProtectedEndpoints = additionalProtectedEndpoints;
-        if (!additionalProtectedEndpoints.isEmpty()) {
-            // do not add new spring security filter chain if not additional endpoint is configured
-            final AntPathRequestMatcher[] matchers = additionalProtectedEndpoints.stream() //
-                    .map(TokenProtectedPath::getProtectedPath) //
-                    .map(AntPathRequestMatcher::new) //
-                    .toArray(AntPathRequestMatcher[]::new);
-            protectedPaths = new OrRequestMatcher(new OrRequestMatcher(matchers), toAnyEndpoint());
-            if (StringUtils.isBlank(token)) {
-                LOGGER.info("No token configured, protected endpoints are unavailable.");
-                tokenAuthenticationFilter = new NoConfiguredTokenFilter(protectedPaths);
-            } else {
-                LOGGER.info("Configured token-based access security.");
-                tokenAuthenticationFilter = new TokenAuthenticationFilter(token, protectedPaths);
-            }
+        final AntPathRequestMatcher[] matchers = additionalProtectedEndpoints.stream() //
+                .map(TokenProtectedPath::getProtectedPath) //
+                .map(AntPathRequestMatcher::new) //
+                .toArray(AntPathRequestMatcher[]::new);
+        protectedPaths = new OrRequestMatcher(new OrRequestMatcher(matchers), toAnyEndpoint());
+        if (StringUtils.isBlank(token)) {
+            LOGGER.info("No token configured, protected endpoints are unavailable.");
+            tokenAuthenticationFilter = new NoConfiguredTokenFilter(protectedPaths);
+        } else {
+            LOGGER.info("Configured token-based access security.");
+            tokenAuthenticationFilter = new TokenAuthenticationFilter(token, protectedPaths);
         }
     }
 
     public void configure(HttpSecurity http) throws Exception {
-        if (protectedPaths == null || additionalProtectedEndpoints.isEmpty()) {
-            // do not add new spring security filter chain if not additional endpoint is configured
-            return;
-        }
-
         ExpressionUrlAuthorizationConfigurer<HttpSecurity>.ExpressionInterceptUrlRegistry registry = http
                 .requestMatcher(protectedPaths)//
                 .csrf() //
@@ -117,5 +111,27 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
             }
         }
         registry.and().addFilterAfter(tokenAuthenticationFilter, BasicAuthenticationFilter.class);
+    }
+
+    public static class TokenSecurityCondition extends AllNestedConditions {
+
+        // do not add new spring security filter chain if not additional endpoint is configured
+        public TokenSecurityCondition() {
+            super(ConfigurationPhase.REGISTER_BEAN);
+        }
+
+        public TokenSecurityCondition(ConfigurationPhase configurationPhase) {
+            super(configurationPhase);
+        }
+
+        @ConditionalOnBean(PathMappedEndpoints.class)
+        static class conditionalPathMappedEndpoints {
+
+        }
+
+        @ConditionalOnBean(TokenProtectedPath.class)
+        static class conditionalTokenProtectedPath {
+
+        }
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
TokenSecurityConfiguration match too much request (any request) and override other spring security custom configuration 

**What is the chosen solution to this problem?**
Register TokenSecurityConfiguration only for protected path request and do not register it if not protected path is set
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
