### PR TITLE
TDKN-257 - Update Commons Codec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <zipkin-sender-kafka11.version>2.1.4</zipkin-sender-kafka11.version>
         <kafka-clients.version>0.10.0.0</kafka-clients.version>
         <jsonassert.version>1.2.3</jsonassert.version>
-        <commons-codec.version>1.6</commons-codec.version>
+        <commons-codec.version>1.13</commons-codec.version>
         <javax.inject.version>1</javax.inject.version>
         <pax-url-aether.version>2.4.7</pax-url-aether.version>
         <mockito-core.version>2.2.15</mockito-core.version>


### PR DESCRIPTION
Currently Daikon has a dependency on an old version of Commons Codec - we should update it to a newer version (I found some dodgy code that uses Random to generate cryptoraphic salts that is fixed in 1.12.0).