### PR TITLE
TDKN-284 - Update Log4j 2 to 2.13.2 (#602)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <pax-url-aether.version>2.6.2</pax-url-aether.version>
         <mockito-core.version>2.2.15</mockito-core.version>
         <ch.qos.logback.version>1.1.7</ch.qos.logback.version>
-        <log4j2.version>2.11.2</log4j2.version>
+        <log4j2.version>2.13.2</log4j2.version>
         <hamcrest-all.version>1.3</hamcrest-all.version>
         <hamcrest-json.version>0.2</hamcrest-json.version>
         <json-path-assert.version>2.2.0</json-path-assert.version>


### PR DESCRIPTION


This task is to update Log4j 2 to 2.13.2 due to the following CVE:

[CVE-2020-9488] Improper validation of certificate with host mismatch in Apache Log4j SMTP appender

https://seclists.org/oss-sec/2020/q2/72
