### PR TITLE
feat(TUP-21518) Remove CryptoHelper31

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/PropertiesImpl.java
@@ -63,7 +63,7 @@ public class PropertiesImpl extends TranslatableTaggedImpl
 
     transient private boolean layoutAlreadyInitalized;
 
-    transient private boolean propsAlreadyInitialized;
+    transient protected boolean propsAlreadyInitialized;
 
     /**
      * Handle post deserialization.


### PR DESCRIPTION

**What is the problem this Pull Request is trying to solve?**
StringProperty depends on CryptoHelper to do data encryption/decryption. There is no way to switch encryption algorithms.
 
**What is the chosen solution to this problem?**
1) Change propsAlreadyInitialized of PropertiesImpl from private to protected so that it can overridden by subclass

2) Override two methods- postDeserialize and handleAllPropertyEncryption of PropertiesImpl in subclass, so that components of studio can decrypt old persist properties with DES algorithm and encrypt/decrypt new properties with AES algorithm
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TUP-21518
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
