### PR TITLE
TPSVC-14487: Negative events not capture when manually generating audit logs (backport)

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/AuditLogScope.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/AuditLogScope.java
@@ -1,0 +1,13 @@
+package org.talend.daikon.spring.audit.logs.api;
+
+/**
+ * Audit log scope indicating if audit logs must be generated for :
+ * - ALL cases
+ * - SUCCESS cases only
+ * - ERROR cases only
+ */
+public enum AuditLogScope {
+    ALL,
+    SUCCESS,
+    ERROR
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/AuditLogScope.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/AuditLogScope.java
@@ -1,5 +1,7 @@
 package org.talend.daikon.spring.audit.logs.api;
 
+import java.util.Arrays;
+
 /**
  * Audit log scope indicating if audit logs must be generated for :
  * - ALL cases
@@ -9,5 +11,9 @@ package org.talend.daikon.spring.audit.logs.api;
 public enum AuditLogScope {
     ALL,
     SUCCESS,
-    ERROR
+    ERROR;
+
+    public boolean in(AuditLogScope... scopes) {
+        return Arrays.stream(scopes).anyMatch(scope -> scope == this);
+    }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/GenerateAuditLog.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/GenerateAuditLog.java
@@ -14,43 +14,53 @@ public @interface GenerateAuditLog {
 
     /**
      * Application from which the log is generated
-     * 
+     *
      * @return the name of the application
      */
     String application();
 
     /**
      * Type of the generated event
-     * 
+     *
      * @return event type
      */
     String eventType();
 
     /**
      * Category of the generated event
-     * 
-     * @return Event catrgory
+     *
+     * @return Event category
      */
     String eventCategory();
 
     /**
      * Operation of the generated event
-     * 
+     *
      * @return Event operation
      */
     String eventOperation();
 
     /**
      * Should include or not the HTTP response body in the generated audit log
-     * 
+     *
      * @return boolean indicating if the HTTP response body is included or not
      */
     boolean includeBodyResponse() default true;
 
     /**
      * Filter whose purpose is to filter HTTP request/response before generation
-     * 
+     *
      * @return Filter class
      */
     Class<? extends AuditContextFilter> filter() default NoOpAuditContextFilter.class;
+
+    /**
+     * Indicate if audit logs must be generated for :
+     * - ALL cases
+     * - SUCCESS cases only
+     * - ERROR cases only
+     *
+     * @return Audit log scope
+     */
+    AuditLogScope scope() default AuditLogScope.ALL;
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -103,6 +103,24 @@ public class AuditLogTest {
     }
 
     @Test
+    @WithUserDetails
+    public void testGet400ErrorOnly() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_ERROR_ONLY)).andExpect(status().isBadRequest());
+
+        verifyContext(basicContextCheck());
+        verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_400_ERROR_ONLY, HttpMethod.GET, null));
+        verifyContext(httpResponseContextCheck(HttpStatus.BAD_REQUEST, null));
+    }
+
+    @Test
+    @WithUserDetails
+    public void testGet400SuccessOnly() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_SUCCESS_ONLY)).andExpect(status().isBadRequest());
+
+        verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
+    }
+
+    @Test
     @WithAnonymousUser
     public void testGet401() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_401)).andExpect(status().isUnauthorized());
@@ -158,6 +176,24 @@ public class AuditLogTest {
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_200_WITHOUT_BODY, HttpMethod.GET, null));
         verifyContext(httpResponseContextCheck(HttpStatus.OK, null));
+    }
+
+    @Test
+    @WithUserDetails
+    public void testGet200ErrorOnly() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_ERROR_ONLY)).andExpect(status().isOk());
+
+        verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    @WithUserDetails
+    public void testGet200SuccessOnly() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_SUCCESS_ONLY)).andExpect(status().isOk());
+
+        verifyContext(basicContextCheck());
+        verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_200_SUCCESS_ONLY, HttpMethod.GET, null));
+        verifyContext(httpResponseContextCheck(HttpStatus.OK, AuditLogTestApp.BODY_RESPONSE));
     }
 
     @Test

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTestApp.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTestApp.java
@@ -43,11 +43,19 @@ public class AuditLogTestApp {
 
     public static final String GET_200_WITHOUT_BODY = "/get/200/nobody";
 
+    public static final String GET_200_ERROR_ONLY = "/get/200/error";
+
+    public static final String GET_200_SUCCESS_ONLY = "/get/200/success";
+
     public static final String GET_400_ANNOTATION = "/get/400/annotation";
 
     public static final String GET_400_EXCEPTION = "/get/400/exception";
 
     public static final String GET_400_RESPONSE_ENTITY = "/get/400/responseentity";
+
+    public static final String GET_400_ERROR_ONLY = "/get/400/error";
+
+    public static final String GET_400_SUCCESS_ONLY = "/get/400/success";
 
     public static final String GET_401 = "/get/401";
 
@@ -96,6 +104,18 @@ public class AuditLogTestApp {
         return ResponseEntity.ok(BODY_RESPONSE);
     }
 
+    @GetMapping(GET_200_ERROR_ONLY)
+    @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION, scope = AuditLogScope.ERROR)
+    public ResponseEntity get200ErrorOnly() {
+        return ResponseEntity.ok(BODY_RESPONSE);
+    }
+
+    @GetMapping(GET_200_SUCCESS_ONLY)
+    @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION, scope = AuditLogScope.SUCCESS)
+    public ResponseEntity get200SuccessOnly() {
+        return ResponseEntity.ok(BODY_RESPONSE);
+    }
+
     @GetMapping(GET_400_ANNOTATION)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION)
@@ -113,6 +133,18 @@ public class AuditLogTestApp {
     @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION)
     public ResponseEntity get400ResponseEntity() {
         return ResponseEntity.badRequest().body(BODY_RESPONSE_400);
+    }
+
+    @GetMapping(GET_400_ERROR_ONLY)
+    @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION, scope = AuditLogScope.ERROR)
+    public ResponseEntity get400ErrorOnly() {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
+    }
+
+    @GetMapping(GET_400_SUCCESS_ONLY)
+    @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION, scope = AuditLogScope.SUCCESS)
+    public ResponseEntity get400SuccessOnly() {
+        throw new ResponseStatusException(HttpStatus.BAD_REQUEST);
     }
 
     @GetMapping(GET_401)


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
In some cases, complex audit logs are generated manually. In those case, the `@GenerateAuditLog` annotation is not used. As a consequence, negative events are not handled. 

A way to handle negative audit logs even in case of manually generated audit logs must be implemented.

Backport of #612

**What is the chosen solution to this problem?**
Add a `scope` argument to `@GenerateAuditLog` annotation indicating if audit logs must be generated for :

- **ALL** cases
- **SUCCESS** cases only
- **ERROR** cases only

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-14487
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
