### PR TITLE
fix(TUP-23482) Remove direct dependency of slf4j

### DIFF
--- a/daikon-crypto/crypto-utils/pom.xml
+++ b/daikon-crypto/crypto-utils/pom.xml
@@ -12,11 +12,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons-lang3.version}</version>

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/Encryption.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/Encryption.java
@@ -2,14 +2,11 @@ package org.talend.daikon.crypto;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Base64;
-
-import javax.crypto.Cipher;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class provides a helper class to encrypt and decrypt a given string using provided {@link CipherSource} and
@@ -17,7 +14,7 @@ import org.slf4j.LoggerFactory;
  */
 public class Encryption {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Encryption.class);
+    private static final Logger LOGGER = Logger.getLogger(Encryption.class.getCanonicalName());
 
     private final KeySource source;
 
@@ -77,7 +74,7 @@ public class Encryption {
         try {
             return decrypt(src);
         } catch (Exception e) {
-            LOGGER.debug("could not decrypt {}, return it as it is", name);
+            LOGGER.log(Level.FINE, "could not decrypt {0}, return it as it is", name);
             return src;
         }
     }
@@ -94,7 +91,7 @@ public class Encryption {
         try {
             uri = new URI(rawUri);
         } catch (URISyntaxException e) {
-            LOGGER.info("Invalid URI {}", rawUri, e);
+            LOGGER.log(Level.INFO, "Invalid URI " + rawUri, e);
             return rawUri;
         }
         UserInfo userInfo = extractCredentials(uri);

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/KeySources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/KeySources.java
@@ -1,8 +1,6 @@
 package org.talend.daikon.crypto;
 
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -16,6 +14,8 @@ import java.security.spec.KeySpec;
 import java.util.Enumeration;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
@@ -164,7 +164,7 @@ public class KeySources {
 
     private static class FileSource implements KeySource {
 
-        private static final Logger LOGGER = LoggerFactory.getLogger(FileSource.class);
+        private static final Logger LOGGER = Logger.getLogger(FileSource.class.getCanonicalName());
 
         private final Properties properties = new Properties();
 
@@ -190,7 +190,7 @@ public class KeySources {
                     }
                 }
             } catch (IOException e) {
-                LOGGER.error("Unable to load key file.", e);
+                LOGGER.log(Level.SEVERE, "Unable to load key file.", e);
             }
         }
 

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/PropertiesEncryption.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/PropertiesEncryption.java
@@ -4,8 +4,6 @@ import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.builder.FileBasedConfigurationBuilder;
 import org.apache.commons.configuration2.builder.fluent.Parameters;
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.talend.daikon.exception.TalendRuntimeException;
 
 import java.io.BufferedReader;
@@ -17,6 +15,8 @@ import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * @see <a href="https://docs.oracle.com/cd/E23095_01/Platform.93/ATGProgGuide/html/s0204propertiesfileformat01.html">
@@ -27,7 +27,7 @@ import java.util.function.Function;
  */
 public class PropertiesEncryption {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesEncryption.class);
+    private static final Logger LOGGER = Logger.getLogger(PropertiesEncryption.class.getCanonicalName());
 
     private final Encryption encryption;
 
@@ -77,11 +77,11 @@ public class PropertiesEncryption {
                 }
                 return result;
             } catch (IOException e) {
-                LOGGER.error("Failed to load input {} {}", input, e);
+                LOGGER.log(Level.SEVERE, "Failed to load input " + input, e);
                 throw TalendRuntimeException.createUnexpectedException(e);
             }
         }
-        LOGGER.error("Input file does not exist {}", input);
+        LOGGER.log(Level.SEVERE, "Input file does not exist {0}", input);
         throw TalendRuntimeException.createUnexpectedException(new FileNotFoundException(input));
     }
 
@@ -110,10 +110,10 @@ public class PropertiesEncryption {
                 }
                 builder.save();
             } catch (ConfigurationException e) {
-                LOGGER.error("unable to read {} {}", input, e);
+                LOGGER.log(Level.SEVERE, "unable to read " + input, e);
             }
         } else {
-            LOGGER.debug("No readable file at {}", input);
+            LOGGER.log(Level.FINE, "No readable file at {0}", input);
         }
     }
 
@@ -132,7 +132,7 @@ public class PropertiesEncryption {
             try {
                 return encryption.encrypt(input);
             } catch (Exception e1) {
-                LOGGER.debug("Error encrypting value.", e1);
+                LOGGER.log(Level.FINE, "Error encrypting value.", e1);
             }
         }
         return "";
@@ -149,7 +149,7 @@ public class PropertiesEncryption {
             return encryption.decrypt(input);
         } catch (Exception e) {
             // Property was already decrypted
-            LOGGER.debug("Trying to decrypt a non encrypted property.", e);
+            LOGGER.log(Level.FINE, "Trying to decrypt a non encrypted property.", e);
             return input;
         }
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Different version of slf4j are introduced in studio jobs.

Studio has thousands of components, each component has its dependencies, some component depends on slf4j, some component does not depend on it.

Studio generates jobs(code/pom/classpath/binary etc) according to the components used, so if daikon changed scope to provided, then some jobs generated may not have slf4j in classpath, this will result in failure of running job.

So it seems removing slf4j from daikon is the best option for now.

**What is the chosen solution to this problem?**

Remove direct dependency slf4j from crypto-utils 

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TUP-23482
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
