### PR TITLE
TDKN-259 - Update Commons Compress

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <easymock.version>3.5.1</easymock.version>
         <avro.version>1.8.1</avro.version>
         <bcprov.version>1.62</bcprov.version>
-        <commons-compress.version>1.18</commons-compress.version>
+        <commons-compress.version>1.19</commons-compress.version>
         <commons-io.version>2.6</commons-io.version>
         <reactor-core.version>3.1.6.RELEASE</reactor-core.version>
 


### PR DESCRIPTION


We should update Commons Compress due to CVE-2019-12402
