### PR TITLE
fix(TPSVC-11976) don't return null as the principal

### DIFF
--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenAuthentication.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenAuthentication.java
@@ -52,7 +52,7 @@ class TokenAuthentication implements Authentication {
 
     @Override
     public Object getPrincipal() {
-        return null;
+        return getName();
     }
 
     @Override

--- a/daikon-spring/daikon-spring-security/src/test/java/org/talend/daikon/security/token/TokenAuthenticationTest.java
+++ b/daikon-spring/daikon-spring-security/src/test/java/org/talend/daikon/security/token/TokenAuthenticationTest.java
@@ -22,7 +22,7 @@ public class TokenAuthenticationTest {
         assertTrue(authentication.isAuthenticated());
         assertEquals(TokenAuthentication.ADMIN_TOKEN_AUTHENTICATION, authentication.getDetails());
         assertNull(authentication.getCredentials());
-        assertNull(authentication.getPrincipal());
+        assertEquals(TokenAuthentication.ADMIN_TOKEN_AUTHENTICATION, authentication.getPrincipal());
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
One can not configure the spring-boot-actuator `ShowDetails.WHEN_AUTHORIZED` with the `TokenAuthentication` because their implementation uses internally the current `Principal` returned by the `Authentication` and the default rule is that it must be non null.

**What is the chosen solution to this problem?**
Basic implementation of the `getPrincipal` for the `TokenAuthentication` class
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-11976
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
