### PR TITLE
feat(TUP-21518) Remove CryptoHelper

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/property/Property.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/property/Property.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.reflect.TypeLiteral;
 import org.apache.commons.lang3.reflect.TypeUtils;
 import org.talend.daikon.NamedThing;
 import org.talend.daikon.SimpleNamedThing;
+import org.talend.daikon.crypto.Encryption;
 import org.talend.daikon.exception.ExceptionContext;
 import org.talend.daikon.exception.TalendRuntimeException;
 import org.talend.daikon.exception.error.CommonErrorCodes;
@@ -497,6 +498,13 @@ public class Property<T> extends SimpleNamedThing implements AnyProperty {
      * Encrypt the stored value or do nothing if there is not implementation for the given type.
      */
     public void encryptStoredValue(boolean encrypt) {
+        // do nothing by default see StringProperty for an example
+    }
+
+    /**
+     * Set Encryption, so that it can be used to encrypt or decrypt data
+     */
+    public void setEncryption(Encryption e) {
         // do nothing by default see StringProperty for an example
     }
 

--- a/daikon/src/main/java/org/talend/daikon/properties/property/StringProperty.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/property/StringProperty.java
@@ -144,8 +144,12 @@ public class StringProperty extends Property<String> {
     private Function<String, String> decryptFunc() {
         if (this.encryption != null) {
             return (src) -> {
-                if (src == null || src.isEmpty()) {
+                // backward compatibility
+                if (src == null) {
                     return null;
+                }
+                if (src.isEmpty()) {
+                    return "";
                 }
                 try {
                     return encryption.decrypt(src);


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
StringProperty depends on CryptoHelper to do data encryption/decryption. There is no way to switch encryption algorithms.
 
**What is the chosen solution to this problem?**
Inject Encryption into StringProperty by set method, so that StringProperty can encrypt/decrypt data based on the injected Encryption. 

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TUP-21518
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
