### PR TITLE
TPSVC-14118: Move audit logs JSON structure from snake case to camel case

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/README.adoc
+++ b/daikon-spring/daikon-spring-audit-logs/README.adoc
@@ -59,13 +59,13 @@ A call to the `createResource` method will generate and send the following audit
 ```json
 {
     "timestamp": "2020-04-07T13:26:09.741821Z",
-    "request_id": "009a511a-a71e-4b6c-8e0b-822a90c71e43",
-    "log_id": "6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
-    "application_id": "daikon",
-    "event_type": "security",
-    "event_category": "resource",
-    "event_operation": "create",
-    "client_ip": "10.80.48.155",
+    "requestId": "009a511a-a71e-4b6c-8e0b-822a90c71e43",
+    "logId": "6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
+    "applicationId": "daikon",
+    "eventType": "security",
+    "eventCategory": "resource",
+    "eventOperation": "create",
+    "clientIp": "10.80.48.155",
     "request": "{\"url\":\"http://app.url/resource\",\"method\":\"POST\",\"user_agent\":\"{USER_AGENT}\",\"body\":\"{REQUEST_BODY}\"}",
     "response": "{\"code\":\"200\",\"body\":\"{REQUEST_BODY}\"}"
 }
@@ -117,17 +117,17 @@ Will generate an audit log enhanced with user information :
 ```json
 {
     "timestamp": "2020-04-07T13:26:09.741821Z",
-    "request_id": "009a511a-a71e-4b6c-8e0b-822a90c71e43",
-    "log_id": "6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
-    "account_id": "81fd11b5-d0c2-479d-833c-85d67f79edd0",
-    "user_id": "84dc9524-b9b6-4533-a849-606feba86720",
+    "requestId": "009a511a-a71e-4b6c-8e0b-822a90c71e43",
+    "logId": "6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
+    "accountId": "81fd11b5-d0c2-479d-833c-85d67f79edd0",
+    "userId": "84dc9524-b9b6-4533-a849-606feba86720",
     "username": "1510_3_int@trial01775.us.talend.com",
     "email": "1510_3_int@yopmail.com",
-    "application_id": "daikon",
-    "event_type": "security",
-    "event_category": "resource",
-    "event_operation": "create",
-    "client_ip": "10.80.48.155",
+    "applicationId": "daikon",
+    "eventType": "security",
+    "eventCategory": "resource",
+    "eventOperation": "create",
+    "clientIp": "10.80.48.155",
     "request": "{\"url\":\"http://app.url/resource\",\"method\":\"POST\",\"user_agent\":\"{USER_AGENT}\",\"body\":\"{REQUEST_BODY}\"}",
     "response": "{\"code\":\"200\",\"body\":\"{REQUEST_BODY}\"}"
 }

--- a/daikon-spring/daikon-spring-audit-logs/README.adoc
+++ b/daikon-spring/daikon-spring-audit-logs/README.adoc
@@ -39,7 +39,7 @@ audit:
     kafka:
         bootstrapServers: localhost:9092 # Kafka bootstrap server urls for audit logs sending
         topic: audit-logs # Kafka topic for audit logs sending
