### PR TITLE
feat(TDKN-294) Add support for time monitoring for content service

### DIFF
--- a/daikon-spring/daikon-content-service/README.md
+++ b/daikon-spring/daikon-content-service/README.md
@@ -15,6 +15,11 @@ This module contains the source files for a generic content service with multipl
 | [local-content-service](local-content-service)     | *Adds local file system capabilities*    |
 | [s3-content-service](s3-content-service)           | *Adds S3 file system capabilities*       |
 
+## Integration with existing monitoring
+Implementations of content service uses `@Timed` to track time spent in operations.
+
+Make sure to include `daikon-spring-metrics` in your dependencies to integrate with Spring Boot Actuator and tracing system.
+
 ## Usage
 
 To use local file system, see [local-content-service](local-content-service) for configuration.

--- a/daikon-spring/daikon-content-service/content-service-common/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-common/pom.xml
@@ -14,6 +14,10 @@
             <artifactId>daikon</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/daikon-spring/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/AbstractResourceResolver.java
+++ b/daikon-spring/daikon-content-service/content-service-common/src/main/java/org/talend/daikon/content/AbstractResourceResolver.java
@@ -4,6 +4,7 @@ import static java.util.Arrays.stream;
 
 import java.io.IOException;
 
+import io.micrometer.core.annotation.Timed;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.WritableResource;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -16,6 +17,7 @@ public abstract class AbstractResourceResolver implements ResourceResolver {
         this.delegate = delegate;
     }
 
