### PR TITLE
fix(content-service) Fix getUrl/getUri when using custom authentication mode

### DIFF
--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/FixedURLS3Resource.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/FixedURLS3Resource.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
@@ -41,11 +40,6 @@ public class FixedURLS3Resource implements DeletableResource {
     @Override
     public void move(String location) throws IOException {
         delegate.move(location);
-    }
-
-    @Override
-    public String getAbsolutePath() throws IOException {
-        return delegate.getAbsolutePath();
     }
 
     @Override

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/FixedURLS3Resource.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/FixedURLS3Resource.java
@@ -85,15 +85,19 @@ public class FixedURLS3Resource implements DeletableResource {
 
     @Override
     public URL getURL() throws IOException {
-        return new URL("https", host, s3Location);
+        if (s3Location.startsWith("/")) {
+            return new URL(host + s3Location);
+        } else {
+            return new URL(host + "/" + s3Location);
+        }
     }
 
     @Override
-    public URI getURI() throws IOException {
-        try {
-            return new URI("https", host, s3Location);
-        } catch (URISyntaxException e) {
-            throw new IOException("Unable to build URI", e);
+    public URI getURI() {
+        if (s3Location.startsWith("/")) {
+            return URI.create(host + s3Location);
+        } else {
+            return URI.create(host + "/" + s3Location);
         }
     }
 

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/FixedURLS3Resource.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/FixedURLS3Resource.java
@@ -1,0 +1,140 @@
+package org.talend.daikon.content.s3;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+
+import org.springframework.core.io.Resource;
+import org.springframework.lang.Nullable;
+import org.talend.daikon.content.DeletableResource;
+
+/**
+ * A {@link DeletableResource} implementation that can contains fixed information about host name and bucket path for
+ * a S3 resource. Useful for Minio/Custom resources that rely on AWS client (allow to workaround missing AWS
+ * information).
+ */
+public class FixedURLS3Resource implements DeletableResource {
+
+    private final String host;
+
+    private final String s3Location;
+
+    private final DeletableResource delegate;
+
+    public FixedURLS3Resource(String host, String s3Location, DeletableResource delegate) {
+        this.host = host;
+        this.s3Location = s3Location;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void delete() throws IOException {
+        delegate.delete();
+    }
+
+    @Override
+    public void move(String location) throws IOException {
+        delegate.move(location);
+    }
+
+    @Override
+    public String getAbsolutePath() throws IOException {
+        return delegate.getAbsolutePath();
+    }
+
+    @Override
+    public boolean isWritable() {
+        return delegate.isWritable();
+    }
+
+    @Override
+    public OutputStream getOutputStream() throws IOException {
+        return delegate.getOutputStream();
+    }
+
+    @Override
+    public WritableByteChannel writableChannel() throws IOException {
+        return delegate.writableChannel();
+    }
+
+    @Override
+    public boolean exists() {
+        return delegate.exists();
+    }
+
+    @Override
+    public boolean isReadable() {
+        return delegate.isReadable();
+    }
+
+    @Override
+    public boolean isOpen() {
+        return delegate.isOpen();
+    }
+
+    @Override
+    public boolean isFile() {
+        return delegate.isFile();
+    }
+
+    @Override
+    public URL getURL() throws IOException {
+        return new URL("https", host, s3Location);
+    }
+
+    @Override
+    public URI getURI() throws IOException {
+        try {
+            return new URI("https", host, s3Location);
+        } catch (URISyntaxException e) {
+            throw new IOException("Unable to build URI", e);
+        }
+    }
+
+    @Override
+    public File getFile() throws IOException {
+        return delegate.getFile();
+    }
+
+    @Override
+    public ReadableByteChannel readableChannel() throws IOException {
+        return delegate.readableChannel();
+    }
+
+    @Override
+    public long contentLength() throws IOException {
+        return delegate.contentLength();
+    }
+
+    @Override
+    public long lastModified() throws IOException {
+        return delegate.lastModified();
+    }
+
+    @Override
+    public Resource createRelative(String s) throws IOException {
+        return delegate.createRelative(s);
+    }
+
+    @Override
+    @Nullable
+    public String getFilename() {
+        return delegate.getFilename();
+    }
+
+    @Override
+    public String getDescription() {
+        return delegate.getDescription();
+    }
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return delegate.getInputStream();
+    }
+}

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ContentServiceConfiguration.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ContentServiceConfiguration.java
@@ -34,17 +34,19 @@ public class S3ContentServiceConfiguration {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3ContentServiceConfiguration.class);
 
-    private static final String EC2_AUTHENTICATION = "EC2";
+    public static final String EC2_AUTHENTICATION = "EC2";
 
-    private static final String TOKEN_AUTHENTICATION = "TOKEN";
+    public static final String TOKEN_AUTHENTICATION = "TOKEN";
 
-    private static final String CUSTOM_AUTHENTICATION = "CUSTOM";
+    public static final String CUSTOM_AUTHENTICATION = "CUSTOM";
 
-    private static final String MINIO_AUTHENTICATION = "MINIO";
+    public static final String MINIO_AUTHENTICATION = "MINIO";
 
-    static final String S3_ENDPOINT_URL = "content-service.store.s3.endpoint_url";
+    public static final String S3_ENDPOINT_URL = "content-service.store.s3.endpoint_url";
 
-    static final String S3_ENABLE_PATH_STYLE = "content-service.store.s3.enable_path_style";
+    public static final String S3_ENABLE_PATH_STYLE = "content-service.store.s3.enable_path_style";
+
+    public static final String CONTENT_SERVICE_STORE_AUTHENTICATION = "content-service.store.s3.authentication";
 
     private static AmazonS3ClientBuilder configureEC2Authentication(AmazonS3ClientBuilder builder) {
         LOGGER.info("Using EC2 authentication");
@@ -66,7 +68,7 @@ public class S3ContentServiceConfiguration {
     @Bean
     public AmazonS3 amazonS3(Environment environment, ApplicationContext applicationContext) {
         // Configure authentication
-        final String authentication = environment.getProperty("content-service.store.s3.authentication", EC2_AUTHENTICATION)
+        final String authentication = environment.getProperty(CONTENT_SERVICE_STORE_AUTHENTICATION, EC2_AUTHENTICATION)
                 .toUpperCase();
         AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard();
         switch (authentication) {
@@ -125,7 +127,7 @@ public class S3ContentServiceConfiguration {
         if (isMultiTenancyEnabled(environment)) {
             try {
                 final S3BucketProvider s3BucketProvider = applicationContext.getBean(S3BucketProvider.class);
-                return new S3ResourceResolver(resolver, amazonS3, s3BucketProvider);
+                return new S3ResourceResolver(resolver, amazonS3, s3BucketProvider, environment);
             } catch (NoSuchBeanDefinitionException e) {
                 throw new InvalidConfigurationMissingBean("No S3 bucket name provider in context", S3BucketProvider.class, e);
             }
@@ -143,7 +145,7 @@ public class S3ContentServiceConfiguration {
                     return StringUtils.EMPTY;
                 }
             };
-            return new S3ResourceResolver(resolver, amazonS3, provider);
+            return new S3ResourceResolver(resolver, amazonS3, provider, environment);
         }
     }
 

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -26,8 +26,7 @@ public class S3ResourceResolver extends AbstractResourceResolver {
 
     private final Environment environment;
 
-    S3ResourceResolver(ResourcePatternResolver delegate, AmazonS3 amazonS3, S3BucketProvider bucket,
-            Environment environment) {
+    S3ResourceResolver(ResourcePatternResolver delegate, AmazonS3 amazonS3, S3BucketProvider bucket, Environment environment) {
         super(delegate);
         this.amazonS3 = amazonS3;
         this.bucket = bucket;
@@ -64,12 +63,12 @@ public class S3ResourceResolver extends AbstractResourceResolver {
                 .getProperty(S3ContentServiceConfiguration.CONTENT_SERVICE_STORE_AUTHENTICATION, EC2_AUTHENTICATION)
                 .toUpperCase();
         switch (authentication) {
-            case S3ContentServiceConfiguration.MINIO_AUTHENTICATION:
-            case S3ContentServiceConfiguration.CUSTOM_AUTHENTICATION:
-                final String host = environment.getProperty(S3ContentServiceConfiguration.S3_ENDPOINT_URL);
-                return new FixedURLS3Resource(host, s3Location, super.getResource("s3://" + s3Location));
-            default:
-                return super.getResource("s3://" + s3Location);
+        case S3ContentServiceConfiguration.MINIO_AUTHENTICATION:
+        case S3ContentServiceConfiguration.CUSTOM_AUTHENTICATION:
+            final String host = environment.getProperty(S3ContentServiceConfiguration.S3_ENDPOINT_URL);
+            return new FixedURLS3Resource(host, s3Location, super.getResource("s3://" + s3Location));
+        default:
+            return super.getResource("s3://" + s3Location);
         }
     }
 
@@ -82,7 +81,7 @@ public class S3ResourceResolver extends AbstractResourceResolver {
 
     @Override
     protected DeletableResource convert(WritableResource writableResource) {
-        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(),
-                bucket.getBucketName(), bucket.getRoot());
+        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket.getBucketName(),
+                bucket.getRoot());
     }
 }

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -2,11 +2,12 @@ package org.talend.daikon.content.s3;
 
 import static org.talend.daikon.content.s3.LocationUtils.toS3Location;
 import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
+import static org.talend.daikon.content.s3.S3ContentServiceConfiguration.EC2_AUTHENTICATION;
 
 import java.io.IOException;
 
-import io.micrometer.core.annotation.Timed;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.env.Environment;
 import org.springframework.core.io.WritableResource;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.talend.daikon.content.AbstractResourceResolver;
@@ -15,16 +16,22 @@ import org.talend.daikon.content.s3.provider.S3BucketProvider;
 
 import com.amazonaws.services.s3.AmazonS3;
 
+import io.micrometer.core.annotation.Timed;
+
 public class S3ResourceResolver extends AbstractResourceResolver {
 
     private final AmazonS3 amazonS3;
 
     private final S3BucketProvider bucket;
 
-    S3ResourceResolver(ResourcePatternResolver delegate, AmazonS3 amazonS3, S3BucketProvider bucket) {
+    private final Environment environment;
+
+    S3ResourceResolver(ResourcePatternResolver delegate, AmazonS3 amazonS3, S3BucketProvider bucket,
+            Environment environment) {
         super(delegate);
         this.amazonS3 = amazonS3;
         this.bucket = bucket;
+        this.environment = environment;
     }
 
     @Timed
@@ -52,7 +59,19 @@ public class S3ResourceResolver extends AbstractResourceResolver {
                 .append(bucket.getRoot()) //
                 .append(toS3Location(location)) //
                 .build();
-        return super.getResource("s3://" + s3Location);
+
+        String host = environment.getProperty(S3ContentServiceConfiguration.S3_ENDPOINT_URL);
+        final String authentication = environment
+                .getProperty(S3ContentServiceConfiguration.CONTENT_SERVICE_STORE_AUTHENTICATION, EC2_AUTHENTICATION)
+                .toUpperCase();
+
+        switch (authentication) {
+            case S3ContentServiceConfiguration.MINIO_AUTHENTICATION:
+            case S3ContentServiceConfiguration.CUSTOM_AUTHENTICATION:
+                return new FixedURLS3Resource(host, s3Location, super.getResource("s3://" + s3Location));
+            default:
+                return super.getResource("s3://" + s3Location);
+        }
     }
 
     @Override
@@ -64,7 +83,7 @@ public class S3ResourceResolver extends AbstractResourceResolver {
 
     @Override
     protected DeletableResource convert(WritableResource writableResource) {
-        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket.getBucketName(),
-                bucket.getRoot());
+        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(),
+                bucket.getBucketName(), bucket.getRoot());
     }
 }

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -60,14 +60,13 @@ public class S3ResourceResolver extends AbstractResourceResolver {
                 .append(toS3Location(location)) //
                 .build();
 
-        String host = environment.getProperty(S3ContentServiceConfiguration.S3_ENDPOINT_URL);
         final String authentication = environment
                 .getProperty(S3ContentServiceConfiguration.CONTENT_SERVICE_STORE_AUTHENTICATION, EC2_AUTHENTICATION)
                 .toUpperCase();
-
         switch (authentication) {
             case S3ContentServiceConfiguration.MINIO_AUTHENTICATION:
             case S3ContentServiceConfiguration.CUSTOM_AUTHENTICATION:
+                final String host = environment.getProperty(S3ContentServiceConfiguration.S3_ENDPOINT_URL);
                 return new FixedURLS3Resource(host, s3Location, super.getResource("s3://" + s3Location));
             default:
                 return super.getResource("s3://" + s3Location);

--- a/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/FixedURLS3ResourceTest.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/FixedURLS3ResourceTest.java
@@ -1,0 +1,86 @@
+package org.talend.daikon.content.s3;
+
+import org.junit.Test;
+import org.talend.daikon.content.DeletableResource;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URL;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class FixedURLS3ResourceTest {
+
+    @Test
+    public void shouldHaveFixedUrl() throws IOException {
+        // Given
+        final DeletableResource delegate = mock(DeletableResource.class);
+        FixedURLS3Resource resource = new FixedURLS3Resource("http://fake.io:9001", "mybucket/file.csv", delegate);
+
+        // When
+        final URL url = resource.getURL();
+
+        // Then
+        assertUrl(delegate, url);
+    }
+
+    @Test
+    public void shouldHaveFixedUrlWithLeadingSlash() throws IOException {
+        // Given
+        final DeletableResource delegate = mock(DeletableResource.class);
+        FixedURLS3Resource resource = new FixedURLS3Resource("http://fake.io:9001", "/mybucket/file.csv", delegate);
+
+        // When
+        final URL url = resource.getURL();
+
+        // Then
+        assertUrl(delegate, url);
+    }
+
+    @Test
+    public void shouldHaveFixedUri() throws IOException {
+        // Given
+        final DeletableResource delegate = mock(DeletableResource.class);
+        FixedURLS3Resource resource = new FixedURLS3Resource("http://fake.io:9001", "mybucket/file.csv", delegate);
+
+        // When
+        final URI uri = resource.getURI();
+
+        // Then
+        assertUri(delegate, uri);
+    }
+
+    @Test
+    public void shouldHaveFixedUriWithLeadingSlash() throws IOException {
+        // Given
+        final DeletableResource delegate = mock(DeletableResource.class);
+        FixedURLS3Resource resource = new FixedURLS3Resource("http://fake.io:9001", "/mybucket/file.csv", delegate);
+
+        // When
+        final URI uri = resource.getURI();
+
+        // Then
+        assertUri(delegate, uri);
+    }
+
+    private void assertUrl(DeletableResource delegate, URL url) throws IOException {
+        // Then
+        verify(delegate, never()).getURL();
+        assertEquals("http", url.getProtocol());
+        assertEquals("fake.io", url.getHost());
+        assertEquals(9001, url.getPort());
+        assertEquals("/mybucket/file.csv", url.getPath());
+    }
+
+    private void assertUri(DeletableResource delegate, URI uri) throws IOException {
+        // Then
+        verify(delegate, never()).getURL();
+        assertEquals("http", uri.getScheme());
+        assertEquals("fake.io", uri.getHost());
+        assertEquals(9001, uri.getPort());
+        assertEquals("/mybucket/file.csv", uri.getPath());
+    }
+}

--- a/daikon-spring/daikon-content-service/s3-content-service/src/test/resources/application.properties
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 content-service.store=s3
 content-service.store.s3.authentication=CUSTOM
+content-service.store.s3.endpoint_url=https://fake.io:9001
 multi-tenancy.s3.active=true


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
By default Spring S3 resources rely on AWS client region to build URL/URI. This works fine for a AWS environment but causes issues when using a custom endpoint (Minio case).

**What is the chosen solution to this problem?**

This PR fixes the build of URLs and URIs when using a MINIO/CUSTOM authentication mode in content service.
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
