### PR TITLE
Fix useless call in TraceRequestUtil

### DIFF
--- a/daikon-logging/logging-request-interceptor/src/main/java/org/talend/daikon/logging/TraceRequestUtil.java
+++ b/daikon-logging/logging-request-interceptor/src/main/java/org/talend/daikon/logging/TraceRequestUtil.java
@@ -26,7 +26,7 @@ public class TraceRequestUtil {
             if (isValidJSON(bodyString)) {
                 return bodyString;
             } else {
-                bodyString.replaceAll("\"", "\\\"");
+                bodyString = bodyString.replaceAll("\"", "\\\"");
                 return "\"" + bodyString + "\"";
             }
         }


### PR DESCRIPTION
The return statement is not used, meaning that the call to replaceAll is useless.