### PR TITLE
TPSVC-14487: Parse request in case of negative audit logs

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -86,6 +86,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -36,7 +36,7 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(this.auditLogGeneratorInterceptor(null));
+        registry.addInterceptor(this.auditLogGeneratorInterceptor(null, null));
     }
 
     private Properties getProperties(AuditKafkaProperties auditKafkaProperties, String applicationName) {
@@ -87,7 +87,7 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public AuditLogGeneratorInterceptor auditLogGeneratorInterceptor(AuditLogSender auditLogSender) {
-        return new AuditLogGeneratorInterceptor(auditLogSender);
+    public AuditLogGeneratorInterceptor auditLogGeneratorInterceptor(AuditLogSender auditLogSender, ObjectMapper objectMapper) {
+        return new AuditLogGeneratorInterceptor(auditLogSender, objectMapper);
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
@@ -3,12 +3,16 @@ package org.talend.daikon.spring.audit.logs.service;
 import static org.talend.daikon.spring.audit.logs.api.AuditLogScope.*;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
@@ -29,8 +34,11 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
 
     private final AuditLogSender auditLogSender;
 
-    public AuditLogGeneratorInterceptor(AuditLogSender auditLogSender) {
+    private final ObjectMapper objectMapper;
+
+    public AuditLogGeneratorInterceptor(AuditLogSender auditLogSender, ObjectMapper objectMapper) {
         this.auditLogSender = auditLogSender;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -50,11 +58,13 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
                 responseCode = HttpStatus.UNAUTHORIZED.value();
             }
             // Read request & response content from cached http request & response
-            String requestBody = Optional.ofNullable(request).map(this::extractContent).orElse(null);
-            String responseBody = Optional.ofNullable(response).map(this::extractContent).orElse(null);
+            String requestBodyString = Optional.ofNullable(request).map(this::extractContent).orElse(null);
+            Object requestBody = Optional.of(handler).map(HandlerMethod.class::cast).map(HandlerMethod::getMethod)
+                    .map(this::extractRequestType).map(t -> this.parse(requestBodyString, t)).orElse(null);
+            String responseBodyString = Optional.ofNullable(response).map(this::extractContent).orElse(null);
             // Only log if code is not successful
             if (!HttpStatus.valueOf(responseCode).is2xxSuccessful()) {
-                this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBody, generateAuditLog.get());
+                this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBodyString, generateAuditLog.get());
             }
         } else {
             super.afterCompletion(request, response, handler, ex);
@@ -77,5 +87,21 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
             }
         }
         return stringContent.isEmpty() ? null : stringContent;
+    }
+
+    private Class extractRequestType(Method method) {
+        return Arrays.stream(method.getParameters()).filter(p -> p.getAnnotation(RequestBody.class) != null).findFirst()
+                .map(Parameter::getType).orElse(null);
+    }
+
+    private Object parse(String str, Class type) {
+        if (str != null && type != null && !type.isAssignableFrom(str.getClass())) {
+            try {
+                return objectMapper.readValue(str, type);
+            } catch (Exception e) {
+                return str;
+            }
+        }
+        return str;
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -5,10 +5,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.stream.IntStream;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
@@ -199,13 +201,18 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testPost200Filtered() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_200_FILTERED).content("Any content"))
-                .andExpect(status().isOk());
+        AuditLogTestApp.RequestObject request = new AuditLogTestApp.RequestObject("val1", "val2");
+
+        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_200_FILTERED) //
+                .content(objectMapper.writeValueAsString(request)) //
+                .contentType(APPLICATION_JSON) //
+                .accept(APPLICATION_JSON) //
+        ).andExpect(status().isOk());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.POST_200_FILTERED, HttpMethod.POST,
-                AuditLogTestApp.FILTERED_BODY_REQUEST));
-        verifyContext(httpResponseContextCheck(HttpStatus.OK, AuditLogTestApp.FILTERED_BODY_RESPONSE));
+                objectMapper.writeValueAsString(request.setUnsafeProp(null))));
+        verifyContext(httpResponseContextCheck(HttpStatus.OK, objectMapper.writeValueAsString(request.setUnsafeProp(null))));
     }
 
     @Test
@@ -228,6 +235,23 @@ public class AuditLogTest {
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.POST_500, HttpMethod.POST, content));
+        verifyContext(httpResponseContextCheck(HttpStatus.INTERNAL_SERVER_ERROR, null));
+    }
+
+    @Test
+    @WithUserDetails
+    public void testPost500Filtered() throws Exception {
+        AuditLogTestApp.RequestObject request = new AuditLogTestApp.RequestObject("val1", "val2");
+
+        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_500_FILTERED) //
+                .content(objectMapper.writeValueAsString(request)) //
+                .contentType(APPLICATION_JSON) //
+                .accept(APPLICATION_JSON) //
+        ).andExpect(status().isInternalServerError());
+
+        verifyContext(basicContextCheck());
+        verifyContext(httpRequestContextCheck(AuditLogTestApp.POST_500_FILTERED, HttpMethod.POST,
+                objectMapper.writeValueAsString(request.setUnsafeProp(null))));
         verifyContext(httpResponseContextCheck(HttpStatus.INTERNAL_SERVER_ERROR, null));
     }
 
@@ -258,7 +282,8 @@ public class AuditLogTest {
                 containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.METHOD.getId(), method)), //
                 AuditLogFieldEnum.REQUEST, //
                 body == null ? not(containsString(String.format("\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId())))
-                        : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId(), body)) };
+                        : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId(),
+                                StringEscapeUtils.escapeJson(body))) };
     }
 
     private Object[] httpResponseContextCheck(HttpStatus status, String body) {
@@ -266,7 +291,8 @@ public class AuditLogTest {
                 containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_CODE.getId(), status.value())), //
                 AuditLogFieldEnum.RESPONSE, //
                 body == null ? not(containsString(String.format("\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId())))
-                        : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId(), body)), //
+                        : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId(),
+                                StringEscapeUtils.escapeJson(body))), //
         };
     }
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
In case of negative events, request body is retrieved by the interceptor as `String` value.

In some cases, a filter is used in order to hide some fields of request body. Most of the time, the filters expect an `Object` and not a `String`.

In order to let the filters filtering requests even in case of negative events, `String` request must be parsed before being added to the context.
 
**What is the chosen solution to this problem?**
- Retrieve `@RequestBody` annotation and corresponding parameter type if possible
- Try to parse `String` request into the retrieved type
- If parsing fails, use the `String` format
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-14487
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
