### PR TITLE
feat(security) allow anonymous access to the version endpoint

### DIFF
--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
@@ -11,6 +11,22 @@
     <artifactId>daikon-spring-example-security</artifactId>
     <version>2.0.0-SNAPSHOT</version>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>build-info</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>org.talend.daikon</groupId>

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
@@ -16,6 +16,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/daikon-spring/daikon-spring-examples/pom.xml
+++ b/daikon-spring/daikon-spring-examples/pom.xml
@@ -15,6 +15,11 @@
     <url>https://github.com/Talend/daikon</url>
     <version>2.0.0-SNAPSHOT</version>
 
+    <properties>
+        <spring-boot.version>2.1.10.RELEASE</spring-boot.version>
+    </properties>
+
+
     <modules>
         <module>daikon-spring-example-security</module>
         <module>daikon-spring-example-metrics</module>

--- a/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
+++ b/daikon-spring/daikon-spring-security/src/main/java/org/talend/daikon/security/token/TokenSecurityConfiguration.java
@@ -94,11 +94,12 @@ public class TokenSecurityConfiguration extends WebSecurityConfigurerAdapter {
         // Configure actuator
         final PathMappedEndpoint prometheus = actuatorEndpoints.getEndpoint(EndpointId.of("prometheus"));
         final PathMappedEndpoint health = actuatorEndpoints.getEndpoint(EndpointId.of("health"));
+        final PathMappedEndpoint info = actuatorEndpoints.getEndpoint(EndpointId.of("info"));
         for (PathMappedEndpoint actuatorEndpoint : actuatorEndpoints) {
             final String rootPath = actuatorEndpoint.getRootPath();
             final boolean enforceTokenUsage;
 
-            if (actuatorEndpoint.equals(health)) {
+            if (actuatorEndpoint.equals(health) || actuatorEndpoint.equals(info)) {
                 enforceTokenUsage = false;
             } else if (allowPrometheusUnauthenticatedAccess && actuatorEndpoint.equals(prometheus)) {
                 enforceTokenUsage = false;

--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,11 @@
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
         </plugins>
     </build>
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -326,11 +326,6 @@
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring-boot.version}</version>
-            </plugin>
         </plugins>
     </build>
     <profiles>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Allow to access to the `info` endpoint without sending credentials 

**What is the chosen solution to this problem?**
Treat the `info` endpoint the same way the code does for the `health` one. 

From the example spring-boot application (with the security profile used)

```bash
http :8080/actuator/info                                                    
HTTP/1.1 200 
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Content-Type: application/vnd.spring-boot.actuator.v2+json;charset=UTF-8
Date: Sat, 08 Feb 2020 15:11:05 GMT
Expires: 0
Pragma: no-cache
Transfer-Encoding: chunked
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 1; mode=block

{
    "build": {
        "artifact": "daikon-spring-example-security",
        "group": "org.talend.daikon",
        "name": "daikon-spring-example-security",
        "time": "2020-02-08T15:27:14.011Z",
        "version": "2.0.0-SNAPSHOT"
    }
}
```

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
