### PR TITLE
TPSVC-14487: Negative events not capture when manually generating audit logs (backport)

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -86,6 +86,12 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -36,7 +36,7 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
-        registry.addInterceptor(this.auditLogGeneratorInterceptor(null));
+        registry.addInterceptor(this.auditLogGeneratorInterceptor(null, null));
     }
 
     private Properties getProperties(AuditKafkaProperties auditKafkaProperties, String applicationName) {
@@ -87,7 +87,7 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public AuditLogGeneratorInterceptor auditLogGeneratorInterceptor(AuditLogSender auditLogSender) {
-        return new AuditLogGeneratorInterceptor(auditLogSender);
+    public AuditLogGeneratorInterceptor auditLogGeneratorInterceptor(AuditLogSender auditLogSender, ObjectMapper objectMapper) {
+        return new AuditLogGeneratorInterceptor(auditLogSender, objectMapper);
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorAspect.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorAspect.java
@@ -71,7 +71,7 @@ public class AuditLogGeneratorAspect {
             }
 
             // Send logs only in case of success or if responseCode can't be defined
-            if (responseCode == 0 || HttpStatus.valueOf(responseCode).is2xxSuccessful()) {
+            if (responseCode == 0 || !HttpStatus.valueOf(responseCode).isError()) {
                 // Finally send the audit log
                 auditLogSender.sendAuditLog(request, extractRequestBody(proceedingJoinPoint), responseCode,
                         auditLogResponseObject, auditLogAnnotation);

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
@@ -63,7 +63,7 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
                     .map(this::extractRequestType).map(t -> this.parse(requestBodyString, t)).orElse(null);
             String responseBodyString = Optional.ofNullable(response).map(this::extractContent).orElse(null);
             // Only log if code is not successful
-            if (!HttpStatus.valueOf(responseCode).is2xxSuccessful()) {
+            if (HttpStatus.valueOf(responseCode).isError()) {
                 this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBodyString, generateAuditLog.get());
             }
         } else {

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
@@ -3,12 +3,16 @@ package org.talend.daikon.spring.audit.logs.service;
 import static org.talend.daikon.spring.audit.logs.api.AuditLogScope.*;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Optional;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -16,6 +20,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
@@ -29,8 +34,11 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
 
     private final AuditLogSender auditLogSender;
 
-    public AuditLogGeneratorInterceptor(AuditLogSender auditLogSender) {
+    private final ObjectMapper objectMapper;
+
+    public AuditLogGeneratorInterceptor(AuditLogSender auditLogSender, ObjectMapper objectMapper) {
         this.auditLogSender = auditLogSender;
+        this.objectMapper = objectMapper;
     }
 
     @Override
@@ -50,11 +58,13 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
                 responseCode = HttpStatus.UNAUTHORIZED.value();
             }
             // Read request & response content from cached http request & response
-            String requestBody = Optional.ofNullable(request).map(this::extractContent).orElse(null);
-            String responseBody = Optional.ofNullable(response).map(this::extractContent).orElse(null);
+            String requestBodyString = Optional.ofNullable(request).map(this::extractContent).orElse(null);
+            Object requestBody = Optional.of(handler).map(HandlerMethod.class::cast).map(HandlerMethod::getMethod)
+                    .map(this::extractRequestType).map(t -> this.parse(requestBodyString, t)).orElse(null);
+            String responseBodyString = Optional.ofNullable(response).map(this::extractContent).orElse(null);
             // Only log if code is not successful
             if (!HttpStatus.valueOf(responseCode).is2xxSuccessful()) {
-                this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBody, generateAuditLog.get());
+                this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBodyString, generateAuditLog.get());
             }
         } else {
             super.afterCompletion(request, response, handler, ex);
@@ -77,5 +87,21 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
             }
         }
         return stringContent.isEmpty() ? null : stringContent;
+    }
+
+    private Class extractRequestType(Method method) {
+        return Arrays.stream(method.getParameters()).filter(p -> p.getAnnotation(RequestBody.class) != null).findFirst()
+                .map(Parameter::getType).orElse(null);
+    }
+
+    private Object parse(String str, Class type) {
+        if (str != null && type != null && !type.isAssignableFrom(str.getClass())) {
+            try {
+                return objectMapper.readValue(str, type);
+            } catch (Exception e) {
+                return str;
+            }
+        }
+        return str;
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -217,6 +217,16 @@ public class AuditLogTest {
 
     @Test
     @WithUserDetails
+    public void testGet302SuccessOnly() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_302_SUCCESS_ONLY)).andExpect(status().isFound());
+
+        verifyContext(basicContextCheck());
+        verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_302_SUCCESS_ONLY, HttpMethod.GET, null));
+        verifyContext(httpResponseContextCheck(HttpStatus.FOUND, null));
+    }
+
+    @Test
+    @WithUserDetails
     public void testPost204() throws Exception {
         final String content = "myContent";
         mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_204).content(content)).andExpect(status().isNoContent());

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -5,10 +5,12 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.Mockito.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.stream.IntStream;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
@@ -199,13 +201,18 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testPost200Filtered() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_200_FILTERED).content("Any content"))
-                .andExpect(status().isOk());
+        AuditLogTestApp.RequestObject request = new AuditLogTestApp.RequestObject("val1", "val2");
+
+        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_200_FILTERED) //
+                .content(objectMapper.writeValueAsString(request)) //
+                .contentType(APPLICATION_JSON) //
+                .accept(APPLICATION_JSON) //
+        ).andExpect(status().isOk());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.POST_200_FILTERED, HttpMethod.POST,
-                AuditLogTestApp.FILTERED_BODY_REQUEST));
-        verifyContext(httpResponseContextCheck(HttpStatus.OK, AuditLogTestApp.FILTERED_BODY_RESPONSE));
+                objectMapper.writeValueAsString(request.setUnsafeProp(null))));
+        verifyContext(httpResponseContextCheck(HttpStatus.OK, objectMapper.writeValueAsString(request.setUnsafeProp(null))));
     }
 
     @Test
