### PR TITLE
TPSVC-15007: Extract public remote ip(s) from x-forwarded-for header

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/README.adoc
+++ b/daikon-spring/daikon-spring-audit-logs/README.adoc
@@ -58,18 +58,29 @@ A call to the `createResource` method will generate and send the following audit
 
 ```json
 {
-    "timestamp": "2020-04-07T13:26:09.741821Z",
-    "requestId": "009a511a-a71e-4b6c-8e0b-822a90c71e43",
-    "logId": "6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
-    "applicationId": "daikon",
-    "eventType": "security",
-    "eventCategory": "resource",
-    "eventOperation": "create",
-    "clientIp": "10.80.48.155",
-    "request": "{\"url\":\"http://app.url/resource\",\"method\":\"POST\",\"user_agent\":\"{USER_AGENT}\",\"body\":\"{REQUEST_BODY}\"}",
-    "response": "{\"code\":\"200\",\"body\":\"{REQUEST_BODY}\"}"
+   "timestamp":"2020-04-07T13:26:09.741821Z",
+   "requestId":"009a511a-a71e-4b6c-8e0b-822a90c71e43",
+   "logId":"6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
+   "accountId":"81fd11b5-d0c2-479d-833c-85d67f79edd0",
+   "userId":"84dc9524-b9b6-4533-a849-606feba86720",
+   "username":"1510_3_int@trial01775.us.talend.com",
+   "email":"1510_3_int@yopmail.com",
+   "applicationId":"daikon",
+   "eventType":"security",
+   "eventCategory":"resource",
+   "eventOperation":"create",
+   "clientIp":"62.80.48.155",
+   "request":{
+      "url":"http://app.url/resource",
+      "method":"POST",
+      "user_agent":"{USER_AGENT}",
+      "body":"{REQUEST_BODY}"
+   },
+   "response":{
+      "code":"200",
+      "body":"{REQUEST_BODY}"
+   }
 }
-
 ```
 
 It is possible to choose to include or not the body response in the generated log with the `includeBodyResponse` annotation parameter.
@@ -116,22 +127,29 @@ Will generate an audit log enhanced with user information :
 
 ```json
 {
-    "timestamp": "2020-04-07T13:26:09.741821Z",
-    "requestId": "009a511a-a71e-4b6c-8e0b-822a90c71e43",
-    "logId": "6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
-    "accountId": "81fd11b5-d0c2-479d-833c-85d67f79edd0",
-    "userId": "84dc9524-b9b6-4533-a849-606feba86720",
-    "username": "1510_3_int@trial01775.us.talend.com",
-    "email": "1510_3_int@yopmail.com",
-    "applicationId": "daikon",
-    "eventType": "security",
-    "eventCategory": "resource",
-    "eventOperation": "create",
-    "clientIp": "10.80.48.155",
-    "request": "{\"url\":\"http://app.url/resource\",\"method\":\"POST\",\"user_agent\":\"{USER_AGENT}\",\"body\":\"{REQUEST_BODY}\"}",
-    "response": "{\"code\":\"200\",\"body\":\"{REQUEST_BODY}\"}"
+   "timestamp":"2020-04-07T13:26:09.741821Z",
+   "requestId":"009a511a-a71e-4b6c-8e0b-822a90c71e43",
+   "logId":"6bfbc27c-654a-41c2-a241-1cbe0e69c1c6",
+   "accountId":"account1",
+   "userId":"user1",
+   "username":"ejarvis",
+   "email":"edwin.jarvis@talend.com",
+   "applicationId":"daikon",
+   "eventType":"security",
+   "eventCategory":"resource",
+   "eventOperation":"create",
+   "clientIp":"62.80.48.155",
+   "request":{
+      "url":"http://app.url/resource",
+      "method":"POST",
+      "user_agent":"{USER_AGENT}",
+      "body":"{REQUEST_BODY}"
+   },
+   "response":{
+      "code":"200",
+      "body":"{REQUEST_BODY}"
+   }
 }
-
 ```
 
 
