### PR TITLE
Trivial fix to avoid creating a File object twice

### DIFF
--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/KeySources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/KeySources.java
@@ -182,8 +182,9 @@ public class KeySources {
                 }
                 final String filePath = System.getProperty("encryption.keys.file");
                 if (StringUtils.isNotEmpty(filePath)) {
-                    if (new File(filePath).exists()) {
-                        try (InputStream in = new FileInputStream(new File(filePath))) {
+                    File file = new File(filePath);
+                    if (file.exists()) {
+                        try (InputStream in = new FileInputStream(file)) {
                             properties.load(in);
                         }
                     }


### PR DESCRIPTION
Trivial fix to avoid creating a File object twice