### PR TITLE
feat(TDP-8780): Update ZipkinKafkaSenderConfiguration bean definition

### DIFF
--- a/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/ZipkinKafkaSenderConfiguration.java
+++ b/daikon-spring/daikon-spring-zipkin/src/main/java/org/talend/daikon/zipkin/ZipkinKafkaSenderConfiguration.java
@@ -1,21 +1,23 @@
 package org.talend.daikon.zipkin;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.sleuth.zipkin2.ZipkinAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
+import zipkin2.Span;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.Reporter;
 import zipkin2.reporter.Sender;
 import zipkin2.reporter.kafka.KafkaSender;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Configures the zipkin kafka sender for another kafka broker than the functional broker.
@@ -31,8 +33,12 @@ public class ZipkinKafkaSenderConfiguration {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZipkinKafkaSenderConfiguration.class);
 
-    @Bean
-    @ConditionalOnMissingBean
+    @Bean(ZipkinAutoConfiguration.REPORTER_BEAN_NAME)
+    public Reporter<Span> myReporter(Sender kafkaSender) {
+        return AsyncReporter.create(kafkaSender);
+    }
+
+    @Bean(ZipkinAutoConfiguration.SENDER_BEAN_NAME)
     public Sender kafkaSender(ZipkinKafkaProperties zipkinKafkaProperties, KafkaProperties kafkaProperties) {
         String bootstrapServers = zipkinKafkaProperties.getBootstrapServers();
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Override the auto-configuration of Zipkin
 
**What is the chosen solution to this problem?**
Following the [Spring documentation](https://cloud.spring.io/spring-cloud-sleuth/2.1.x/single/spring-cloud-sleuth.html#_overriding_the_auto_configuration_of_zipkin), update the kafkaSender bean name and define a Reporter bean.

More info: 
https://github.com/spring-cloud/spring-cloud-sleuth/blob/2.1.x/spring-cloud-sleuth-zipkin/src/main/java/org/springframework/cloud/sleuth/zipkin2/sender/ZipkinKafkaSenderConfiguration.java#L39
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDP-8780 

**Fix wanted in the Daikon 2.0.x version**
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