-        partitionKeyName: account_id # Kafka partitionKey for audit logs sending
+        partitionKeyName: accountId # Kafka partitionKey for audit logs sending
 ```
 
 == @GenerateAuditLog

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
@@ -9,7 +9,7 @@ public class AuditKafkaProperties {
 
     private String topic = "audit-logs";
 
-    private String partitionKeyName = "account_id";
+    private String partitionKeyName = "accountId";
 
     public String getBootstrapServers() {
         return bootstrapServers;

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/model/AuditLogFieldEnum.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/model/AuditLogFieldEnum.java
@@ -6,23 +6,23 @@ import java.util.List;
 public enum AuditLogFieldEnum {
 
     TIMESTAMP("timestamp"),
-    REQUEST_ID("request_id"),
-    LOG_ID("log_id"),
+    REQUEST_ID("requestId"),
+    LOG_ID("logId"),
     // account id is not mandatory in the case of audit log of anonymous users
-    ACCOUNT_ID("account_id", false),
+    ACCOUNT_ID("accountId", false),
     // user info is not mandatory in the case of audit log of anonymous users
-    USER_ID("user_id", false),
+    USER_ID("userId", false),
     USERNAME("username", false),
     EMAIL("email", false),
-    APPLICATION_ID("application_id"),
-    EVENT_TYPE("event_type"),
-    EVENT_CATEGORY("event_category"),
-    EVENT_OPERATION("event_operation"),
-    CLIENT_IP("client_ip"),
+    APPLICATION_ID("applicationId"),
+    EVENT_TYPE("eventType"),
+    EVENT_CATEGORY("eventCategory"),
+    EVENT_OPERATION("eventOperation"),
+    CLIENT_IP("clientIp"),
     URL("url"),
     METHOD("method"),
     // user agent not mandatory because not always provided
-    USER_AGENT("user_agent", false),
+    USER_AGENT("userAgent", false),
     // request body is not present for all user actions
     REQUEST_BODY("body", false),
     REQUEST("request", Arrays.asList(URL, METHOD, USER_AGENT, REQUEST_BODY)),

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilderTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilderTest.java
@@ -52,19 +52,18 @@ public class AuditLogContextBuilderTest {
                 .withResponse(httpStatus.value(), responseBody).build();
 
         assertNotNull(context.get("timestamp"));
-        assertNotNull(context.get("log_id"));
-        assertNotNull(context.get("request_id"));
-        assertEquals("accountId", context.get("account_id"));
-        assertEquals("userId", context.get("user_id"));
+        assertNotNull(context.get("logId"));
+        assertNotNull(context.get("requestId"));
+        assertEquals("accountId", context.get("accountId"));
+        assertEquals("userId", context.get("userId"));
         assertEquals("fakeUser", context.get("username"));
         assertEquals("fakeUser@talend.com", context.get("email"));
-        assertEquals("TTT", context.get("application_id"));
-        assertEquals("a type", context.get("event_type"));
-        assertEquals("a category", context.get("event_category"));
-        assertEquals("an operation", context.get("event_operation"));
-        assertEquals("127.0.0.1", context.get("client_ip"));
-        assertEquals(
-                "{\"url\":\"http://localhost/\",\"method\":\"POST\",\"user_agent\":\"user agent\",\"body\":\"post request\"}",
+        assertEquals("TTT", context.get("applicationId"));
+        assertEquals("a type", context.get("eventType"));
+        assertEquals("a category", context.get("eventCategory"));
+        assertEquals("an operation", context.get("eventOperation"));
+        assertEquals("127.0.0.1", context.get("clientIp"));
+        assertEquals("{\"url\":\"http://localhost/\",\"method\":\"POST\",\"userAgent\":\"user agent\",\"body\":\"post request\"}",
                 context.get("request"));
         assertEquals("{\"code\":\"202\",\"body\":{\"error\":false,\"entity\":\"user\"}}", context.get("response"));
     }
@@ -121,13 +120,13 @@ public class AuditLogContextBuilderTest {
                 .withResponse(httpStatus.value(), null).build();
 
         assertNotNull(context.get("timestamp"));
-        assertNotNull(context.get("log_id"));
-        assertNotNull(context.get("request_id"));
-        assertEquals("TTT", context.get("application_id"));
-        assertEquals("a type", context.get("event_type"));
-        assertEquals("a category", context.get("event_category"));
-        assertEquals("an operation", context.get("event_operation"));
-        assertEquals("127.0.0.1", context.get("client_ip"));
+        assertNotNull(context.get("logId"));
+        assertNotNull(context.get("requestId"));
+        assertEquals("TTT", context.get("applicationId"));
+        assertEquals("a type", context.get("eventType"));
+        assertEquals("a category", context.get("eventCategory"));
+        assertEquals("an operation", context.get("eventOperation"));
+        assertEquals("127.0.0.1", context.get("clientIp"));
         assertEquals("{\"url\":\"http://localhost/\",\"method\":\"POST\"}", context.get("request"));
         assertEquals("{\"code\":\"202\"}", context.get("response"));
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Using cameCase for JSOn structure is the Talend recommendation.
Audit logs keys format must be updated to fit this recommendation.
 
**What is the chosen solution to this problem?**
Update audit logs field enum, tests and readme accordingly.

This change will be backported on v2.0 (see #601). 

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-14118
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
