### PR TITLE
TDKN-268 - Update Pax URL

### DIFF
--- a/daikon-crypto/daikon-signature-verifier/pom.xml
+++ b/daikon-crypto/daikon-signature-verifier/pom.xml
@@ -44,7 +44,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>

--- a/daikon-documentation/pom.xml
+++ b/daikon-documentation/pom.xml
@@ -112,15 +112,7 @@
                     <version>3.0.2</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
-                </plugin>
-                <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>

--- a/daikon-i18n/pom.xml
+++ b/daikon-i18n/pom.xml
@@ -51,7 +51,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/daikon-scala/dynamic-log/dynamic-log-web-play/pom.xml
+++ b/daikon-scala/dynamic-log/dynamic-log-web-play/pom.xml
@@ -96,7 +96,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <skipMain>true</skipMain> <!-- skip compile -->
                     <skip>true</skip> <!-- skip testCompile -->

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <jsonassert.version>1.2.3</jsonassert.version>
         <commons-codec.version>1.13</commons-codec.version>
         <javax.inject.version>1</javax.inject.version>
-        <pax-url-aether.version>2.4.7</pax-url-aether.version>
+        <pax-url-aether.version>2.6.2</pax-url-aether.version>
         <mockito-core.version>2.2.15</mockito-core.version>
         <ch.qos.logback.version>1.1.7</ch.qos.logback.version>
         <log4j2.version>2.11.2</log4j2.version>
@@ -235,7 +235,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>2.22.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION

We should update Pax URL to the latest fix to pick up a fix for a CVE:

pax-url-aether-2.4.7.jar/META-INF/maven/org.codehaus.plexus/plexus-utils/pom.xml (pkg:maven/org.codehaus.plexus/plexus-utils@3.0.17, cpe:2.3:a:plexus-utils_project:plexus-utils:3.0.17:::::::*) : Directory traversal in org.codehaus.plexus.util.Expand, Possible XML Injection

As part of the PR I also fixed a few inconsistencies with the compiler plugin I noticed.