### PR TITLE
fix: set the S3 bucket as a URL path for MINIO configuration

### DIFF
--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ContentServiceConfiguration.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ContentServiceConfiguration.java
@@ -79,7 +79,7 @@ public class S3ContentServiceConfiguration {
             if (!environment.containsProperty(S3_ENDPOINT_URL)) {
                 throw new InvalidConfiguration("Missing '" + S3_ENDPOINT_URL + "' configuration");
             }
-            builder = AmazonS3ClientBuilder.standard();
+            builder = builder.withPathStyleAccessEnabled(true);
             break;
         case CUSTOM_AUTHENTICATION:
             try {

--- a/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3ContentServiceConfigurationTest.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3ContentServiceConfigurationTest.java
@@ -37,14 +37,14 @@ public class S3ContentServiceConfigurationTest {
 
         when(environment.getProperty(eq("content-service.store.s3.authentication"), anyString())).thenReturn("MINIO");
         when(environment.containsProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn(true);
-        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn("http://fake.io");
+        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn("http://fake.io:9001");
 
         // when
         final AmazonS3 amazonS3 = configuration.amazonS3(environment, context);
 
         // then
         final String fileUrl = amazonS3.getUrl("mybucket", "file.csv").toString();
-        assertEquals("http://mybucket.fake.io/file.csv", fileUrl);
+        assertEquals("http://fake.io:9001/mybucket/file.csv", fileUrl);
     }
 
     @Test


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

S3 bucket is set a sub domain instead of path when the minio authentication is set
 
**What is the chosen solution to this problem?**

Configure the client to use path-style access for request instead of virtual-hosted-style
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