@@ -156,4 +174,61 @@ Then the filter must be referenced in the `@GenerateAuditLog` annotation :
 
 ```java
 @GenerateAuditLog([...], filter = MyCustomAuditContextFilter.class)
+```
+
+== IP address
+The IP address(es) is extracted from `x-forwarded-for` header if available.
+If the header is not set, https://docs.oracle.com/javaee/6/api/javax/servlet/ServletRequest.html#getRemoteAddr()[`ServletRequest.getRemoteAddr()`] method is called.
+
+As `x-forwarded-for` header can contain many addresses, including private and public ones,
+only the public addresses are extracted.
+Private internal proxy addresses are extracted with the following pattern (http://tomcat.apache.org/tomcat-9.0-doc/api/org/apache/catalina/valves/RemoteIpValve.html[from Tomcat specifications]) :
+
+```
+10\.\d{1,3}\.\d{1,3}\.\d{1,3}|
+192\.168\.\d{1,3}\.\d{1,3}|
+169\.254\.\d{1,3}\.\d{1,3}|
+127\.\d{1,3}\.\d{1,3}\.\d{1,3}|
+172\.1[6-9]{1}\.\d{1,3}\.\d{1,3}|
+172\.2[0-9]{1}\.\d{1,3}\.\d{1,3}|
+172\.3[0-1]{1}\.\d{1,3}\.\d{1,3}|
+0:0:0:0:0:0:0:1|::1
+```
+
+=== Unique public IP
+
+For example, a request with the following `x-forwarded-for` header value :
+
+```
+x-forwarded-header: "62.23.50.122, 10.12.15.26, 172.169.12.54"
+```
+
+Will generate an audit log with the following ip :
+
+```json
+{
+   "...": "...",
+   "clientIp":"62.23.50.122",
+   "...": "..."
+}
+```
+
+The private internal addresses `10.12.15.26` and `172.169.12.54` are filtered.
+
+=== Multiple public IPs
+
+In some cases (ip forgery attempt, public proxy, ...), the `x-forwarded-for` can contains several public ips :
+
+```
+x-forwarded-header: "51.51.51.51, 62.23.50.122, 10.12.15.26, 172.169.12.54"
+```
+
+In this case, the generated audit log will contains all the public ips :
+
+```json
+{
+   "...": "...",
+   "clientIp":"51.51.51.51, 62.23.50.122",
+   "...": "..."
+}
 ```

--- a/daikon-spring/daikon-spring-audit-logs/README.adoc
+++ b/daikon-spring/daikon-spring-audit-logs/README.adoc
@@ -36,6 +36,7 @@ Then the module must be enabled and configured with Kafka information :
 ```yaml
 audit:
     enabled: true # Enable audit feature
+    trusted-proxies: 42.42.42.42 # Regular expression matching trusted proxy ips (these ips won't appear in audit logs)
     kafka:
         bootstrapServers: localhost:9092 # Kafka bootstrap server urls for audit logs sending
         topic: audit-logs # Kafka topic for audit logs sending
@@ -195,6 +196,8 @@ Private internal proxy addresses are extracted with the following pattern (http:
 0:0:0:0:0:0:0:1|::1
 ```
 
+In addition, the `audit.trusted-proxies` property can be defined in order to filter extra trusted ips.
+
 === Unique public IP
 
 For example, a request with the following `x-forwarded-for` header value :
@@ -229,6 +232,29 @@ In this case, the generated audit log will contains all the public ips :
 {
    "...": "...",
    "clientIp":"51.51.51.51, 62.23.50.122",
+   "...": "..."
+}
+```
+
+=== Trusted IP
+
+Public IPs can be filtered from `x-forwarded-for` header by specifying a matching regex pattern in the `audit.trusted-proxies` property :
+
+```yaml
+audit:
+   trusted-proxies: 42.42.42.42
+```
+
+The IPs from `x-forwarded-for` header matching the trusted proxies pattern won't appear in the generated audit logs :
+
+```
+x-forwarded-header: "62.23.50.122, 42.42.42.42, 10.12.15.26, 172.169.12.54"
+```
+
+```json
+{
+   "...": "...",
+   "clientIp":"62.23.50.122",
    "...": "..."
 }
 ```

--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -54,6 +54,11 @@
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
         </dependency>
+        <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>1.6</version>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 
 @Configuration
 @EnableAspectJAutoProxy(proxyTargetClass = true)
-@EnableConfigurationProperties(AuditKafkaProperties.class)
+@EnableConfigurationProperties({ AuditProperties.class, AuditKafkaProperties.class })
 @ConditionalOnProperty(value = "audit.enabled", havingValue = "true", matchIfMissing = true)
 public class AuditLogAutoConfiguration implements WebMvcConfigurer {
 
@@ -75,10 +75,10 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    public AuditLogSender auditLogSender(ObjectMapper objectMapper, Optional<AuditUserProvider> auditUserProvider,
-            AuditLoggerBase auditLoggerBase) {
+    public AuditLogSender auditLogSender(Optional<AuditUserProvider> auditUserProvider, AuditLoggerBase auditLoggerBase,
+            AuditLogIpExtractor AuditLogIpExtractor) {
         AuditLogger auditLogger = AuditLoggerFactory.getEventAuditLogger(AuditLogger.class, auditLoggerBase);
-        return new AuditLogSenderImpl(objectMapper, auditUserProvider.orElse(new NoOpAuditUserProvider()), auditLogger);
+        return new AuditLogSenderImpl(auditUserProvider.orElse(new NoOpAuditUserProvider()), auditLogger, AuditLogIpExtractor);
     }
 
     @Bean
@@ -89,5 +89,10 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
     @Bean
     public AuditLogGeneratorInterceptor auditLogGeneratorInterceptor(AuditLogSender auditLogSender, ObjectMapper objectMapper) {
         return new AuditLogGeneratorInterceptor(auditLogSender, objectMapper);
+    }
+
+    @Bean
+    public AuditLogIpExtractor auditLogIpExtractor(AuditProperties auditProperties) {
+        return new AuditLogIpExtractorImpl(auditProperties);
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditProperties.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditProperties.java
@@ -1,0 +1,18 @@
+package org.talend.daikon.spring.audit.logs.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "audit")
+public class AuditProperties {
+
+    private String trustedProxies;
+
+    public String getTrustedProxies() {
+        return trustedProxies;
+    }
+
+    public AuditProperties setTrustedProxies(String trustedProxies) {
+        this.trustedProxies = trustedProxies;
+        return this;
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilder.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilder.java
@@ -133,12 +133,12 @@ public class AuditLogContextBuilder {
 
     public Context build() throws AuditLogException {
         try {
+            // Compute request fields only at build step to leverage ip extractor
+            computeRequestFields();
+
             context.values().removeAll(Collections.singletonList(null));
             request.values().removeAll(Collections.singletonList(null));
             response.values().removeAll(Collections.singletonList(null));
-
-            // Compute request fields only at build step to leverage ip extractor
-            computeRequestFields();
 
             if (!request.isEmpty()) {
                 request.replaceAll((k, v) -> convertToString(v));

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogIpExtractor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogIpExtractor.java
@@ -1,0 +1,8 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface AuditLogIpExtractor {
+
+    String extract(HttpServletRequest servletRequest);
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogIpExtractorImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogIpExtractorImpl.java
@@ -1,0 +1,53 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.apache.commons.validator.routines.InetAddressValidator;
+import org.talend.daikon.spring.audit.logs.config.AuditProperties;
+
+public class AuditLogIpExtractorImpl implements AuditLogIpExtractor {
+
+    private static final String INTERNAL_PROXIES = "" + //
+            "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" + //
+            "192\\.168\\.\\d{1,3}\\.\\d{1,3}|" + //
+            "169\\.254\\.\\d{1,3}\\.\\d{1,3}|" + //
+            "127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|" + //
+            "172\\.1[6-9]{1}\\.\\d{1,3}\\.\\d{1,3}|" + //
+            "172\\.2[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|" + //
+            "172\\.3[0-1]{1}\\.\\d{1,3}\\.\\d{1,3}|" + //
+            "0:0:0:0:0:0:0:1|::1"; //
+
+    private static final Pattern INTERNAL_PROXIES_PATTERN = Pattern.compile(INTERNAL_PROXIES);
+
+    private static final String REMOTE_IP_HEADER = "X-Forwarded-For";
+
+    private String trustedProxies;
+
+    // This pattern matches nothing
+    private Pattern trustedProxiesPattern = Pattern.compile("a^");
+
+    public AuditLogIpExtractorImpl(AuditProperties auditProperties) {
+        this.trustedProxies = auditProperties.getTrustedProxies();
+        if (this.trustedProxies != null) {
+            trustedProxiesPattern = Pattern.compile(trustedProxies);
+        }
+    }
+
+    public String extract(HttpServletRequest request) {
+        return Arrays.stream(Optional.ofNullable(request.getHeader(REMOTE_IP_HEADER)).orElse(request.getRemoteAddr()).split(",")) //
+                .map(String::trim)
+                // Validate Ip format
+                .filter(ip -> InetAddressValidator.getInstance().isValid(ip))
+                // Do not keep ips matching internal proxy ips
+                .filter(ip -> !INTERNAL_PROXIES_PATTERN.matcher(ip).matches())
+                // Do not keep ips matching trusted proxy pattern
+                .filter(ip -> !trustedProxiesPattern.matcher(ip).matches()) //
+                .distinct() //
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSender.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSender.java
@@ -19,6 +19,13 @@ public interface AuditLogSender {
     void sendAuditLog(Context context);
 
     /**
+     * Build a context from a context builder and send the generated context
+     *
+     * @param builder audit log context builder
+     */
+    void sendAuditLog(AuditLogContextBuilder builder);
+
+    /**
      * Build a context from given parameters and send the corresponding audit log
      *
      * @param request HTTP request

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -51,6 +51,16 @@ import ch.qos.logback.core.read.ListAppender;
 @Import(AuditLogTestConfig.class)
 public class AuditLogTest {
 
+    private static final String REMOTE_IP_HEADER = "X-Forwarded-For";
+
+    private static final String MY_IP = "35.74.154.242";
+
+    private static final String MY_IP_WITH_INTERNAL_PROXIES = "35.74.154.242, 10.72.5.245, 10.80.17.172";
+
+    private static final String MY_IP_WITH_FORGERY_ATTEMPT = "51.51.51.51, 35.74.154.242";
+
+    private static final String MY_IP_WITH_FORGERY_ATTEMPT_AND_INTERNAL_PROXIES = "51.51.51.51, 35.74.154.242, 10.72.5.245, 10.80.17.172";
+
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -76,7 +86,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet400Exception() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_EXCEPTION)).andExpect(status().isBadRequest());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_EXCEPTION).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isBadRequest());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_400_EXCEPTION, HttpMethod.GET, null));
@@ -86,7 +97,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet400Annotation() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_ANNOTATION)).andExpect(status().isBadRequest());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_ANNOTATION).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isBadRequest());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_400_ANNOTATION, HttpMethod.GET, null));
@@ -96,8 +108,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet400ResponseEntity() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_RESPONSE_ENTITY)).andExpect(status().isBadRequest())
-                .andExpect(content().string(AuditLogTestApp.BODY_RESPONSE_400)).andReturn();
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_RESPONSE_ENTITY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isBadRequest()).andExpect(content().string(AuditLogTestApp.BODY_RESPONSE_400)).andReturn();
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_400_RESPONSE_ENTITY, HttpMethod.GET, null));
@@ -107,7 +119,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet400ErrorOnly() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_ERROR_ONLY)).andExpect(status().isBadRequest());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_ERROR_ONLY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isBadRequest());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_400_ERROR_ONLY, HttpMethod.GET, null));
@@ -117,7 +130,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet400SuccessOnly() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_SUCCESS_ONLY)).andExpect(status().isBadRequest());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_400_SUCCESS_ONLY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isBadRequest());
 
         verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
     }
@@ -125,7 +139,8 @@ public class AuditLogTest {
     @Test
     @WithAnonymousUser
     public void testGet401() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_401)).andExpect(status().isUnauthorized());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_401).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isUnauthorized());
 
         verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
         assertThat(logListAppender.list.get(0).getLevel(), is(Level.ERROR));
@@ -134,7 +149,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet403() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_403)).andExpect(status().isForbidden());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_403).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isForbidden());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_403, HttpMethod.GET, null));
@@ -144,7 +160,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet404() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_404)).andExpect(status().isNotFound());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_404).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isNotFound());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_404, HttpMethod.GET, null));
@@ -154,7 +171,8 @@ public class AuditLogTest {
     @Test
     @WithAnonymousUser
     public void testGet200Anonymous() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY)).andExpect(status().isOk());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isOk());
 
         verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
         assertThat(logListAppender.list.get(0).getLevel(), is(Level.ERROR));
@@ -163,7 +181,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet200Body() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY)).andExpect(status().isOk());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isOk());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_200_WITH_BODY, HttpMethod.GET, null));
@@ -173,7 +192,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet200NoBody() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITHOUT_BODY)).andExpect(status().isOk());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITHOUT_BODY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isOk());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_200_WITHOUT_BODY, HttpMethod.GET, null));
@@ -183,7 +203,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet200ErrorOnly() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_ERROR_ONLY)).andExpect(status().isOk());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_ERROR_ONLY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isOk());
 
         verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
     }
@@ -191,7 +212,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet200SuccessOnly() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_SUCCESS_ONLY)).andExpect(status().isOk());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_SUCCESS_ONLY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isOk());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_200_SUCCESS_ONLY, HttpMethod.GET, null));
@@ -200,10 +222,45 @@ public class AuditLogTest {
 
     @Test
     @WithUserDetails
+    public void testGet200InternalProxies() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY).header(REMOTE_IP_HEADER,
+                MY_IP_WITH_INTERNAL_PROXIES)).andExpect(status().isOk());
+
+        verifyContext(basicContextCheck());
+        verifyContext(AuditLogFieldEnum.CLIENT_IP, is(MY_IP));
+    }
+
+    @Test
+    @WithUserDetails
+    public void testGet200ForgeryAttempt() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY).header(REMOTE_IP_HEADER,
+                MY_IP_WITH_FORGERY_ATTEMPT_AND_INTERNAL_PROXIES)).andExpect(status().isOk());
+
+        verifyContext(basicContextCheck());
+        verifyContext(AuditLogFieldEnum.CLIENT_IP, is(MY_IP_WITH_FORGERY_ATTEMPT));
+    }
+
+    @Test
+    @WithUserDetails
+    public void testGet200EmptyXForwardedForHeader() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders //
+                .get(AuditLogTestApp.GET_200_WITH_BODY) //
+                .with(req -> {
+                    req.setRemoteAddr(MY_IP);
+                    return req;
+                })).andExpect(status().isOk());
+
+        verifyContext(basicContextCheck());
+        verifyContext(AuditLogFieldEnum.CLIENT_IP, is(MY_IP));
+    }
+
+    @Test
+    @WithUserDetails
     public void testPost200Filtered() throws Exception {
         AuditLogTestApp.RequestObject request = new AuditLogTestApp.RequestObject("val1", "val2");
 
         mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_200_FILTERED) //
+                .header(REMOTE_IP_HEADER, MY_IP) //
                 .content(objectMapper.writeValueAsString(request)) //
                 .contentType(APPLICATION_JSON) //
                 .accept(APPLICATION_JSON) //
@@ -218,7 +275,8 @@ public class AuditLogTest {
     @Test
     @WithUserDetails
     public void testGet302SuccessOnly() throws Exception {
-        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_302_SUCCESS_ONLY)).andExpect(status().isFound());
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_302_SUCCESS_ONLY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isFound());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.GET_302_SUCCESS_ONLY, HttpMethod.GET, null));
@@ -229,7 +287,8 @@ public class AuditLogTest {
     @WithUserDetails
     public void testPost204() throws Exception {
         final String content = "myContent";
-        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_204).content(content)).andExpect(status().isNoContent());
+        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_204).header(REMOTE_IP_HEADER, MY_IP).content(content))
+                .andExpect(status().isNoContent());
 
         verifyContext(basicContextCheck());
         verifyContext(httpRequestContextCheck(AuditLogTestApp.POST_204, HttpMethod.POST, content));
@@ -240,7 +299,7 @@ public class AuditLogTest {
     @WithUserDetails
     public void testPost500() throws Exception {
         final String content = "myContent";
-        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_500).content(content))
+        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_500).header(REMOTE_IP_HEADER, MY_IP).content(content))
                 .andExpect(status().isInternalServerError());
 
         verifyContext(basicContextCheck());
@@ -253,7 +312,7 @@ public class AuditLogTest {
     public void testPost500Filtered() throws Exception {
         AuditLogTestApp.RequestObject request = new AuditLogTestApp.RequestObject("val1", "val2");
 
-        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_500_FILTERED) //
+        mockMvc.perform(MockMvcRequestBuilders.post(AuditLogTestApp.POST_500_FILTERED).header(REMOTE_IP_HEADER, MY_IP) //
                 .content(objectMapper.writeValueAsString(request)) //
                 .contentType(APPLICATION_JSON) //
                 .accept(APPLICATION_JSON) //
@@ -281,7 +340,7 @@ public class AuditLogTest {
                 AuditLogFieldEnum.EVENT_TYPE, is(AuditLogTestApp.EVENT_TYPE), //
                 AuditLogFieldEnum.EVENT_CATEGORY, is(AuditLogTestApp.EVENT_CATEGORY), //
                 AuditLogFieldEnum.EVENT_OPERATION, is(AuditLogTestApp.EVENT_OPERATION), //
-                AuditLogFieldEnum.CLIENT_IP, is("127.0.0.1") //
+                AuditLogFieldEnum.CLIENT_IP, containsString(MY_IP) //
         };
     }
 

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -68,7 +68,7 @@ public class AuditLogTest {
 
     private static final String MY_IP_WITH_INTERNAL_PROXIES_AND_TRUSTED_PROXIES = "35.74.154.242, 42.42.42.42, 10.72.5.245, 10.80.17.172";
 
-    private static final String MY_IP_WITH_FORGERY_ATTEMPT = "51.51.51.51, 35.74.154.242";
+    private static final String MY_IP_WITH_FORGERY_ATTEMPT = "35.74.154.242, 51.51.51.51";
 
     private static final String MY_IP_WITH_FORGERY_ATTEMPT_AND_INTERNAL_PROXIES = "51.51.51.51, 35.74.154.242, 10.72.5.245, 10.80.17.172";
 

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -70,7 +70,7 @@ public class AuditLogTest {
 
     private static final String MY_IP_WITH_FORGERY_ATTEMPT = "35.74.154.242, 51.51.51.51";
 
-    private static final String MY_IP_WITH_FORGERY_ATTEMPT_AND_INTERNAL_PROXIES = "51.51.51.51, 35.74.154.242, 10.72.5.245, 10.80.17.172";
+    private static final String MY_IP_WITH_FORGERY_ATTEMPT_AND_INTERNAL_PROXIES = "35.74.154.242, 51.51.51.51, 10.72.5.245, 10.80.17.172";
 
     @Autowired
     private ObjectMapper objectMapper;


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
In the scope of [TPSVC-14747](https://jira.talendforge.org/browse/TPSVC-14747) is has been decided to not let services handling `x-forwarded-for` header by themselves.

For that purpose, the following property is defined for the TPSVC services :
`server.use-forward-headers: false`

As a consequence, retrieving the remote id address from the request using `request.getRemoteAddr()` is no more relevant.
 
**What is the chosen solution to this problem?**

The solution is to extract the public ip from the `x-forwarded-for` header.
In order to prevent forgery attempts, all public ips are retrieved.

In order to deal with WAF, a new property `audit.trusted-proxies` is added. 
Trusted public IPs are filtered based on that pattern.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-15007
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
