### PR TITLE
backport(TDKN-206) Update TokenGenerator.generateToken interface

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/security/CryptoHelper.java
+++ b/daikon/src/main/java/org/talend/daikon/security/CryptoHelper.java
@@ -15,6 +15,7 @@ package org.talend.daikon.security;
 import java.io.UnsupportedEncodingException;
 import java.security.spec.AlgorithmParameterSpec;
 import java.security.spec.KeySpec;
+import java.util.function.Function;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
@@ -28,8 +29,11 @@ import org.talend.daikon.crypto.KeySources;
 
 /**
  * Encrypt and decrypt strings, encapsulating the cryptography algorithm and configured by a passphrase.
+ *
+ * @deprecated This class uses and encourages constant passphrases usage that makes encryption <b>highly unsecure</b>.
+ * Users of this class are encouraged to migrate to crypto-utils module (in Daikon).
  */
-public class CryptoHelper {
+public class CryptoHelper implements Function<String, String> {
 
     private static final String UTF8 = "UTF8"; //$NON-NLS-1$
 
@@ -142,5 +146,10 @@ public class CryptoHelper {
 
     public static final CryptoHelper getDefault() {
         return new CryptoHelper(PASSPHRASE);
+    }
+
+    @Override
+    public String apply(String s) {
+        return encrypt(s);
     }
 }

--- a/daikon/src/main/java/org/talend/daikon/token/TokenGenerator.java
+++ b/daikon/src/main/java/org/talend/daikon/token/TokenGenerator.java
@@ -6,10 +6,10 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Enumeration;
 import java.util.UUID;
+import java.util.function.Function;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.talend.daikon.security.CryptoHelper;
 
 /**
  * A utility class to generate tokens.
@@ -30,14 +30,14 @@ public class TokenGenerator {
      * </ul>
      * Should any of the 3 steps above fails, code falls back for a random UUID.
      *
-     * @param cryptoHelper A non-null {@link CryptoHelper helper} used to encrypt generated machine token.
+     * @param cryptoFunction A non-null {@link Function function} used to encrypt generated machine token.
      * @return A non-empty, non-null and encrypted token computed based on information of the running machine.
      * @see InetAddress#getLocalHost()
      * @see UUID#randomUUID()
      */
-    public static String generateMachineToken(CryptoHelper cryptoHelper) {
-        if (cryptoHelper == null) {
-            throw new IllegalArgumentException("Crypto helper cannot be null."); //$NON-NLS-1$
+    public static String generateMachineToken(Function<String, String> cryptoFunction) {
+        if (cryptoFunction == null) {
+            throw new IllegalArgumentException("Crypto function cannot be null."); //$NON-NLS-1$
         }
         final StringBuilder sb = new StringBuilder();
         try {
@@ -70,7 +70,7 @@ public class TokenGenerator {
         }
 
         // ... and encode the result with a static pass phrase.
-        final String machineId = cryptoHelper.encrypt(sb.toString());
+        final String machineId = cryptoFunction.apply(sb.toString());
         LOGGER.debug("Generated machine token: {}", machineId);
         return machineId;
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

 According to https://jira.talendforge.org/browse/TUP-21518, we are going to remove CryptoHelper from all of studio code, with this backport, I can pass non CryptoHelper object into TokenGenerator.generateToken() which is defined inside daikon.

**What is the chosen solution to this problem?**

 Backport fix of TDKN-206 to 0.31 branch

**Link to the JIRA issue**

 https://jira.talendforge.org/browse/TDKN-206

**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
