### PR TITLE
chore(TPSVC-12467): make AmazonS3TestWrapper constructor public

### DIFF
--- a/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/AmazonS3TestWrapper.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/AmazonS3TestWrapper.java
@@ -24,7 +24,7 @@ public class AmazonS3TestWrapper implements AmazonS3 {
 
     private final AmazonS3 delegate;
 
-    AmazonS3TestWrapper(AmazonS3 delegate) {
+    public AmazonS3TestWrapper(AmazonS3 delegate) {
         this.delegate = delegate;
     }
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
TPSVC use AmazonS3TestWrapper in their UT. In order to be able to migrate config-client to SB2 we need to put it on public
 
**What is the chosen solution to this problem?**
Add public on the AmazonS3TestWrapper constructor

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
