### PR TITLE
TPSVC-14487: Negative events not capture when manually generating audit logs

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorAspect.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorAspect.java
@@ -71,8 +71,7 @@ public class AuditLogGeneratorAspect {
             }
 
             // Send logs only in case of success or if responseCode can't be defined
-            if (responseCode == 0 || HttpStatus.valueOf(responseCode).is2xxSuccessful()
-                    || HttpStatus.valueOf(responseCode).is3xxRedirection()) {
+            if (responseCode == 0 || !HttpStatus.valueOf(responseCode).isError()) {
                 // Finally send the audit log
                 auditLogSender.sendAuditLog(request, extractRequestBody(proceedingJoinPoint), responseCode,
                         auditLogResponseObject, auditLogAnnotation);

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorAspect.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorAspect.java
@@ -71,7 +71,8 @@ public class AuditLogGeneratorAspect {
             }
 
             // Send logs only in case of success or if responseCode can't be defined
-            if (responseCode == 0 || HttpStatus.valueOf(responseCode).is2xxSuccessful()) {
+            if (responseCode == 0 || HttpStatus.valueOf(responseCode).is2xxSuccessful()
+                    || HttpStatus.valueOf(responseCode).is3xxRedirection()) {
                 // Finally send the audit log
                 auditLogSender.sendAuditLog(request, extractRequestBody(proceedingJoinPoint), responseCode,
                         auditLogResponseObject, auditLogAnnotation);

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
@@ -63,7 +63,7 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
                     .map(this::extractRequestType).map(t -> this.parse(requestBodyString, t)).orElse(null);
             String responseBodyString = Optional.ofNullable(response).map(this::extractContent).orElse(null);
             // Only log if code is not successful
-            if (!HttpStatus.valueOf(responseCode).is2xxSuccessful()) {
+            if (!HttpStatus.valueOf(responseCode).is2xxSuccessful() && !HttpStatus.valueOf(responseCode).is3xxRedirection()) {
                 this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBodyString, generateAuditLog.get());
             }
         } else {

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
@@ -63,7 +63,7 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
                     .map(this::extractRequestType).map(t -> this.parse(requestBodyString, t)).orElse(null);
             String responseBodyString = Optional.ofNullable(response).map(this::extractContent).orElse(null);
             // Only log if code is not successful
-            if (!HttpStatus.valueOf(responseCode).is2xxSuccessful() && !HttpStatus.valueOf(responseCode).is3xxRedirection()) {
+            if (HttpStatus.valueOf(responseCode).isError()) {
                 this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBodyString, generateAuditLog.get());
             }
         } else {

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -217,6 +217,16 @@ public class AuditLogTest {
 
     @Test
     @WithUserDetails
+    public void testGet302SuccessOnly() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_302_SUCCESS_ONLY)).andExpect(status().isFound());
+
+        verifyContext(basicContextCheck());
+        verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_302_SUCCESS_ONLY, HttpMethod.GET, null));
+        verifyContext(httpResponseContextCheck(HttpStatus.FOUND, null));
+    }
+
+    @Test
+    @WithUserDetails
     public void testPost204() throws Exception {
         final String content = "myContent";
         mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_204).content(content)).andExpect(status().isNoContent());

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTestApp.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTestApp.java
@@ -1,5 +1,6 @@
 package org.talend.daikon.spring.audit.logs.api;
 
+import java.net.URI;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -48,6 +49,8 @@ public class AuditLogTestApp {
     public static final String GET_200_ERROR_ONLY = "/get/200/error";
 
     public static final String GET_200_SUCCESS_ONLY = "/get/200/success";
+
+    public static final String GET_302_SUCCESS_ONLY = "/get/302/success";
 
     public static final String GET_400_ANNOTATION = "/get/400/annotation";
 
@@ -151,6 +154,12 @@ public class AuditLogTestApp {
     @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION, scope = AuditLogScope.SUCCESS)
     public ResponseEntity get200SuccessOnly() {
         return ResponseEntity.ok(BODY_RESPONSE);
+    }
+
+    @GetMapping(GET_302_SUCCESS_ONLY)
+    @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION, scope = AuditLogScope.SUCCESS)
+    public ResponseEntity get302SuccessOnly() {
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(GET_200_SUCCESS_ONLY)).build();
     }
 
     @GetMapping(GET_400_ANNOTATION)


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
In some cases (login flow), HTTP requests return `3xx REDIRECTION` codes. These responses must generate audit logs as well as `2xx SUCCESSFUL` codes

**What is the chosen solution to this problem?**

Consider `3xx REDIRECTION` http code as successful and generate corresponding audit logs in the Aspect.

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