@@ -228,6 +235,23 @@ public class AuditLogTest {
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.POST_500, HttpMethod.POST, content));
+        verifyContext(httpResponseContextCheck(HttpStatus.INTERNAL_SERVER_ERROR, null));
+    }
+
+    @Test
+    @WithUserDetails
+    public void testPost500Filtered() throws Exception {
+        AuditLogTestApp.RequestObject request = new AuditLogTestApp.RequestObject("val1", "val2");
+
+        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_500_FILTERED) //
+                .content(objectMapper.writeValueAsString(request)) //
+                .contentType(APPLICATION_JSON) //
+                .accept(APPLICATION_JSON) //
+        ).andExpect(status().isInternalServerError());
+
+        verifyContext(basicContextCheck());
+        verifyContext(httpRequestContextCheck(AuditLogTestApp.POST_500_FILTERED, HttpMethod.POST,
+                objectMapper.writeValueAsString(request.setUnsafeProp(null))));
         verifyContext(httpResponseContextCheck(HttpStatus.INTERNAL_SERVER_ERROR, null));
     }
 
@@ -258,7 +282,8 @@ public class AuditLogTest {
                 containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.METHOD.getId(), method)), //
                 AuditLogFieldEnum.REQUEST, //
                 body == null ? not(containsString(String.format("\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId())))
-                        : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId(), body)) };
+                        : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.REQUEST_BODY.getId(),
+                                StringEscapeUtils.escapeJson(body))) };
     }
 
     private Object[] httpResponseContextCheck(HttpStatus status, String body) {
@@ -266,7 +291,8 @@ public class AuditLogTest {
                 containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_CODE.getId(), status.value())), //
                 AuditLogFieldEnum.RESPONSE, //
                 body == null ? not(containsString(String.format("\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId())))
-                        : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId(), body)), //
+                        : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId(),
+                                StringEscapeUtils.escapeJson(body))), //
         };
     }
 

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTestApp.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTestApp.java
@@ -1,5 +1,6 @@
 package org.talend.daikon.spring.audit.logs.api;
 
+import java.net.URI;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -48,6 +49,8 @@ public class AuditLogTestApp {
     public static final String GET_200_ERROR_ONLY = "/get/200/error";
 
     public static final String GET_200_SUCCESS_ONLY = "/get/200/success";
+
+    public static final String GET_302_SUCCESS_ONLY = "/get/302/success";
 
     public static final String GET_400_ANNOTATION = "/get/400/annotation";
 
@@ -151,6 +154,12 @@ public class AuditLogTestApp {
     @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION, scope = AuditLogScope.SUCCESS)
     public ResponseEntity get200SuccessOnly() {
         return ResponseEntity.ok(BODY_RESPONSE);
+    }
+
+    @GetMapping(GET_302_SUCCESS_ONLY)
+    @GenerateAuditLog(application = APPLICATION, eventType = EVENT_TYPE, eventCategory = EVENT_CATEGORY, eventOperation = EVENT_OPERATION, scope = AuditLogScope.SUCCESS)
+    public ResponseEntity get302SuccessOnly() {
+        return ResponseEntity.status(HttpStatus.FOUND).location(URI.create(GET_200_SUCCESS_ONLY)).build();
     }
 
     @GetMapping(GET_400_ANNOTATION)


### PR DESCRIPTION
Backport of #614 & #615 about [TPSVC-14487: Negative events not capture when manually generating audit logs](https://jira.talendforge.org/browse/TPSVC-14487).