### PR TITLE
chore(journal): Performance improvement for content journal

### DIFF
--- a/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedResourceResolver.java
+++ b/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedResourceResolver.java
@@ -31,7 +31,7 @@ public class JournalizedResourceResolver implements ResourceResolver {
     public DeletableResource[] getResources(String locationPattern) throws IOException {
         if (resourceJournal.ready()) {
             return resourceJournal.matches(locationPattern) //
-                    .map(this::getResource) //
+                    .map(location -> new LazyDeletableResource(location, this)) //
                     .toArray(DeletableResource[]::new);
         } else {
             return delegate.getResources(locationPattern);

--- a/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedResourceResolver.java
+++ b/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/JournalizedResourceResolver.java
@@ -34,6 +34,7 @@ public class JournalizedResourceResolver implements ResourceResolver {
                     .map(location -> new LazyDeletableResource(location, this)) //
                     .toArray(DeletableResource[]::new);
         } else {
+            LOGGER.warn("Journal is not ready (delegate call to non-indexed resolver to find '{}')", locationPattern);
             return delegate.getResources(locationPattern);
         }
     }

--- a/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/LazyDeletableResource.java
+++ b/daikon-spring/daikon-content-service/content-service-journal/src/main/java/org/talend/daikon/content/journal/LazyDeletableResource.java
@@ -1,0 +1,149 @@
+package org.talend.daikon.content.journal;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import org.springframework.core.io.Resource;
+import org.springframework.lang.Nullable;
+import org.talend.daikon.content.DeletableResource;
+import org.talend.daikon.content.ResourceResolver;
+
+/**
+ * <p>
+ * An implementation of {@link DeletableResource} that do not perform any lookup information on external systems to be
+ * created.
+ * </p>
+ * <p>
+ * When information from actual {@link DeletableResource} is required a call to {@link #materialize()} is performed to
+ * retrieve information from {@link ResourceResolver}.
+ * </p>
+ * 
+ * @see ResourceResolver#getResource(String)
+ */
+class LazyDeletableResource implements DeletableResource {
+
+    private final String location;
+
+    private final ResourceResolver resourceResolver;
+
+    private DeletableResource resource;
+
+    public LazyDeletableResource(String location, ResourceResolver resourceResolver) {
+        this.location = location;
+        this.resourceResolver = resourceResolver;
+    }
+
+    private synchronized DeletableResource materialize() {
+        if (resource == null) {
+            resource = resourceResolver.getResource(location);
+        }
+        return resource;
+    }
+
+    @Override
+    @Nullable
+    public String getFilename() {
+        return location;
+    }
+
+    @Override
+    public void delete() throws IOException {
+        materialize().delete();
+    }
+
+    @Override
+    public void move(String location) throws IOException {
+        materialize().move(location);
+    }
+
+    @Override
+    public String getAbsolutePath() throws IOException {
+        return materialize().getAbsolutePath();
+    }
+
+    @Override
+    public boolean isWritable() {
+        return materialize().isWritable();
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return materialize().getOutputStream();
+    }
+
+    @Override
+    public WritableByteChannel writableChannel() throws IOException {
+        return materialize().writableChannel();
+    }
+
+    @Override
+    public boolean exists() {
+        return materialize().exists();
+    }
+
+    @Override
+    public boolean isReadable() {
+        return materialize().isReadable();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return materialize().isOpen();
+    }
+
+    @Override
+    public boolean isFile() {
+        return materialize().isFile();
+    }
+
+    @Override
+    public URL getURL() throws IOException {
+        return materialize().getURL();
+    }
+
+    @Override
+    public URI getURI() throws IOException {
+        return materialize().getURI();
+    }
+
+    @Override
+    public File getFile() throws IOException {
+        return materialize().getFile();
+    }
+
+    @Override
+    public ReadableByteChannel readableChannel() throws IOException {
+        return materialize().readableChannel();
+    }
+
+    @Override
+    public long contentLength() throws IOException {
+        return materialize().contentLength();
+    }
+
+    @Override
+    public long lastModified() throws IOException {
+        return materialize().lastModified();
+    }
+
+    @Override
+    public Resource createRelative(String relativePath) throws IOException {
+        return materialize().createRelative(relativePath);
+    }
+
+    @Override
+    public String getDescription() {
+        return materialize().getDescription();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return materialize().getInputStream();
+    }
+}

--- a/daikon-spring/daikon-content-service/content-service-journal/src/test/java/org/talend/daikon/content/journal/JournalizedResourceResolverTest.java
+++ b/daikon-spring/daikon-content-service/content-service-journal/src/test/java/org/talend/daikon/content/journal/JournalizedResourceResolverTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -96,5 +97,18 @@ public class JournalizedResourceResolverTest {
         verify(delegate, times(1)).getResource(eq("resource1.txt"));
         verify(delegate, times(1)).getResource(eq("resource2.txt"));
         verify(delegate, times(2)).getResource(anyString());
+    }
+
+    @Test
+    public void shouldBypassGetResources() throws IOException {
+        // given
+        when(delegate.getResource(eq("resource1.txt"))).thenReturn(mock(DeletableResource.class));
+
+        // when
+        journalizedResourceResolver.getResources("resource1.txt");
+
+        // then
+        verify(delegate, times(1)).getResource(eq("resource1.txt"));
+        verify(resourceJournal, never()).matches(anyString());
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

When using getResources on a journalized content service, each returned result causes a save operation in the journal. Even if each save operation doesn't last long, this cause 2 issues:

* It's a useless save (it's about writing an information that has just been read).
* When returning a lot of resources, this adds an overhead. 
 
**What is the chosen solution to this problem?**
 
* Prevent useless journal save calls during resource list
* Add unit tests to ensure expected behavior

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
