### PR TITLE
TDKN-276 - Update to Spring Boot 1.5.22

### DIFF
--- a/daikon-content-service/content-service-journal-mongo/pom.xml
+++ b/daikon-content-service/content-service-journal-mongo/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
-            <version>1.5.9.RELEASE</version>
+            <version>1.5.22.RELEASE</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/daikon-logging/logging-http-headers/pom.xml
+++ b/daikon-logging/logging-http-headers/pom.xml
@@ -12,7 +12,6 @@
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <slf4j.version>1.7.25</slf4j.version>
         <tomcat.version>8.5.23</tomcat.version>
-        <spring.boot.version>1.5.9.RELEASE</spring.boot.version>
     </properties>
 
     <dependencies>
@@ -37,14 +36,14 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
-            <version>${spring.boot.version}</version>
+            <version>${spring-boot.version}</version>
             <optional>true</optional>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring.boot.version}</version>
+            <version>${spring-boot.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/daikon-logging/logging-kafka-interceptor/pom.xml
+++ b/daikon-logging/logging-kafka-interceptor/pom.xml
@@ -15,7 +15,7 @@
 		<dependency>
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-web</artifactId>
-		    <version>1.5.9.RELEASE</version>
+		    <version>${spring-boot.version}</version>
 		    <scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -92,7 +92,7 @@
 		<dependency>
 		    <groupId>org.springframework.boot</groupId>
 		    <artifactId>spring-boot-starter-test</artifactId>
-		    <version>1.5.9.RELEASE</version>
+		    <version>${spring-boot.version}</version>
 		    <scope>test</scope>
 		</dependency>
     </dependencies>

--- a/daikon-messages/messages-demo/demo-listener/pom.xml
+++ b/daikon-messages/messages-demo/demo-listener/pom.xml
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/daikon-messages/messages-demo/demo-producer/pom.xml
+++ b/daikon-messages/messages-demo/demo-producer/pom.xml
@@ -15,7 +15,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/daikon-messages/messages-demo/pom.xml
+++ b/daikon-messages/messages-demo/pom.xml
@@ -28,7 +28,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -58,12 +58,12 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-tomcat</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-security</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>

--- a/daikon-messages/messages-model-spring-support/pom.xml
+++ b/daikon-messages/messages-model-spring-support/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-autoconfigure</artifactId>
-            <version>${spring.boot.version}</version>
+            <version>${spring-boot.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/daikon-messages/pom.xml
+++ b/daikon-messages/pom.xml
@@ -10,10 +10,6 @@
     <name>daikon-messages</name>
     <packaging>pom</packaging>
 
-    <properties>
-        <spring.boot.version>1.5.2.RELEASE</spring.boot.version>
-    </properties>
-
     <modules>
         <module>messages-model</module>
         <module>messages-model-spring-support</module>

--- a/daikon-multitenant/pom.xml
+++ b/daikon-multitenant/pom.xml
@@ -15,8 +15,6 @@
         <java.version>1.8</java.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spring.version>4.3.3.RELEASE</spring.version>
-        <spring.boot.version>1.4.2.RELEASE</spring.boot.version>
     </properties>
     <modules>
         <module>multitenant-core</module>
@@ -29,22 +27,22 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-web</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-web</artifactId>
-                <version>${spring.version}</version>
+                <version>${spring-core.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-security</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>
@@ -54,7 +52,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-starter-test</artifactId>
-                <version>${spring.boot.version}</version>
+                <version>${spring-boot.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/daikon-service/pom.xml
+++ b/daikon-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.1.RELEASE</version>
+		<version>1.5.22.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 

--- a/poc/daikon-cqrs/pom.xml
+++ b/poc/daikon-cqrs/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.1.RELEASE</version>
+		<version>1.5.22.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 
@@ -78,7 +78,7 @@
 		<dependency>
 			<groupId>org.talend.daikon</groupId>
 			<artifactId>daikon</artifactId>
-			<version>0.17.0-SNAPSHOT</version>
+			<version>0.31.11-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <avro.version>1.8.1</avro.version>
         <commons-io.version>1.3.2</commons-io.version>
         <reactor-core.version>3.1.6.RELEASE</reactor-core.version>
-        <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
+        <spring-boot.version>1.5.22.RELEASE</spring-boot.version>
         <fongo.version>2.0.12</fongo.version>
         <s3mock.version>0.1.6</s3mock.version>
         <aws-java-sdk-s3.version>1.11.18</aws-java-sdk-s3.version>


### PR DESCRIPTION
We should update to Spring Boot 1.5.22 to pick up a bunch of CVE fixes (for example in Jetty). In addition, lots of the modules define their own version of Spring Boot 1.5.x, instead of picking up the root version.

https://jira.talendforge.org/browse/TDKN-276