### PR TITLE
Updating Beanutils to fix a CVE and removing duplicate Jackson version

### DIFF
--- a/daikon-crypto/crypto-utils/pom.xml
+++ b/daikon-crypto/crypto-utils/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.3</version>
+            <version>1.9.4</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
         <guava.version>21</guava.version>
         <spring-core.version>4.3.20.RELEASE</spring-core.version>
         <spring-data-mongodb.version>1.8.2.RELEASE</spring-data-mongodb.version>
-        <jackson.version>2.9.5</jackson.version>
         <aspectjweaver.version>1.8.9</aspectjweaver.version>
         <commons-lang.version>2.6</commons-lang.version>
         <spring-aop.version>4.3.6.RELEASE</spring-aop.version>


### PR DESCRIPTION
This PR fixes a CVE in Beanutils 1.9.3 by updating to 1.9.4. In addition, it removes a duplicate Jackson version which meant we were really including Jackson 2.9.5 instead of 2.10.1.