### PR TITLE
fix(TDKN-293): Fix number comparison when using "="

### DIFF
--- a/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
+++ b/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
@@ -484,6 +484,18 @@ public class BeanPredicateVisitorTest {
         assertFalse(predicate.test(bean));
     }
 
+    @Test
+    public void testDoubleIntComparison() {
+        // given
+        final Expression query = Tql.parse("int = 10.0");
+
+        // when
+        final Predicate<Bean> predicate = query.accept(new BeanPredicateVisitor<>(Bean.class));
+
+        // then
+        assertTrue(predicate.test(bean));
+    }
+
     // Test class
     public static class Bean {
 

--- a/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
+++ b/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
@@ -496,6 +496,18 @@ public class BeanPredicateVisitorTest {
         assertTrue(predicate.test(bean));
     }
 
+    @Test
+    public void testIntComparison() {
+        // given
+        final Expression query = Tql.parse("int = 10");
+
+        // when
+        final Predicate<Bean> predicate = query.accept(new BeanPredicateVisitor<>(Bean.class));
+
+        // then
+        assertTrue(predicate.test(bean));
+    }
+
     // Test class
     public static class Bean {
 


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

When using "=" operator with BeanPredicateVisitor, comparison is performed on string equals. This cause `field = 10` and `field = 10.0` to be differently interpreted.
 
**What is the chosen solution to this problem?**

* Fix BeanPredicateVisitor predicate creation when using "=" with a numeric value.
* Add unit test for issue.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-293
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
