### PR TITLE
TPSVC-15007: Use remote addr if ip extracted from x-forwarded-for header is empty (backport)

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogIpExtractorImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogIpExtractorImpl.java
@@ -1,7 +1,6 @@
 package org.talend.daikon.spring.audit.logs.service;
 
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
@@ -39,7 +38,7 @@ public class AuditLogIpExtractorImpl implements AuditLogIpExtractor {
     }
 
     public String extract(HttpServletRequest request) {
-        String ips = request.getRemoteAddr();
+        String ips = "";
         if (request.getHeader(REMOTE_IP_HEADER) != null) {
             ips = Arrays.stream(request.getHeader(REMOTE_IP_HEADER).split(",")) //
                     .map(String::trim)
@@ -52,6 +51,6 @@ public class AuditLogIpExtractorImpl implements AuditLogIpExtractor {
                     .distinct() //
                     .collect(Collectors.joining(", "));
         }
-        return ips;
+        return ips.isEmpty() ? request.getRemoteAddr() : ips;
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
On the dev cluster, calling public ingress, we have these ips : 

- **Remote addr :** 10.223.64.69
- **x-forwarded-for header :** 10.223.38.137

In this case, during audit log generation, the ip is extracted from `x-forwarded-header`. 
The ip `10.223.38.137` is then filtered out as it is an internal ip. 
As a consequence, because ip field is mandatory for audit logs, an error is thrown and the audit log can't be generated.

**What is the chosen solution to this problem?**
Try to extract and filter the ips from `x-forwarded-for` header and use normal remote ip if result is empty.
 
Backport of #633

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
