### PR TITLE
TPSVC-13814: daikon-spring-audit-logs port from v2 to v3

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/README.adoc
+++ b/daikon-spring/daikon-spring-audit-logs/README.adoc
@@ -1,0 +1,159 @@
+= Daikon Spring Audit Logs support
+:toc:
+
+This module provides support for Audit Logs over Spring.
+
+== Introduction
+
+This module is built above Daikon link:../../daikon-audit/README.adoc[audit-kafka] module whose purpose is to send audit logs through Kafka.
+
+The purpose of the current module is to enhance context building using Spring leverage.
+
+== Usage
+
+To start using Audit Logging Spring support it is necessary to :
+
+. Add dependency
+. Configure the module
+. Use `@GenerateAuditLog` annotation
+
+== Adding dependency
+
+To start using Audit Logging client it’s necessary to add the next dependencies:
+
+```xml
+<dependency>
+    <groupId>org.talend.daikon</groupId>
+    <artifactId>daikon-spring-audit-logs</artifactId>
+    <version>${daikon.version}</version>
+</dependency>
+```
+
+== Configuration
+
+Then the module must be enabled and configured with Kafka information :
+
+```yaml
+audit:
+    enabled: true # Enable audit feature
+    kafka:
+        bootstrapServers: localhost:9092 # Kafka bootstrap server urls for audit logs sending
+        topic: audit-logs # Kafka topic for audit logs sending
+        partitionKeyName: account_id # Kafka partitionKey for audit logs sending
+```
+
+== @GenerateAuditLog
+
+Finally the following `@GenerateAuditLog` annotation must be added on methods whose a call must generate an audit log :
+
+```java
+@GenerateAuditLog(application = "daikon", eventType = "security", eventCategory = "resource", eventOperation = "create", includeBodyResponse = true)
+@PostMapping("/resource")
+public ResponseEntity<Resource> creatResource(@RequestBody Resource resource) {
+    return this.resourceService.create(resource);
+}
+```
+
+A call to the `createResource` method will generate and send the following audit log through Kafka :
+
+```json
+{
+    "timestamp": "2020-04-07T13:26:09.741821Z",
+    "request_id": "009a511a-a71e-4b6c-8e0b-822a90c71e43",
+    "log_id": "6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
+    "application_id": "daikon",
+    "event_type": "security",
+    "event_category": "resource",
+    "event_operation": "create",
+    "client_ip": "10.80.48.155",
+    "request": "{\"url\":\"http://app.url/resource\",\"method\":\"POST\",\"user_agent\":\"{USER_AGENT}\",\"body\":\"{REQUEST_BODY}\"}",
+    "response": "{\"code\":\"200\",\"body\":\"{REQUEST_BODY}\"}"
+}
+
+```
+
+It is possible to choose to include or not the body response in the generated log with the `includeBodyResponse` annotation parameter.
+
+== AuditUserProvider
+
+By default, the generated audit logs don't contain any information about the caller user.
+
+Adding user information is possible by providing a custom `AuditUserProvider` declared as `@Bean`.
+
+For example, declaring the following custom `AuditUserProvider` :
+
+```java
+@Configuration
+public class AuditLogsConfiguration {
+    @Bean
+    public AuditUserProvider auditUserProvider() {
+        return new AuditUserProvider() {
+            @Override
+            public String getUserId() {
+                return "user1";
+            }
+
+            @Override
+            public String getUsername() {
+                return "ejarvis";
+            }
+
+            @Override
+            public String getUserEmail() {
+                return "edwin.jarvis@talend.com";
+            }
+
+            @Override
+            public String getAccountId() {
+                return "account1";
+            }
+        };
+    }
+}
+```
+
+Will generate an audit log enhanced with user information :
+
+```json
+{
+    "timestamp": "2020-04-07T13:26:09.741821Z",
+    "request_id": "009a511a-a71e-4b6c-8e0b-822a90c71e43",
+    "log_id": "6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
+    "account_id": "81fd11b5-d0c2-479d-833c-85d67f79edd0",
+    "user_id": "84dc9524-b9b6-4533-a849-606feba86720",
+    "username": "1510_3_int@trial01775.us.talend.com",
+    "email": "1510_3_int@yopmail.com",
+    "application_id": "daikon",
+    "event_type": "security",
+    "event_category": "resource",
+    "event_operation": "create",
+    "client_ip": "10.80.48.155",
+    "request": "{\"url\":\"http://app.url/resource\",\"method\":\"POST\",\"user_agent\":\"{USER_AGENT}\",\"body\":\"{REQUEST_BODY}\"}",
+    "response": "{\"code\":\"200\",\"body\":\"{REQUEST_BODY}\"}"
+}
+
+```
+
+
+== AuditContextFilter
+
+In some cases, some information shouldn't be exposed through the audit logs.
+
+In order to filter context info before audit log generation, the module provides the `AuditContextFilter` interface.
+A custom filter can be created simply by implementing this interface :
+
+```java
+public class MyCustomAuditContextFilter implements AuditContextFilter {
+
+    public AuditLogContextBuilder filter(AuditLogContextBuilder builder, Object requestBody) {
+        [...]
+        return builder.withRequestBody(filteredRequestBody);
+    }
+}
+```
+
+Then the filter must be referenced in the `@GenerateAuditLog` annotation :
+
+```java
+@GenerateAuditLog([...], filter = MyCustomAuditContextFilter.class)
+```

