### PR TITLE
TPSVC-14037: Negative audit logs - fix empty response

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -60,6 +60,9 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
             ServletResponse wrappedResponse = Optional.of(servletResponse).filter(r -> r instanceof HttpServletResponse)
                     .map(HttpServletResponse.class::cast).map(ContentCachingResponseWrapper::new).get();
             filterChain.doFilter(wrappedRequest, wrappedResponse);
+            if (wrappedResponse instanceof ContentCachingResponseWrapper) {
+                ((ContentCachingResponseWrapper) wrappedResponse).copyBodyToResponse();
+            }
         };
     }
 

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
@@ -70,9 +70,6 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
         if (rawContent != null) {
             try {
                 stringContent = IOUtils.toString(rawContent, StandardCharsets.UTF_8.toString());
-                if (wrapper instanceof ContentCachingResponseWrapper) {
-                    ((ContentCachingResponseWrapper) wrapper).copyBodyToResponse();
-                }
             } catch (IOException e) {
                 LOGGER.warn("Wrapper content can't be read", e);
             }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
In order to read the HTTP response body from the interceptor in case of negative event, the [HttpServletResponse](https://docs.oracle.com/javaee/6/api/javax/servlet/http/HttpServletResponse.html) is wrapped into a [ContentCachingResponseWrapper](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/util/ContentCachingResponseWrapper.html).

Once the content read from `ContentCachingResponseWrapper`, the method `copyBodyToResponse()` must be called (as explained [here](https://stackoverflow.com/a/39945940/2220149 )). If this method is not called, the content remains empty and can't be read by the next filter.

In some cases, it seems that the HTTP response is empty for the next filter.

**What is the chosen solution to this problem?**
The problem has been fixed by calling the the method `copyBodyToResponse()` from the filter instead of the interceptor. 
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-14037
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
