### PR TITLE
chore(tql): make mono repo private and remove unused deps

### DIFF
--- a/daikon-tql/daikon-tql-client/package.json
+++ b/daikon-tql/daikon-tql-client/package.json
@@ -19,11 +19,7 @@
   "bugs": {
     "url": "https://github.com/Talend/daikon/issues"
   },
-  "dependencies": {
-    "babel-polyfill": "^6.26.0",
-    "hoist-non-react-statics": "^1.2.0",
-    "mock-socket": "^7.0.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",

--- a/daikon-tql/package.json
+++ b/daikon-tql/package.json
@@ -9,5 +9,6 @@
   },
   "devDependencies": {
     "lerna": "^2.9.1"
-  }
+  },
+  "private": true
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
the mono repo has been published to npm
http://npmjs.com/package/daikon-tql

the client package has dependencies never imported

**What is the chosen solution to this problem?**

remove unused dependencies

deprecate `daikon-tql` on  npm
make mono repo package a `private`
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->