+    @Timed
     @Override
     public DeletableResource[] getResources(String locationPattern) throws IOException {
         final Resource[] resources = delegate.getResources(locationPattern);
@@ -24,6 +26,7 @@ public abstract class AbstractResourceResolver implements ResourceResolver {
                 .toArray(DeletableResource[]::new);
     }
 
+    @Timed
     @Override
     public DeletableResource getResource(String location) {
         return convert((WritableResource) delegate.getResource(location));

--- a/daikon-spring/daikon-content-service/content-service-journal-mongo/src/main/java/org/talend/daikon/content/journal/MongoResourceJournalResolver.java
+++ b/daikon-spring/daikon-content-service/content-service-journal-mongo/src/main/java/org/talend/daikon/content/journal/MongoResourceJournalResolver.java
@@ -3,6 +3,7 @@ package org.talend.daikon.content.journal;
 import java.io.IOException;
 import java.util.stream.Stream;
 
+import io.micrometer.core.annotation.Timed;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,7 @@ public class MongoResourceJournalResolver implements ResourceJournal {
      */
     private ResourceResolver resourceResolver;
 
+    @Timed
     @Override
     public void sync() {
         if (ready()) {
@@ -100,6 +102,7 @@ public class MongoResourceJournalResolver implements ResourceJournal {
         return locationPrefix;
     }
 
+    @Timed
     @Override
     public Stream<String> matches(String pattern) {
         LOGGER.debug("Match locations using pattern '{}'", pattern);
@@ -111,6 +114,7 @@ public class MongoResourceJournalResolver implements ResourceJournal {
         return repository.findByNameStartsWith(patternForMatch).stream().map(ResourceJournalEntry::getName);
     }
 
+    @Timed
     @Override
     public void clear(String pattern) {
         String patternForClear = formattingStringToMongoPattern(removePrefixFromResourceName(pattern));
@@ -118,6 +122,7 @@ public class MongoResourceJournalResolver implements ResourceJournal {
         LOGGER.debug("Cleared location '{}'.", patternForClear);
     }
 
+    @Timed
     @Override
     public void add(String location) {
         if (StringUtils.isEmpty(location)) {
@@ -130,12 +135,14 @@ public class MongoResourceJournalResolver implements ResourceJournal {
         LOGGER.debug("Location '{}' added to journal.", savedLocation);
     }
 
+    @Timed
     @Override
     public void remove(String location) {
         repository.deleteByName(removePrefixFromResourceName(location));
         LOGGER.debug("Location '{}' removed from journal.", location);
     }
 
+    @Timed
     @Override
     public void move(String source, String target) {
         String sourceWithoutPrefix = removePrefixFromResourceName(source);
@@ -153,6 +160,7 @@ public class MongoResourceJournalResolver implements ResourceJournal {
         }
     }
 
+    @Timed
     @Override
     public boolean exist(String location) {
         String savedLocation = updateLocationToAbsolutePath(removePrefixFromResourceName(location));

--- a/daikon-spring/daikon-content-service/content-service-journal/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-journal/pom.xml
@@ -14,7 +14,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -48,5 +51,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
+
     </dependencies>
 </project>

--- a/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedDeletableResource.java
+++ b/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedDeletableResource.java
@@ -50,7 +50,7 @@ class JournalizedDeletableResource implements DeletableResource {
 
     @Override
     public boolean exists() {
-        return resource.exists();
+        return true;
     }
 
     @Override

--- a/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedDeletableResource.java
+++ b/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedDeletableResource.java
@@ -50,7 +50,7 @@ class JournalizedDeletableResource implements DeletableResource {
 
     @Override
     public boolean exists() {
-        return true;
+        return resource.exists();
     }
 
     @Override

--- a/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedResourceResolver.java
+++ b/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedResourceResolver.java
@@ -1,5 +1,6 @@
 package org.talend.daikon.content.journal;
 
+import io.micrometer.core.annotation.Timed;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.daikon.content.DeletableResource;
@@ -25,6 +26,7 @@ public class JournalizedResourceResolver implements ResourceResolver {
         this.resourceJournal = resourceJournal;
     }
 
+    @Timed
     @Override
     public DeletableResource[] getResources(String locationPattern) throws IOException {
         if (resourceJournal.ready()) {
@@ -36,6 +38,7 @@ public class JournalizedResourceResolver implements ResourceResolver {
         }
     }
 
+    @Timed
     @Override
     public DeletableResource getResource(String location) {
         final DeletableResource resource = delegate.getResource(location);
@@ -48,6 +51,7 @@ public class JournalizedResourceResolver implements ResourceResolver {
         return delegate.getLocationPrefix();
     }
 
+    @Timed
     @Override
     public void clear(String location) throws IOException {
         Stream.of(getResources(location)).forEach(deletableResource -> {

--- a/daikon-spring/daikon-content-service/s3-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/s3-content-service/pom.xml
@@ -13,6 +13,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.talend.daikon</groupId>

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -5,6 +5,7 @@ import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
 
 import java.io.IOException;
 
+import io.micrometer.core.annotation.Timed;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.io.WritableResource;
 import org.springframework.core.io.support.ResourcePatternResolver;
@@ -26,6 +27,7 @@ class S3ResourceResolver extends AbstractResourceResolver {
         this.bucket = bucket;
     }
 
+    @Timed
     @Override
     public DeletableResource[] getResources(String locationPattern) throws IOException {
         final String location = builder(bucket.getBucketName()) //
@@ -35,6 +37,7 @@ class S3ResourceResolver extends AbstractResourceResolver {
         return super.getResources("s3://" + location);
     }
 
+    @Timed
     @Override
     public DeletableResource getResource(String location) {
         if (location == null) {

--- a/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3ContentServiceConfigurationTest.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3ContentServiceConfigurationTest.java
@@ -39,7 +39,8 @@ public class S3ContentServiceConfigurationTest {
         when(environment.getProperty(eq("content-service.store.s3.authentication"), anyString())).thenReturn("MINIO");
         when(environment.containsProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn(true);
         when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn("http://fake.io:9001");
-        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENABLE_PATH_STYLE), eq(Boolean.class), any())).thenReturn(true);
+        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENABLE_PATH_STYLE), eq(Boolean.class), any()))
+                .thenReturn(true);
 
         // when
         final AmazonS3 amazonS3 = configuration.amazonS3(environment, context);
@@ -58,7 +59,8 @@ public class S3ContentServiceConfigurationTest {
         when(environment.getProperty(eq("content-service.store.s3.authentication"), anyString())).thenReturn("TOKEN");
         when(environment.getProperty("content-service.store.s3.secretKey")).thenReturn("verySecret");
         when(environment.getProperty("content-service.store.s3.accessKey")).thenReturn("anAccessKey");
-        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENABLE_PATH_STYLE), eq(Boolean.class), any())).thenReturn(false);
+        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENABLE_PATH_STYLE), eq(Boolean.class), any()))
+                .thenReturn(false);
 
         // when
         configuration.amazonS3(environment, context);

--- a/daikon-spring/daikon-spring-metrics/src/main/java/org/talend/daikon/spring/metrics/config/MetricsConfiguration.java
+++ b/daikon-spring/daikon-spring-metrics/src/main/java/org/talend/daikon/spring/metrics/config/MetricsConfiguration.java
@@ -1,6 +1,7 @@
 package org.talend.daikon.spring.metrics.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 public class MetricsConfiguration {
 
     @Bean
+    @ConditionalOnBean({ Tracer.class, MeterRegistry.class })
     public Aspects metricAspect(@Autowired Tracer tracer, @Autowired MeterRegistry repository) {
         return new Aspects(tracer, repository);
     }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
To provide better production issue insights, it would be nice to have a way to track time spent in ResourceResolver methods. 

**What is the chosen solution to this problem?**
 
* Leverage aspects provided by daikon-spring-metrics
* Mark resource resolver methods as time monitored (see daikon-spring-metrics).

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-294
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