--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>daikon-spring</artifactId>
+        <groupId>org.talend.daikon</groupId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>daikon-spring-audit-logs</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.talend.daikon</groupId>
+            <artifactId>audit-kafka</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.8</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/AuditContextFilter.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/AuditContextFilter.java
@@ -1,0 +1,9 @@
+package org.talend.daikon.spring.audit.logs.api;
+
+import org.talend.daikon.spring.audit.logs.service.AuditLogContextBuilder;
+
+public interface AuditContextFilter {
+
+    AuditLogContextBuilder filter(AuditLogContextBuilder auditLogContextBuilder, Object requestBody);
+
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/AuditUserProvider.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/AuditUserProvider.java
@@ -1,0 +1,12 @@
+package org.talend.daikon.spring.audit.logs.api;
+
+public interface AuditUserProvider {
+
+    String getUserId();
+
+    String getUsername();
+
+    String getUserEmail();
+
+    String getAccountId();
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/GenerateAuditLog.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/GenerateAuditLog.java
@@ -1,0 +1,23 @@
+package org.talend.daikon.spring.audit.logs.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GenerateAuditLog {
+
+    String application();
+
+    String eventType();
+
+    String eventCategory();
+
+    String eventOperation();
+
+    boolean includeBodyResponse() default true;
+
+    Class<? extends AuditContextFilter> filter() default NoOpAuditContextFilter.class;
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/NoOpAuditContextFilter.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/NoOpAuditContextFilter.java
@@ -1,0 +1,11 @@
+package org.talend.daikon.spring.audit.logs.api;
+
+import org.talend.daikon.spring.audit.logs.service.AuditLogContextBuilder;
+
+public class NoOpAuditContextFilter implements AuditContextFilter {
+
+    @Override
+    public AuditLogContextBuilder filter(AuditLogContextBuilder auditLogContextBuilder, Object requestBody) {
+        return auditLogContextBuilder;
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/NoOpAuditUserProvider.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/NoOpAuditUserProvider.java
@@ -1,0 +1,24 @@
+package org.talend.daikon.spring.audit.logs.api;
+
+public class NoOpAuditUserProvider implements AuditUserProvider {
+
+    @Override
+    public String getUserId() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public String getUserEmail() {
+        return null;
+    }
+
+    @Override
+    public String getAccountId() {
+        return null;
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
@@ -1,0 +1,37 @@
+package org.talend.daikon.spring.audit.logs.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "audit.kafka")
+public class AuditKafkaProperties {
+
+    private String bootstrapServers;
+
+    private String topic = "audit-logs";
+
+    private String partitionKeyName = "account_id";
+
+    public String getBootstrapServers() {
+        return bootstrapServers;
+    }
+
+    public void setBootstrapServers(String bootstrapServers) {
+        this.bootstrapServers = bootstrapServers;
+    }
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public String getPartitionKeyName() {
+        return partitionKeyName;
+    }
+
+    public void setPartitionKeyName(String partitionKeyName) {
+        this.partitionKeyName = partitionKeyName;
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogConfig.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogConfig.java
@@ -1,0 +1,51 @@
+package org.talend.daikon.spring.audit.logs.config;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.talend.daikon.spring.audit.logs.api.AuditUserProvider;
+import org.talend.daikon.spring.audit.logs.api.NoOpAuditUserProvider;
+import org.talend.daikon.spring.audit.logs.service.AuditLogGenerationFilter;
+import org.talend.daikon.spring.audit.logs.service.AuditLogGenerationFilterImpl;
+import org.talend.daikon.spring.audit.logs.service.AuditLogger;
+import org.talend.logging.audit.AuditLoggerFactory;
+import org.talend.logging.audit.LogAppenders;
+import org.talend.logging.audit.impl.AuditConfiguration;
+import org.talend.logging.audit.impl.AuditConfigurationMap;
+import org.talend.logging.audit.impl.Backends;
+import org.talend.logging.audit.impl.SimpleAuditLoggerBase;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@EnableConfigurationProperties(AuditKafkaProperties.class)
+@ConditionalOnProperty(value = "audit.enabled", havingValue = "true", matchIfMissing = true)
+public class AuditLogConfig {
+
+    private Properties getProperties(AuditKafkaProperties auditKafkaProperties, String applicationName) {
+        Properties properties = new Properties();
+        properties.put("application.name", applicationName);
+        properties.put("backend", Backends.KAFKA.name());
+        properties.put("log.appender", LogAppenders.NONE.name());
+        properties.put("kafka.bootstrap.servers", auditKafkaProperties.getBootstrapServers());
+        properties.put("kafka.topic", auditKafkaProperties.getTopic());
+        properties.put("kafka.partition.key.name", auditKafkaProperties.getPartitionKeyName());
+        return properties;
+    }
+
+    @Bean
+    public AuditLogGenerationFilterImpl auditLogAspect(ObjectMapper objectMapper, Optional<AuditUserProvider> auditUserProvider,
+            AuditKafkaProperties auditKafkaProperties, @Value("${spring.application.name}") String applicationName) {
+        Properties properties = getProperties(auditKafkaProperties, applicationName);
+        AuditConfigurationMap config = AuditConfiguration.loadFromProperties(properties);
+        AuditLogger auditLogger = AuditLoggerFactory.getEventAuditLogger(AuditLogger.class, new SimpleAuditLoggerBase(config));
+        return new AuditLogGenerationFilterImpl(objectMapper, auditUserProvider.orElse(new NoOpAuditUserProvider()), auditLogger);
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/model/AuditLogFieldEnum.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/model/AuditLogFieldEnum.java
@@ -1,0 +1,72 @@
+package org.talend.daikon.spring.audit.logs.model;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum AuditLogFieldEnum {
+
+    TIMESTAMP("timestamp"),
+    REQUEST_ID("request_id"),
+    LOG_ID("log_id"),
+    // account id is not mandatory in the case of audit log of anonymous users
+    ACCOUNT_ID("account_id", false),
+    // user info is not mandatory in the case of audit log of anonymous users
+    USER_ID("user_id", false),
+    USERNAME("username", false),
+    EMAIL("email", false),
+    APPLICATION_ID("application_id"),
+    EVENT_TYPE("event_type"),
+    EVENT_CATEGORY("event_category"),
+    EVENT_OPERATION("event_operation"),
+    CLIENT_IP("client_ip"),
+    URL("url"),
+    METHOD("method"),
+    // user agent not mandatory because not always provided
+    USER_AGENT("user_agent", false),
+    // request body is not present for all user actions
+    REQUEST_BODY("body", false),
+    REQUEST("request", Arrays.asList(URL, METHOD, USER_AGENT, REQUEST_BODY)),
+    RESPONSE_BODY("body", false),
+    RESPONSE_CODE("code"),
+    RESPONSE("response", Arrays.asList(RESPONSE_BODY, RESPONSE_CODE));
+
+    private String id;
+
+    private boolean mandatory;
+
+    private final List<AuditLogFieldEnum> children;
+
+    AuditLogFieldEnum(String id, List<AuditLogFieldEnum> children) {
+        this.id = id;
+        this.mandatory = true;
+        this.children = children;
+    }
+
+    AuditLogFieldEnum(String id, boolean mandatory) {
+        this.id = id;
+        this.mandatory = mandatory;
+        this.children = null;
+    }
+
+    AuditLogFieldEnum(String id) {
+        this.id = id;
+        this.mandatory = true;
+        this.children = null;
+    }
+
+    public boolean hasParent() {
+        return Arrays.stream(values()).anyMatch(it -> it.getChildren() != null && it.getChildren().contains(this));
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public boolean isMandatory() {
+        return mandatory;
+    }
+
+    public List<AuditLogFieldEnum> getChildren() {
+        return children;
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilder.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilder.java
@@ -1,0 +1,192 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import static org.talend.daikon.spring.audit.logs.model.AuditLogFieldEnum.*;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+import org.talend.daikon.spring.audit.logs.model.AuditLogFieldEnum;
+import org.talend.logging.audit.Context;
+import org.talend.logging.audit.impl.DefaultContextImpl;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class AuditLogContextBuilder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogContextBuilder.class);
+
+    private final Map<String, String> context = new LinkedHashMap<>();
+
+    private final Map<String, Object> request = new LinkedHashMap<>();
+
+    private final Map<String, Object> response = new LinkedHashMap<>();
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    private AuditLogContextBuilder() {
+    }
+
+    public static Context emptyContext() {
+        return new DefaultContextImpl();
+    }
+
+    public static AuditLogContextBuilder create() {
+        return new AuditLogContextBuilder();
+    }
+
+    private AuditLogContextBuilder with(String key, String value) {
+        return with(key, value, context);
+    }
+
+    private AuditLogContextBuilder with(String key, Object value, Map contextMap) {
+        if (key == null) {
+            throw new IllegalArgumentException("key cannot be null");
+        }
+        contextMap.put(key, value);
+        return this;
+    }
+
+    public AuditLogContextBuilder withTimestamp(String timestamp) {
+        return this.with(TIMESTAMP.getId(), timestamp);
+    }
+
+    public AuditLogContextBuilder withLogId(UUID logId) {
+        return this.with(LOG_ID.getId(), logId.toString());
+    }
+
+    public AuditLogContextBuilder withRequestId(UUID requestId) {
+        return this.with(REQUEST_ID.getId(), requestId.toString());
+    }
+
+    public AuditLogContextBuilder withAccountId(String accountId) {
+        return this.with(ACCOUNT_ID.getId(), accountId);
+    }
+
+    public AuditLogContextBuilder withUserId(String userId) {
+        return this.with(USER_ID.getId(), userId);
+    }
+
+    public AuditLogContextBuilder withUsername(String username) {
+        return this.with(USERNAME.getId(), username);
+    }
+
+    public AuditLogContextBuilder withEmail(String email) {
+        return this.with(EMAIL.getId(), email);
+    }
+
+    public AuditLogContextBuilder withApplicationId(String applicationId) {
+        return this.with(APPLICATION_ID.getId(), applicationId);
+    }
+
+    public AuditLogContextBuilder withEventType(String eventType) {
+        return this.with(EVENT_TYPE.getId(), eventType);
+    }
+
+    public AuditLogContextBuilder withEventCategory(String eventCategory) {
+        return this.with(EVENT_CATEGORY.getId(), eventCategory);
+    }
+
+    public AuditLogContextBuilder withEventOperation(String eventOperation) {
+        return this.with(EVENT_OPERATION.getId(), eventOperation);
+    }
+
+    public AuditLogContextBuilder withClientIp(String clientIp) {
+        return this.with(CLIENT_IP.getId(), clientIp);
+    }
+
+    public AuditLogContextBuilder withRequestUrl(String requestUrl) {
+        return this.with(URL.getId(), requestUrl, request);
+    }
+
+    public AuditLogContextBuilder withRequestMethod(String requestMethod) {
+        return this.with(METHOD.getId(), requestMethod, request);
+    }
+
+    public AuditLogContextBuilder withRequestUserAgent(String requestUserAgent) {
+        return this.with(USER_AGENT.getId(), requestUserAgent, request);
+    }
+
+    public AuditLogContextBuilder withRequestBody(Object requestBody) {
+        return this.with(REQUEST_BODY.getId(), requestBody, request);
+    }
+
+    public AuditLogContextBuilder withResponseCode(int httpStatus) {
+        return this.with(RESPONSE_CODE.getId(), String.valueOf(httpStatus), response);
+    }
+
+    public AuditLogContextBuilder withResponseBody(Object responseBody) {
+        return this.with(RESPONSE_BODY.getId(), responseBody, response);
+    }
+
+    public Context build() {
+        try {
+            context.values().removeAll(Collections.singletonList(null));
+            request.values().removeAll(Collections.singletonList(null));
+            response.values().removeAll(Collections.singletonList(null));
+            if (!request.isEmpty()) {
+                context.put(REQUEST.getId(), objectMapper.writeValueAsString(request));
+            }
+            if (!response.isEmpty()) {
+                context.put(RESPONSE.getId(), objectMapper.writeValueAsString(response));
+            }
+            checkAuditContextIsValid();
+            return new DefaultContextImpl(context);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public AuditLogContextBuilder withRequest(HttpServletRequest request, Object requestBody) {
+        String userAgent = request.getHeader("User-Agent");
+        return withClientIp(request.getRemoteAddr()).withRequestUrl(request.getRequestURL().toString())
+                .withRequestMethod(request.getMethod()).withRequestUserAgent(userAgent).withRequestBody(requestBody);
+    }
+
+    public AuditLogContextBuilder withResponse(int httpStatus, Object body) {
+        return withResponseCode(httpStatus).withResponseBody(body);
+    }
+
+    public void checkAuditContextIsValid() {
+        // check elements of the context
+        List<AuditLogFieldEnum> notFound = new ArrayList<>();
+        for (AuditLogFieldEnum auditLogFieldEnum : AuditLogFieldEnum.values()) {
+            if (auditLogFieldEnum.isMandatory() && !auditLogFieldEnum.hasParent()) {
+                if (!context.containsKey(auditLogFieldEnum.getId())
+                        || StringUtils.isEmpty(context.get(auditLogFieldEnum.getId()))) {
+                    notFound.add(auditLogFieldEnum);
+                }
+            }
+        }
+        // then check request and response
+        for (AuditLogFieldEnum requestChild : REQUEST.getChildren()) {
+            if (requestChild.isMandatory()
+                    && (!request.containsKey(requestChild.getId()) || StringUtils.isEmpty(request.get(requestChild.getId())))) {
+                notFound.add(requestChild);
+            }
+        }
+        for (AuditLogFieldEnum responseChild : RESPONSE.getChildren()) {
+            if (responseChild.isMandatory() && (!response.containsKey(responseChild.getId())
+                    || StringUtils.isEmpty(response.get(responseChild.getId())))) {
+                notFound.add(responseChild);
+            }
+        }
+
+        if (!notFound.isEmpty()) {
+            throw new RuntimeException("audit log context is incomplete, missing information: " + notFound);
+        }
+    }
+
+    Map<String, String> getContext() {
+        return context;
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilter.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilter.java
@@ -1,0 +1,11 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import org.talend.daikon.spring.audit.logs.api.AuditUserProvider;
+import org.talend.logging.audit.Context;
+
+public interface AuditLogGenerationFilter {
+
+    void sendAuditLog(Context context);
+
+    AuditUserProvider getAuditUserProvider();
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilterImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilterImpl.java
@@ -1,0 +1,163 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.time.OffsetDateTime;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.talend.daikon.spring.audit.logs.api.AuditContextFilter;
+import org.talend.daikon.spring.audit.logs.api.AuditUserProvider;
+import org.talend.daikon.spring.audit.logs.api.GenerateAuditLog;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.talend.logging.audit.Context;
+
+@Aspect
+public class AuditLogGenerationFilterImpl implements AuditLogGenerationFilter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogGenerationFilterImpl.class);
+
+    private final ObjectMapper objectMapper;
+
+    private final AuditUserProvider auditUserProvider;
+
+    private final AuditLogger auditLogger;
+
+    public AuditLogGenerationFilterImpl(ObjectMapper objectMapper, AuditUserProvider auditUserProvider, AuditLogger auditLogger) {
+        this.objectMapper = objectMapper;
+        this.auditUserProvider = auditUserProvider;
+        this.auditLogger = auditLogger;
+    }
+
+    /**
+     * This aspect will be ran around all method with the @GenerateAuditLog annotation
+     */
+    @Around("@annotation(org.talend.daikon.spring.audit.logs.api.GenerateAuditLog)")
+    public Object auditLogGeneration(final ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        // Retrieve @GenerateAuditLog annotation
+        MethodSignature signature = (MethodSignature) proceedingJoinPoint.getSignature();
+        Method method = signature.getMethod();
+        GenerateAuditLog auditLogAnnotation = method.getAnnotation(GenerateAuditLog.class);
+        ResponseStatus responseStatusAnnotation = method.getAnnotation(ResponseStatus.class);
+
+        // Retrieve HTTP request & response
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        HttpServletResponse response = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getResponse();
+
+        /**
+         * ---------------------
+         * Determine Request info
+         * ---------------------
+         */
+
+        // Retrieve @RequestBody annotation index (if used in original method)
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        AtomicReference<Integer> argumentIndex = new AtomicReference<>();
+        AtomicInteger index = new AtomicInteger();
+        Arrays.asList(parameterAnnotations).forEach(annotations -> {
+            if (Arrays.stream(annotations)
+                    .anyMatch(annotation -> annotation.annotationType().getName().equals(RequestBody.class.getName()))) {
+                argumentIndex.set(index.intValue());
+            }
+            index.getAndIncrement();
+        });
+        // If @RequestBody arg annotation exists, retrieve the associated argument
+        Object requestBody = null;
+        if (argumentIndex.get() != null) {
+            requestBody = proceedingJoinPoint.getArgs()[argumentIndex.get()];
+        }
+
+        /**
+         * ----------------------
+         * Determine Response info
+         * ----------------------
+         */
+
+        // Response code is deducted from HttpServletResponse if possible
+        // Otherwise let's use a default value (0)
+        int responseCode = response != null ? response.getStatus() : 0;
+        if (responseStatusAnnotation != null) {
+            responseCode = responseStatusAnnotation.value().value();
+        }
+
+        // Run original method
+        try {
+            // Run original method and retrieve the result
+            Object responseObject = proceedingJoinPoint.proceed();
+            // This result will be used as Response body
+            Object auditLogResponseObject = responseObject;
+            if (responseObject instanceof ResponseEntity) {
+                // In case of ResponseEntity, body and status code can be retrieved directly
+                responseCode = ((ResponseEntity) responseObject).getStatusCode().value();
+                auditLogResponseObject = ((ResponseEntity) responseObject).getBody();
+            }
+            // Finally send the audit log
+            sendAuditLog(request, requestBody, responseCode, auditLogResponseObject, auditLogAnnotation);
+            return responseObject;
+        } catch (Throwable throwable) {
+            // In case of exception, the audit log must be send anyway
+            sendAuditLog(request, requestBody, HttpStatus.INTERNAL_SERVER_ERROR.value(), null, auditLogAnnotation);
+            throw throwable;
+        }
+
+    }
+
+    /**
+     * Build the context and send the audit log
+     */
+    private void sendAuditLog(HttpServletRequest request, Object requestBody, int responseCode, Object responseObject,
+            GenerateAuditLog auditLogAnnotation) throws JsonProcessingException {
+        // Build context from request, response & annotation info
+        AuditLogContextBuilder auditLogContextBuilder = AuditLogContextBuilder.create()
+                .withTimestamp(OffsetDateTime.now().toString()).withLogId(UUID.randomUUID()).withRequestId(UUID.randomUUID())
+                .withApplicationId(auditLogAnnotation.application()).withEventType(auditLogAnnotation.eventType())
+                .withEventCategory(auditLogAnnotation.eventCategory()).withEventOperation(auditLogAnnotation.eventOperation())
+                .withUserId(auditUserProvider.getUserId()).withUsername(auditUserProvider.getUsername())
+                .withEmail(auditUserProvider.getUserEmail()).withAccountId(auditUserProvider.getAccountId())
+                .withRequest(request, requestBody).withResponse(responseCode,
+                        (auditLogAnnotation.includeBodyResponse() && responseObject != null)
+                                ? objectMapper.writeValueAsString(responseObject)
+                                : null);
+
+        try {
+            // Filter the context if needed
+            AuditContextFilter filter = auditLogAnnotation.filter().getDeclaredConstructor().newInstance();
+            auditLogContextBuilder = filter.filter(auditLogContextBuilder, requestBody);
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        // Finally send the log
+        auditLogger.sendAuditLog(auditLogContextBuilder.build());
+
+        LOGGER.info("audit log generated with metadata {}", auditLogAnnotation);
+    }
+
+    public void sendAuditLog(Context context) {
+        auditLogger.sendAuditLog(context);
+    }
+
+    public AuditUserProvider getAuditUserProvider() {
+        return auditUserProvider;
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilterInterface.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilterInterface.java
@@ -1,0 +1,8 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import org.talend.logging.audit.Context;
+
+public interface AuditLogGenerationFilterInterface {
+
+    void sendAuditLog(Context context);
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogger.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogger.java
@@ -1,0 +1,10 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import org.talend.logging.audit.AuditEvent;
+import org.talend.logging.audit.EventAuditLogger;
+
+public interface AuditLogger extends EventAuditLogger {
+
+    @AuditEvent(category = "audit log")
+    void sendAuditLog(Object... args);
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/resources/META-INF/spring.factories
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+org.talend.daikon.spring.audit.logs.config.AuditLogConfig

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/config/AuditLogConfig.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/config/AuditLogConfig.java
@@ -1,0 +1,31 @@
+package org.talend.daikon.spring.audit.logs.config;
+
+import java.util.Optional;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.context.annotation.Primary;
+import org.talend.daikon.spring.audit.logs.api.AuditUserProvider;
+import org.talend.daikon.spring.audit.logs.api.NoOpAuditUserProvider;
+import org.talend.daikon.spring.audit.logs.service.AuditLogGenerationFilter;
+import org.talend.daikon.spring.audit.logs.service.AuditLogGenerationFilterImpl;
+import org.talend.daikon.spring.audit.logs.service.AuditLogger;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@EnableAspectJAutoProxy(proxyTargetClass = true)
+@EnableConfigurationProperties(AuditKafkaProperties.class)
+@ConditionalOnProperty(value = "audit.enabled", havingValue = "true", matchIfMissing = true)
+public class AuditLogConfig {
+
+    @Primary
+    @Bean
+    public AuditLogGenerationFilter auditLogAspect(ObjectMapper objectMapper, Optional<AuditUserProvider> auditUserProvider,
+            AuditLogger auditLogger) {
+        return new AuditLogGenerationFilterImpl(objectMapper, auditUserProvider.orElse(new NoOpAuditUserProvider()), auditLogger);
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilderTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilderTest.java
@@ -1,0 +1,174 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.talend.logging.audit.Context;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class AuditLogContextBuilderTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void testBuildAllFields() {
+        Map<String, Object> responseBody = new HashMap<>();
+        responseBody.put("entity", "user");
+        responseBody.put("error", false);
+
+        HttpStatus httpStatus = HttpStatus.ACCEPTED;
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setRemoteHost("localhost");
+        request.setRemotePort(80);
+        request.setRequestURI("/");
+        request.setMethod("POST");
+        request.addHeader("User-Agent", "user agent");
+
+        String fakeUsername = "fakeUser";
+        String accountId = "accountId";
+        String userId = "userId";
+        String email = "fakeUser@talend.com";
+
+        String applicationId = "TTT";
+        String eventType = "a type";
+        String eventCategory = "a category";
+        String eventOperation = "an operation";
+        String timestamp = OffsetDateTime.now().toString();
+        Context context = AuditLogContextBuilder.create().withTimestamp(timestamp).withLogId(UUID.randomUUID())
+                .withRequestId(UUID.randomUUID()).withApplicationId(applicationId).withEventType(eventType)
+                .withEventOperation(eventOperation).withEventCategory(eventCategory).withUserId(userId).withUsername(fakeUsername)
+                .withEmail(email).withAccountId(accountId).withRequest(request, "post request")
+                .withResponse(httpStatus.value(), responseBody).build();
+
+        assertNotNull(context.get("timestamp"));
+        assertNotNull(context.get("log_id"));
+        assertNotNull(context.get("request_id"));
+        assertEquals("accountId", context.get("account_id"));
+        assertEquals("userId", context.get("user_id"));
+        assertEquals("fakeUser", context.get("username"));
+        assertEquals("fakeUser@talend.com", context.get("email"));
+        assertEquals("TTT", context.get("application_id"));
+        assertEquals("a type", context.get("event_type"));
+        assertEquals("a category", context.get("event_category"));
+        assertEquals("an operation", context.get("event_operation"));
+        assertEquals("127.0.0.1", context.get("client_ip"));
+        assertEquals(
+                "{\"url\":\"http://localhost/\",\"method\":\"POST\",\"user_agent\":\"user agent\",\"body\":\"post request\"}",
+                context.get("request"));
+        assertEquals("{\"code\":\"202\",\"body\":{\"error\":false,\"entity\":\"user\"}}", context.get("response"));
+    }
+
+    @Test
+    public void testBuildWithIncompleteRequestAndResponse() {
+        HttpStatus httpStatus = HttpStatus.ACCEPTED;
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setRemoteHost("localhost");
+        request.setRemotePort(80);
+        request.setRequestURI("/");
+        request.setMethod(null);
+        request.addHeader("User-Agent", "user agent");
+
+        String fakeUsername = "fakeUser";
+        String accountId = "accountId";
+        String userId = "userId";
+        String email = "fakeUser@talend.com";
+
+        String applicationId = "TTT";
+        String eventType = "a type";
+        String eventCategory = "a category";
+        String eventOperation = "an operation";
+        String timestamp = OffsetDateTime.now().toString();
+
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("audit log context is incomplete, missing information: [METHOD]");
+
+        AuditLogContextBuilder.create().withTimestamp(timestamp).withLogId(UUID.randomUUID()).withRequestId(UUID.randomUUID())
+                .withApplicationId(applicationId).withEventType(eventType).withEventOperation(eventOperation)
+                .withEventCategory(eventCategory).withUserId(userId).withUsername(fakeUsername).withEmail(email)
+                .withAccountId(accountId).withRequest(request, null).withResponse(httpStatus.value(), null).build();
+    }
+
+    @Test
+    public void testBuildEmptyNotMandatoryFields() {
+        HttpStatus httpStatus = HttpStatus.ACCEPTED;
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setScheme("http");
+        request.setRemoteHost("localhost");
+        request.setRemotePort(80);
+        request.setRequestURI("/");
+        request.setMethod("POST");
+
+        String applicationId = "TTT";
+        String eventType = "a type";
+        String eventCategory = "a category";
+        String eventOperation = "an operation";
+        String timestamp = OffsetDateTime.now().toString();
+        Context context = AuditLogContextBuilder.create().withTimestamp(timestamp).withLogId(UUID.randomUUID())
+                .withRequestId(UUID.randomUUID()).withApplicationId(applicationId).withEventType(eventType)
+                .withEventOperation(eventOperation).withEventCategory(eventCategory).withRequest(request, null)
+                .withResponse(httpStatus.value(), null).build();
+
+        assertNotNull(context.get("timestamp"));
+        assertNotNull(context.get("log_id"));
+        assertNotNull(context.get("request_id"));
+        assertEquals("TTT", context.get("application_id"));
+        assertEquals("a type", context.get("event_type"));
+        assertEquals("a category", context.get("event_category"));
+        assertEquals("an operation", context.get("event_operation"));
+        assertEquals("127.0.0.1", context.get("client_ip"));
+        assertEquals("{\"url\":\"http://localhost/\",\"method\":\"POST\"}", context.get("request"));
+        assertEquals("{\"code\":\"202\"}", context.get("response"));
+    }
+
+    @Test
+    public void testBuildAllFieldsEmpty() {
+        expectedException.expect(RuntimeException.class);
+        expectedException.expectMessage("audit log context is incomplete, missing information: "
+                + "[TIMESTAMP, REQUEST_ID, LOG_ID, APPLICATION_ID, EVENT_TYPE, EVENT_CATEGORY,"
+                + " EVENT_OPERATION, CLIENT_IP, REQUEST, RESPONSE, URL, METHOD, RESPONSE_CODE]");
+
+        AuditLogContextBuilder.create().build();
+    }
+
+    @Test
+    public void testBuildNullValuesAreRemoved() {
+        AuditLogContextBuilder builder = AuditLogContextBuilder.create();
+        try {
+            builder.withEmail("email").withUsername(null).withRequestMethod("PUT").withRequestBody(null).withResponseCode(200)
+                    .build();
+        } catch (RuntimeException e) {
+            // do nothing
+        }
+        assertEquals(3, builder.getContext().size());
+        assertEquals("email", builder.getContext().get("email"));
+        assertEquals("{\"method\":\"PUT\"}", builder.getContext().get("request"));
+        assertEquals("{\"code\":\"200\"}", builder.getContext().get("response"));
+    }
+
+    @Test
+    public void testBuildValuesCanBeOverriden() {
+        AuditLogContextBuilder builder = AuditLogContextBuilder.create();
+        try {
+            builder.withResponseCode(200);
+            // override
+            builder.withResponseCode(500).build();
+        } catch (RuntimeException e) {
+            // do nothing
+        }
+        assertEquals(1, builder.getContext().size());
+        assertEquals("{\"code\":\"500\"}", builder.getContext().get("response"));
+    }
+
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilterConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilterConfiguration.java
@@ -1,0 +1,29 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import org.mockito.Mockito;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.talend.daikon.spring.audit.logs.api.AuditUserProvider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@ComponentScan("org.talend.daikon.spring.audit.logs.config")
+public class AuditLogGenerationFilterConfiguration {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+
+    @Bean
+    public AuditLogger auditLogger() {
+        return Mockito.spy(AuditLogger.class);
+    }
+
+    @Bean
+    public AuditUserProvider auditUserProvider() {
+        return Mockito.mock(AuditUserProvider.class);
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilterImplTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/service/AuditLogGenerationFilterImplTest.java
@@ -1,0 +1,590 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import static org.mockito.Mockito.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.core.StringContains.containsString;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import org.apache.commons.text.StringEscapeUtils;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.talend.daikon.spring.audit.logs.api.AuditContextFilter;
+import org.talend.daikon.spring.audit.logs.api.AuditUserProvider;
+import org.talend.daikon.spring.audit.logs.api.GenerateAuditLog;
+import org.talend.daikon.spring.audit.logs.api.NoOpAuditContextFilter;
+import org.talend.daikon.spring.audit.logs.model.AuditLogFieldEnum;
+import org.talend.logging.audit.Context;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = AuditLogGenerationFilterConfiguration.class)
+@TestPropertySource(properties = { "audit.enabled=false" })
+public class AuditLogGenerationFilterImplTest {
+
+    static public class SensitiveFilter implements AuditContextFilter {
+
+        @Override
+        public AuditLogContextBuilder filter(AuditLogContextBuilder auditLogContextBuilder, Object requestBody) {
+            return auditLogContextBuilder.withRequestBody(((String) requestBody).replace("sensitiveValue", ""));
+        }
+    }
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
+
+    private AuditLogGenerationFilterImpl auditLogGenerationFilterImpl;
+
+    @Autowired
+    private AuditLogger auditLogger;
+
+    @Autowired
+    private AuditUserProvider auditUserProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private ProceedingJoinPoint proceedingJoinPoint;
+
+    private Method method;
+
+    private MockHttpServletRequest request = new MockHttpServletRequest();
+
+    private MockHttpServletResponse response = new MockHttpServletResponse();
+
+    @Before
+    public void setUp() {
+        // Reset AuditLogger mock
+        reset(auditLogger);
+        // Mock ProceedingJoinPoint & Method
+        proceedingJoinPoint = mock(ProceedingJoinPoint.class);
+        method = mock(Method.class);
+        MethodSignature methodSignature = mock(MethodSignature.class);
+        when(proceedingJoinPoint.getSignature()).thenReturn(methodSignature);
+        when(methodSignature.getMethod()).thenReturn(method);
+
+        auditLogGenerationFilterImpl = new AuditLogGenerationFilterImpl(objectMapper, auditUserProvider, auditLogger);
+    }
+
+    /**
+     * GIVEN a incomplete context (with missing info)
+     * AND the @GenerateAuditLog well configured placed on a RestController method
+     * WHEN the method is called (a rest request has been performed)
+     * THEN a RuntimeException is thrown
+     */
+    @Test
+    public void testGenerateAuditLogMissingMandatoryField() throws Throwable {
+
+        // GIVEN a incomplete context (with missing info)
+        // AND the @GenerateAuditLog well configured placed on a RestController method
+
+        // Mock @GenerateAuditLog annotation as following :
+        // @GenerateAuditLog(application = "TMC", eventType = "application security", eventCategory = "user account",
+        // eventOperation = "create")
+        mockGenerateAuditLog("daikon", "security", "resource", "create", false);
+
+        // Mock no authenticated user
+        mockUser(null, null, null, null);
+
+        // Mock minimal HTTP request & response with missing info
+        // METHOD is missing
+        mockHttpRequest("0.0.0.0", "/resource", null, null, null);
+        mockHttpResponse(HttpStatus.OK, null);
+
+        // WHEN the method is called (a rest request has been performed)
+        // THEN a RuntimeException is thrown
+        exceptionRule.expect(RuntimeException.class);
+        exceptionRule.expectMessage("audit log context is incomplete, missing information: ");
+        exceptionRule.expectMessage(AuditLogFieldEnum.METHOD.toString());
+        auditLogGenerationFilterImpl.auditLogGeneration(proceedingJoinPoint);
+    }
+
+    /**
+     * GIVEN a minimal context configured
+     * AND the @GenerateAuditLog well configured placed on a RestController method
+     * WHEN the method is called (a rest request has been performed)
+     * THEN an audit log with minimal context must be sent
+     */
+    @Test
+    public void testGenerateAuditLogMinimalContext() throws Throwable {
+
+        // GIVEN a minimal context configured
+        // AND the @GenerateAuditLog well configured placed on a RestController method
+
+        // Mock @GenerateAuditLog annotation as following :
+        // @GenerateAuditLog(application = "TMC", eventType = "application security", eventCategory = "user account",
+        // eventOperation = "create")
+        mockGenerateAuditLog("daikon", "security", "resource", "create", false);
+
+        // Mock no authenticated user
+        mockUser(null, null, null, null);
+
+        // Mock minimal HTTP request & response
+        mockHttpRequest("0.0.0.0", "/resource", HttpMethod.POST, null, null);
+        mockHttpResponse(HttpStatus.OK, null);
+
+        // WHEN the method is called (a rest request has been performed)
+        auditLogGenerationFilterImpl.auditLogGeneration(proceedingJoinPoint);
+
+        // THEN an audit log with minimal context must be sent
+        ArgumentCaptor<Context> context = ArgumentCaptor.forClass(Context.class);
+        verify(auditLogger, times(1)).sendAuditLog(context.capture());
+        verifyContext(context.getValue(),
+                // Basic mandatory fields must be filled
+                AuditLogFieldEnum.TIMESTAMP, is(not(nullValue())), //
+                AuditLogFieldEnum.REQUEST_ID, is(not(nullValue())), //
+                AuditLogFieldEnum.LOG_ID, is(not(nullValue())), //
+                // User information must be empty
+                AuditLogFieldEnum.ACCOUNT_ID, is(nullValue()), //
+                AuditLogFieldEnum.USER_ID, is(nullValue()), //
+                AuditLogFieldEnum.USERNAME, is(nullValue()), //
+                AuditLogFieldEnum.EMAIL, is(nullValue()), //
+                // Other mandatory contextual information must be filled
+                AuditLogFieldEnum.APPLICATION_ID, is("daikon"), //
+                AuditLogFieldEnum.EVENT_TYPE, is("security"), //
+                AuditLogFieldEnum.EVENT_CATEGORY, is("resource"), //
+                AuditLogFieldEnum.EVENT_OPERATION, is("create"), //
+                AuditLogFieldEnum.CLIENT_IP, is("0.0.0.0"), //
+                // Request payload must be filled with minimal mandatory info
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"http://localhost/resource\"", AuditLogFieldEnum.URL.getId())),
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.METHOD.getId(), HttpMethod.POST)),
+                AuditLogFieldEnum.REQUEST, not(containsString(AuditLogFieldEnum.REQUEST_BODY.getId())), AuditLogFieldEnum.REQUEST,
+                not(containsString(AuditLogFieldEnum.USER_AGENT.getId())),
+                // Response payload must be filled with minimal mandatory info
+                AuditLogFieldEnum.RESPONSE, not(containsString(AuditLogFieldEnum.RESPONSE_BODY.getId())),
+                AuditLogFieldEnum.RESPONSE,
+                containsString(String.format("\"%s\":\"200\"", AuditLogFieldEnum.RESPONSE_CODE.getId())));
+    }
+
+    /**
+     * GIVEN a minimal context configured
+     * AND the @GenerateAuditLog well configured placed on a RestController method
+     * WHEN the method is called (a rest request has been performed) and that method is annotated with @ResponseStatus
+     * THEN an audit log with minimal context must be sent
+     */
+    @Test
+    public void testGenerateAuditLogMinimalContextWithResponseCode() throws Throwable {
+
+        // GIVEN a minimal context configured
+        // AND the @GenerateAuditLog well configured placed on a RestController method
+
+        // Mock @GenerateAuditLog annotation as following :
+        // @GenerateAuditLog(application = "TMC", eventType = "application security", eventCategory = "user account",
+        // eventOperation = "create")
+        mockGenerateAuditLog("daikon", "security", "resource", "create", false);
+        mockResponseStatus(HttpStatus.NO_CONTENT);
+
+        // Mock no authenticated user
+        mockUser(null, null, null, null);
+
+        // Mock minimal HTTP request & response
+        mockHttpRequest("0.0.0.0", "/resource", HttpMethod.POST, null, null);
+        mockHttpResponse(HttpStatus.OK, null);
+
+        // WHEN the method is called (a rest request has been performed)
+        auditLogGenerationFilterImpl.auditLogGeneration(proceedingJoinPoint);
+
+        // THEN an audit log with minimal context must be sent
+        ArgumentCaptor<Context> context = ArgumentCaptor.forClass(Context.class);
+        verify(auditLogger, times(1)).sendAuditLog(context.capture());
+        verifyContext(context.getValue(),
+                // Basic mandatory fields must be filled
+                AuditLogFieldEnum.TIMESTAMP, is(not(nullValue())), //
+                AuditLogFieldEnum.REQUEST_ID, is(not(nullValue())), //
+                AuditLogFieldEnum.LOG_ID, is(not(nullValue())), //
+                // User information must be empty
+                AuditLogFieldEnum.ACCOUNT_ID, is(nullValue()), //
+                AuditLogFieldEnum.USER_ID, is(nullValue()), //
+                AuditLogFieldEnum.USERNAME, is(nullValue()), //
+                AuditLogFieldEnum.EMAIL, is(nullValue()), //
+                // Other mandatory contextual information must be filled
+                AuditLogFieldEnum.APPLICATION_ID, is("daikon"), //
+                AuditLogFieldEnum.EVENT_TYPE, is("security"), //
+                AuditLogFieldEnum.EVENT_CATEGORY, is("resource"), //
+                AuditLogFieldEnum.EVENT_OPERATION, is("create"), //
+                AuditLogFieldEnum.CLIENT_IP, is("0.0.0.0"), //
+                // Request payload must be filled with minimal mandatory info
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"http://localhost/resource\"", AuditLogFieldEnum.URL.getId())),
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.METHOD.getId(), HttpMethod.POST)),
+                AuditLogFieldEnum.REQUEST, not(containsString(AuditLogFieldEnum.REQUEST_BODY.getId())), AuditLogFieldEnum.REQUEST,
+                not(containsString(AuditLogFieldEnum.USER_AGENT.getId())),
+                // Response payload must be filled with minimal mandatory info
+                AuditLogFieldEnum.RESPONSE, not(containsString(AuditLogFieldEnum.RESPONSE_BODY.getId())),
+                AuditLogFieldEnum.RESPONSE,
+                containsString(String.format("\"%s\":\"204\"", AuditLogFieldEnum.RESPONSE_CODE.getId())));
+    }
+
+    /**
+     * GIVEN a full context configured
+     * AND the @GenerateAuditLog well configured placed on a RestController method
+     * WHEN the method is called (a rest request has been performed)
+     * THEN an audit log with full context must be sent
+     */
+    @Test
+    public void testGenerateAuditLogFullContext() throws Throwable {
+
+        // GIVEN a full context configured
+        // AND the @GenerateAuditLog well configured placed on a RestController method
+
+        // Mock @GenerateAuditLog annotation as following :
+        // @GenerateAuditLog(application = "TMC", eventType = "application security", eventCategory = "user account",
+        // eventOperation = "create")
+        mockGenerateAuditLog("daikon", "security", "resource", "create", true);
+
+        // Mock current authenticated user
+        mockUser("user1", "ejarvis", "edwin.jarvis@talend.com", "account1");
+
+        // Mock HTTP request & response
+        Map<String, String> createdResource = new HashMap<>();
+        createdResource.put("id", "myResourceId");
+        createdResource.put("name", "myResourceName");
+        mockHttpRequest("0.0.0.0", "/resource", HttpMethod.POST, objectMapper.writeValueAsString(createdResource), "myUserAgent");
+        mockHttpResponse(HttpStatus.OK, createdResource);
+
+        // WHEN the method is called (a rest request has been performed)
+        auditLogGenerationFilterImpl.auditLogGeneration(proceedingJoinPoint);
+
+        // THEN an audit log with full context must be sent
+        ArgumentCaptor<Context> context = ArgumentCaptor.forClass(Context.class);
+        verify(auditLogger, times(1)).sendAuditLog(context.capture());
+        verifyContext(context.getValue(),
+                // Basic mandatory fields must be filled
+                AuditLogFieldEnum.TIMESTAMP, is(not(nullValue())), //
+                AuditLogFieldEnum.REQUEST_ID, is(not(nullValue())), //
+                AuditLogFieldEnum.LOG_ID, is(not(nullValue())), //
+                // User information must be filled
+                AuditLogFieldEnum.ACCOUNT_ID, is("account1"), //
+                AuditLogFieldEnum.USER_ID, is("user1"), //
+                AuditLogFieldEnum.USERNAME, is("ejarvis"), //
+                AuditLogFieldEnum.EMAIL, is("edwin.jarvis@talend.com"), //
+                // Other mandatory contextual information must be filled
+                AuditLogFieldEnum.APPLICATION_ID, is("daikon"), //
+                AuditLogFieldEnum.EVENT_TYPE, is("security"), //
+                AuditLogFieldEnum.EVENT_CATEGORY, is("resource"), //
+                AuditLogFieldEnum.EVENT_OPERATION, is("create"), //
+                AuditLogFieldEnum.CLIENT_IP, is("0.0.0.0"), //
+                // Request payload must be filled
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"http://localhost/resource\"", AuditLogFieldEnum.URL.getId())),
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.METHOD.getId(), HttpMethod.POST)),
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId(),
+                        StringEscapeUtils.escapeJava(objectMapper.writeValueAsString(createdResource)))),
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"myUserAgent\"", AuditLogFieldEnum.USER_AGENT.getId())),
+                // Response payload must be filled
+                AuditLogFieldEnum.RESPONSE,
+                containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId(),
+                        StringEscapeUtils.escapeJava(objectMapper.writeValueAsString(createdResource)))),
+                AuditLogFieldEnum.RESPONSE,
+                containsString(String.format("\"%s\":\"200\"", AuditLogFieldEnum.RESPONSE_CODE.getId())));
+    }
+
+    /**
+     * GIVEN a full context configured
+     * AND the @GenerateAuditLog well configured placed on a RestController method
+     * AND a filter configured to remove sensitive information
+     * WHEN the method is called (a rest request has been performed) with sensitive information
+     * THEN an audit log with full context must be sent without sensitive information
+     */
+    @Test
+    public void testGenerateAuditLogFilteredContext() throws Throwable {
+
+        // GIVEN a full context configured
+        // AND the @GenerateAuditLog well configured placed on a RestController method
+        // AND a filter configured to remove sensitive information
+
+        // Mock @GenerateAuditLog annotation as following :
+        // @GenerateAuditLog(application = "TMC", eventType = "application security", eventCategory = "user account",
+        // eventOperation = "create", filter = SensitiveFilter.class)
+        mockGenerateAuditLog("daikon", "security", "resource", "create", true, SensitiveFilter.class);
+
+        // Mock current authenticated user
+        mockUser("user1", "ejarvis", "edwin.jarvis@talend.com", "account1");
+
+        // Mock HTTP request & response
+        Map<String, String> createdResource = new HashMap<>();
+        createdResource.put("id", "myResourceId");
+        createdResource.put("name", "myResourceName");
+        // Request contains sensitive data
+        createdResource.put("sensitiveKey", "sensitiveValue");
+        mockHttpRequest("0.0.0.0", "/resource", HttpMethod.POST, objectMapper.writeValueAsString(createdResource), "myUserAgent");
+        mockHttpResponse(HttpStatus.OK, createdResource);
+
+        // WHEN the method is called (a rest request has been performed) with sensitive information
+        auditLogGenerationFilterImpl.auditLogGeneration(proceedingJoinPoint);
+
+        // THEN an audit log with full context must be sent without sensitive information
+        ArgumentCaptor<Context> context = ArgumentCaptor.forClass(Context.class);
+        verify(auditLogger, times(1)).sendAuditLog(context.capture());
+        verifyContext(context.getValue(),
+                // Basic mandatory fields must be filled
+                AuditLogFieldEnum.TIMESTAMP, is(not(nullValue())), //
+                AuditLogFieldEnum.REQUEST_ID, is(not(nullValue())), //
+                AuditLogFieldEnum.LOG_ID, is(not(nullValue())), //
+                // User information must be filled
+                AuditLogFieldEnum.ACCOUNT_ID, is("account1"), //
+                AuditLogFieldEnum.USER_ID, is("user1"), //
+                AuditLogFieldEnum.USERNAME, is("ejarvis"), //
+                AuditLogFieldEnum.EMAIL, is("edwin.jarvis@talend.com"), //
+                // Other mandatory contextual information must be filled
+                AuditLogFieldEnum.APPLICATION_ID, is("daikon"), //
+                AuditLogFieldEnum.EVENT_TYPE, is("security"), //
+                AuditLogFieldEnum.EVENT_CATEGORY, is("resource"), //
+                AuditLogFieldEnum.EVENT_OPERATION, is("create"), //
+                AuditLogFieldEnum.CLIENT_IP, is("0.0.0.0"), //
+                // Request payload must be filled
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"http://localhost/resource\"", AuditLogFieldEnum.URL.getId())),
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.METHOD.getId(), HttpMethod.POST)),
+                // Verify that request doesn't contain any sensitive value
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId(),
+                        StringEscapeUtils
+                                .escapeJava(objectMapper.writeValueAsString(createdResource).replace("sensitiveValue", "")))),
+                AuditLogFieldEnum.REQUEST,
+                containsString(String.format("\"%s\":\"myUserAgent\"", AuditLogFieldEnum.USER_AGENT.getId())),
+                // Response payload must be filled
+                AuditLogFieldEnum.RESPONSE,
+                containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId(),
+                        StringEscapeUtils.escapeJava(objectMapper.writeValueAsString(createdResource)))),
+                AuditLogFieldEnum.RESPONSE,
+                containsString(String.format("\"%s\":\"200\"", AuditLogFieldEnum.RESPONSE_CODE.getId())));
+    }
+
+    /**
+     * GIVEN a full context configured
+     * AND the @GenerateAuditLog well configured placed on a RestController method
+     * WHEN the method is called (a rest request has been performed)
+     * AND an exception occurs
+     * THEN an audit log with full context must be sent with code 500
+     * AND the exception is thrown
+     */
+    @Test
+    public void testGenerateAuditLogException() throws Throwable {
+
+        // GIVEN a full context configured
+        // AND the @GenerateAuditLog well configured placed on a RestController method
+
+        // Mock @GenerateAuditLog annotation as following :
+        // @GenerateAuditLog(application = "TMC", eventType = "application security", eventCategory = "user account",
+        // eventOperation = "create")
+        mockGenerateAuditLog("daikon", "security", "resource", "create", true);
+
+        // Mock current authenticated user
+        mockUser("user1", "ejarvis", "edwin.jarvis@talend.com", "account1");
+
+        // Mock HTTP request & response
+        Map<String, String> createdResource = new HashMap<>();
+        createdResource.put("id", "myResourceId");
+        createdResource.put("name", "myResourceName");
+        mockHttpRequest("0.0.0.0", "/resource", HttpMethod.POST, objectMapper.writeValueAsString(createdResource), "myUserAgent");
+        mockHttpResponse(HttpStatus.OK, createdResource);
+
+        // WHEN the method is called (a rest request has been performed)
+        // AND an exception occurs
+        when(proceedingJoinPoint.proceed()).thenThrow(new Exception("Ouch !"));
+        exceptionRule.expect(Exception.class);
+        exceptionRule.expectMessage("Ouch !");
+        try {
+            auditLogGenerationFilterImpl.auditLogGeneration(proceedingJoinPoint);
+        } catch (Exception e) {
+            // THEN an audit log with full context must be sent
+            ArgumentCaptor<Context> context = ArgumentCaptor.forClass(Context.class);
+            verify(auditLogger, times(1)).sendAuditLog(context.capture());
+            verifyContext(context.getValue(),
+                    // Basic mandatory fields must be filled
+                    AuditLogFieldEnum.TIMESTAMP, is(not(nullValue())), //
+                    AuditLogFieldEnum.REQUEST_ID, is(not(nullValue())), //
+                    AuditLogFieldEnum.LOG_ID, is(not(nullValue())), //
+                    // User information must be filled
+                    AuditLogFieldEnum.ACCOUNT_ID, is("account1"), //
+                    AuditLogFieldEnum.USER_ID, is("user1"), //
+                    AuditLogFieldEnum.USERNAME, is("ejarvis"), //
+                    AuditLogFieldEnum.EMAIL, is("edwin.jarvis@talend.com"), //
+                    // Other mandatory contextual information must be filled
+                    AuditLogFieldEnum.APPLICATION_ID, is("daikon"), //
+                    AuditLogFieldEnum.EVENT_TYPE, is("security"), //
+                    AuditLogFieldEnum.EVENT_CATEGORY, is("resource"), //
+                    AuditLogFieldEnum.EVENT_OPERATION, is("create"), //
+                    AuditLogFieldEnum.CLIENT_IP, is("0.0.0.0"), //
+                    // Request payload must be filled
+                    AuditLogFieldEnum.REQUEST,
+                    containsString(String.format("\"%s\":\"http://localhost/resource\"", AuditLogFieldEnum.URL.getId())),
+                    AuditLogFieldEnum.REQUEST,
+                    containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.METHOD.getId(), HttpMethod.POST)),
+                    AuditLogFieldEnum.REQUEST,
+                    containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId(),
+                            StringEscapeUtils.escapeJava(objectMapper.writeValueAsString(createdResource)))),
+                    AuditLogFieldEnum.REQUEST,
+                    containsString(String.format("\"%s\":\"myUserAgent\"", AuditLogFieldEnum.USER_AGENT.getId())),
+                    // Response payload must be filled
+                    AuditLogFieldEnum.RESPONSE, not(containsString(AuditLogFieldEnum.RESPONSE_BODY.getId())),
+                    AuditLogFieldEnum.RESPONSE,
+                    containsString(String.format("\"%s\":\"500\"", AuditLogFieldEnum.RESPONSE_CODE.getId())));
+            // AND the exception is thrown
+            throw e;
+        }
+    }
+
+    /**
+     * Verify that context has expected key & values
+     *
+     * @param context Context to check
+     * @param o Succession of context keys (AuditLogFieldEnum) and matcher values (Matcher<String>)
+     */
+    private void verifyContext(Context context, Object... o) {
+        IntStream.range(0, o.length).filter(i -> i % 2 == 0).forEach(i -> assertThat(
+                String.format("Wrong expected value for key %s", ((AuditLogFieldEnum) o[i]).getId()),
+                context.containsKey(((AuditLogFieldEnum) o[i]).getId()) ? context.get(((AuditLogFieldEnum) o[i]).getId()) : null,
+                (Matcher<String>) o[i + 1]));
+    }
+
+    /**
+     * Mock authenticated user
+     *
+     * @param userId User id
+     * @param userName User name
+     * @param userEmail User email
+     * @param accountId Account id
+     */
+    private void mockUser(String userId, String userName, String userEmail, String accountId) {
+        when(auditUserProvider.getUserId()).thenReturn(userId);
+        when(auditUserProvider.getUsername()).thenReturn(userName);
+        when(auditUserProvider.getUserEmail()).thenReturn(userEmail);
+        when(auditUserProvider.getAccountId()).thenReturn(accountId);
+    }
+
+    /**
+     * Mock HTTP request
+     *
+     * @param remoteAddress Caller remote address
+     * @param url Request URL
+     * @param method Request method
+     * @param body Request body
+     * @param userAgent Caller user agent
+     */
+    private void mockHttpRequest(String remoteAddress, String url, HttpMethod method, Object body, String userAgent) {
+        // Mock HttpServletRequest
+        request = new MockHttpServletRequest();
+        if (remoteAddress != null) {
+            request.setRemoteAddr(remoteAddress);
+        }
+        if (url != null) {
+            request.setRequestURI(url);
+        }
+        if (method != null) {
+            request.setMethod(method.name());
+        }
+        if (userAgent != null) {
+            request.addHeader("User-Agent", userAgent);
+        }
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, response));
+        // Mock @RequestBody annotation & arg if needed
+        Annotation[][] annotations = { {} };
+        Object[] args = {};
+        if (body != null) {
+            Annotation requestBody = mock(Annotation.class);
+            doReturn(RequestBody.class).when(requestBody).annotationType();
+            annotations = new Annotation[][] { { requestBody } };
+            args = new Object[] { body };
+        }
+        when(this.method.getParameterAnnotations()).thenReturn(annotations);
+        when(proceedingJoinPoint.getArgs()).thenReturn(args);
+    }
+
+    /**
+     * Mock HTTP response
+     *
+     * @param status Response status code
+     * @param body Response body
+     * @throws Throwable
+     */
+    private void mockHttpResponse(HttpStatus status, Object body) throws Throwable {
+        // Mock HttpServletResponse
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        if (status != null) {
+            response.setStatus(status.value());
+        }
+        if (body != null) {
+            response.getWriter().print(body);
+            // Mock object returned by annotated method if needed
+            when(proceedingJoinPoint.proceed()).thenReturn(body);
+        }
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request, response));
+    }
+
+    /**
+     * Mock @GenerateAuditLog annotation with default NoOp filter
+     *
+     * @param application application param value
+     * @param eventType eventType param value
+     * @param eventCategory eventCategory param value
+     * @param eventOperation eventOperation param value
+     * @param includeBodyResponse includeBodyResponse param value
+     */
+    private void mockGenerateAuditLog(String application, String eventType, String eventCategory, String eventOperation,
+            boolean includeBodyResponse) {
+        mockGenerateAuditLog(application, eventType, eventCategory, eventOperation, includeBodyResponse,
+                NoOpAuditContextFilter.class);
+    }
+
+    /**
+     * Mock @GenerateAuditLog annotation with custom filter
+     *
+     * @param application application param value
+     * @param eventType eventType param value
+     * @param eventCategory eventCategory param value
+     * @param eventOperation eventOperation param value
+     * @param includeBodyResponse includeBodyResponse param value
+     * @param filterClass custom filter class
+     */
+    private void mockGenerateAuditLog(String application, String eventType, String eventCategory, String eventOperation,
+            boolean includeBodyResponse, Class<? extends AuditContextFilter> filterClass) {
+        GenerateAuditLog annotation = mock(GenerateAuditLog.class);
+        when(annotation.application()).thenReturn(application);
+        when(annotation.eventType()).thenReturn(eventType);
+        when(annotation.eventCategory()).thenReturn(eventCategory);
+        when(annotation.eventOperation()).thenReturn(eventOperation);
+        when(annotation.includeBodyResponse()).thenReturn(includeBodyResponse);
+        doReturn(filterClass).when(annotation).filter();
+        when(method.getAnnotation(GenerateAuditLog.class)).thenReturn(annotation);
+    }
+
+    private void mockResponseStatus(HttpStatus httpStatus) {
+        ResponseStatus annotation = mock(ResponseStatus.class);
+        when(annotation.value()).thenReturn(httpStatus);
+        when(method.getAnnotation(ResponseStatus.class)).thenReturn(annotation);
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/daikon-spring/pom.xml
+++ b/daikon-spring/pom.xml
@@ -39,5 +39,6 @@
         <module>daikon-content-service</module>
         <module>daikon-spring-examples</module>
         <module>daikon-spring-metrics</module>
+        <module>daikon-spring-audit-logs</module>
     </modules>
 </project>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Most of the Talend applications generating audit logs are built using Spring. Audit log context enhancement using Spring leverage must be centralized.

As part of #596, `daikon-spring-audit-logs` has been initialized in Daikon `v2`.
The module must be ported on Daikon `v3`.
 
**What is the chosen solution to this problem?** 
As mentioned in #596, last step of [TPSVC-13814](https://jira.talendforge.org/browse/TPSVC-13814) is to port `daikon-spring-audit-logs` from Daikon `v2` to Daikon `v3`.

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
