### PR TITLE
TDKN-283 - Update BouncyCastle to 1.65

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <logback.version>1.2.3</logback.version>
         <easymock.version>3.5.1</easymock.version>
         <avro.version>1.9.1</avro.version>
-        <bcprov.version>1.62</bcprov.version>
+        <bcprov.version>1.65</bcprov.version>
         <commons-compress.version>1.19</commons-compress.version>
         <commons-io.version>2.6</commons-io.version>
         <reactor-core.version>3.1.6.RELEASE</reactor-core.version>


### PR DESCRIPTION
This task is to update BouncyCastle to 1.65. In some of the projects, we needed to ship a beta version of 1.65 due to a bug with Java 11 and TLS.