### PR TITLE
TPSVC-15007: [AUDIT LOGS] Extract IPs from x-forwarded-for header & filter WAF IPs (backport)

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogIpExtractorImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogIpExtractorImpl.java
@@ -39,15 +39,19 @@ public class AuditLogIpExtractorImpl implements AuditLogIpExtractor {
     }
 
     public String extract(HttpServletRequest request) {
-        return Arrays.stream(Optional.ofNullable(request.getHeader(REMOTE_IP_HEADER)).orElse(request.getRemoteAddr()).split(",")) //
-                .map(String::trim)
-                // Validate Ip format
-                .filter(ip -> InetAddressValidator.getInstance().isValid(ip))
-                // Do not keep ips matching internal proxy ips
-                .filter(ip -> !INTERNAL_PROXIES_PATTERN.matcher(ip).matches())
-                // Do not keep ips matching trusted proxy pattern
-                .filter(ip -> !trustedProxiesPattern.matcher(ip).matches()) //
-                .distinct() //
-                .collect(Collectors.joining(", "));
+        String ips = request.getRemoteAddr();
+        if (request.getHeader(REMOTE_IP_HEADER) != null) {
+            ips = Arrays.stream(request.getHeader(REMOTE_IP_HEADER).split(",")) //
+                    .map(String::trim)
+                    // Validate Ip format
+                    .filter(ip -> InetAddressValidator.getInstance().isValid(ip))
+                    // Do not keep ips matching internal proxy ips
+                    .filter(ip -> !INTERNAL_PROXIES_PATTERN.matcher(ip).matches())
+                    // Do not keep ips matching trusted proxy pattern
+                    .filter(ip -> !trustedProxiesPattern.matcher(ip).matches()) //
+                    .distinct() //
+                    .collect(Collectors.joining(", "));
+        }
+        return ips;
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
In some cases, `x-forwarded-for` header is missing and ip address retrieved from `HttpServletRequest.getRemoteAddr()` is an internal address (dev cluster, local, ...). In these cases the audit log is not generated and an error is thrown because ip address is missing (because filtered out).
 
**What is the chosen solution to this problem?**
Filter out internal/trusted ip addresses only when ip addresses come from `x-forwarded-for` header.
Otherwise, retrieve unfiltered remote addr.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-15007
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
