### PR TITLE
Backport(TDI-42756): Table hidden flag missing

### DIFF
--- a/daikon/src/test/java/org/talend/daikon/properties/presentation/WidgetTest.java
+++ b/daikon/src/test/java/org/talend/daikon/properties/presentation/WidgetTest.java
@@ -11,6 +11,7 @@ import static org.talend.daikon.properties.property.PropertyFactory.newString;
 import org.junit.Test;
 import org.talend.daikon.properties.Properties;
 import org.talend.daikon.properties.property.Property;
+import org.talend.daikon.properties.property.Property.Flags;
 import org.talend.daikon.properties.testproperties.TestProperties;
 
 public class WidgetTest {
@@ -93,6 +94,25 @@ public class WidgetTest {
                     .setConfigurationValue(Widget.SELECT_WIZARD_WIDGET_TYPE, true)
                     .setConfigurationValue(Widget.EXTERNAL_LINK_WIDGET_TYPE, true));
         }
+    }
+
+    @Test
+    public void testSetHidden() {
+        WidgetTestProperties properties = (WidgetTestProperties) new WidgetTestProperties("test").init();
+        Widget widget = new Widget(properties);
+        widget.setHidden(true);
+        assertTrue(properties.confProperty.getFlags().contains(Flags.HIDDEN));
+        widget.setHidden(false);
+        assertFalse(properties.confProperty.getFlags().contains(Flags.HIDDEN));
+
+        Property<String> stringProperty = newProperty("stringProperty");
+        stringProperty.getFlags();
+        Widget widget2 = new Widget(stringProperty);
+        widget2.setHidden(true);
+        assertTrue(stringProperty.isFlag(Flags.HIDDEN));
+        widget2.setHidden(false);
+        assertFalse(stringProperty.isFlag(Flags.HIDDEN));
+
     }
 
 }


### PR DESCRIPTION
* fix(TDI-42756):table widget miss hidden flag.
* fix(TDI-42756):replace reflection with PropertiesVisitor
* use recursion to set flag for nested property.

**What is the problem this Pull Request is trying to solve?**
 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDI-42756
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
