### PR TITLE
feat(s3) S3 configuration improvement

### DIFF
--- a/daikon-spring/daikon-content-service/s3-content-service/README.md
+++ b/daikon-spring/daikon-content-service/s3-content-service/README.md
@@ -38,6 +38,16 @@ public class MyComponent {
 
 ## Additional S3 configuration
 
+### Specify bucket name using path or host style
+
+You can configure S3 client to use "path style" for bucket name instead of host using the `content-service.store.s3.enable_path_style` property. Its default value differs from the authentication mode you use:
+
+| Authentication mode | Use path style as default? |
+|---------------------|----------------------------|
+| EC2                 | no                         |
+| TOKEN               | no                         |
+| MINIO               | yes                        |
+
 ### S3 client creation
 By default, AWS S3 client will authenticate using running EC2 instance credentials. Default behavior is same as:
 

--- a/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3ContentServiceConfigurationTest.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3ContentServiceConfigurationTest.java
@@ -1,6 +1,7 @@
 package org.talend.daikon.content.s3;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -38,6 +39,7 @@ public class S3ContentServiceConfigurationTest {
         when(environment.getProperty(eq("content-service.store.s3.authentication"), anyString())).thenReturn("MINIO");
         when(environment.containsProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn(true);
         when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn("http://fake.io:9001");
+        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENABLE_PATH_STYLE), eq(Boolean.class), any())).thenReturn(true);
 
         // when
         final AmazonS3 amazonS3 = configuration.amazonS3(environment, context);
@@ -56,6 +58,7 @@ public class S3ContentServiceConfigurationTest {
         when(environment.getProperty(eq("content-service.store.s3.authentication"), anyString())).thenReturn("TOKEN");
         when(environment.getProperty("content-service.store.s3.secretKey")).thenReturn("verySecret");
         when(environment.getProperty("content-service.store.s3.accessKey")).thenReturn("anAccessKey");
+        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENABLE_PATH_STYLE), eq(Boolean.class), any())).thenReturn(false);
 
         // when
         configuration.amazonS3(environment, context);


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

Path is enabled by default for Minio access yet it remains impossible:
* To disable path style access for Minio
* To enable/disable path style access for other modes.

**What is the chosen solution to this problem?**
 
Introduce a new property to configure behavior without impacting current default behaviors.


**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
