### PR TITLE
chore(TDS-4671): rely on sb starter instead of a custom version of ka…

### DIFF
--- a/daikon-spring/daikon-spring-zipkin/pom.xml
+++ b/daikon-spring/daikon-spring-zipkin/pom.xml
@@ -15,9 +15,8 @@
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.zipkin.reporter2</groupId>
-            <artifactId>zipkin-sender-kafka11</artifactId>
-            <version>${zipkin-sender-kafka11.version}</version>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-zipkin</artifactId>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,6 @@
         <guava.version>27.1-jre</guava.version>
         <aspectjweaver.version>1.8.9</aspectjweaver.version>
         <bnd.version>3.0.0</bnd.version>
-        <zipkin-sender-kafka11.version>2.1.4</zipkin-sender-kafka11.version>
         <kafka-clients.version>0.10.0.0</kafka-clients.version>
         <jsonassert.version>1.2.3</jsonassert.version>
         <commons-codec.version>1.13</commons-codec.version>


### PR DESCRIPTION
…fka sender

**What is the problem this Pull Request is trying to solve?**
TDS is migrating on BOM dependency management. Custom version of spring dependencies are now prohibited : we must rely on standard spring boot starters to have same version of spring dependencies amongst all projects which use daikon.
This PR fixes the daikon-spring-zipkin module regarding dependencies.
 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/TDS-4671 -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
