### PR TITLE
fix(content-service) Ensure both getResource and getResources are fixed

### DIFF
--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/LocationUtils.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/LocationUtils.java
@@ -21,6 +21,9 @@ class LocationUtils {
      * @return The location ready to processed in all the S3 related classes.
      */
     public static String toS3Location(String location) {
+        if (location == null) {
+            return null;
+        }
         if (location.startsWith("/") && location.length() > 1) {
             return location.substring(1);
         } else {

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -27,8 +27,7 @@ public class S3ResourceResolver extends AbstractResourceResolver {
 
     private final Environment environment;
 
-    S3ResourceResolver(ResourcePatternResolver delegate, AmazonS3 amazonS3, S3BucketProvider bucket,
-            Environment environment) {
+    S3ResourceResolver(ResourcePatternResolver delegate, AmazonS3 amazonS3, S3BucketProvider bucket, Environment environment) {
         super(delegate);
         this.amazonS3 = amazonS3;
         this.bucket = bucket;
@@ -44,8 +43,7 @@ public class S3ResourceResolver extends AbstractResourceResolver {
                 .build();
 
         final DeletableResource[] resources = super.getResources("s3://" + cleanedUpLocationPattern);
-        return Stream
-                .of(resources) //
+        return Stream.of(resources) //
                 .map(r -> {
                     final String s3Location = builder(bucket.getBucketName()) //
                             .append(bucket.getRoot()) //
@@ -99,7 +97,7 @@ public class S3ResourceResolver extends AbstractResourceResolver {
 
     @Override
     protected DeletableResource convert(WritableResource writableResource) {
-        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(),
-                bucket.getBucketName(), bucket.getRoot());
+        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket.getBucketName(),
+                bucket.getRoot());
     }
 }

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -46,7 +46,13 @@ public class S3ResourceResolver extends AbstractResourceResolver {
         final DeletableResource[] resources = super.getResources("s3://" + cleanedUpLocationPattern);
         return Stream
                 .of(resources) //
-                .map(r -> wrap(toS3Location(r.getFilename()), r)) //
+                .map(r -> {
+                    final String s3Location = builder(bucket.getBucketName()) //
+                            .append(bucket.getRoot()) //
+                            .append(toS3Location(r.getFilename())) //
+                            .build();
+                    return wrap(s3Location, r);
+                }) //
                 .toArray(DeletableResource[]::new);
     }
 


### PR DESCRIPTION


**What is the problem this Pull Request is trying to solve?**

S3 Resource resolver is able to return DeletableResource instances that works fine with Minio. However when accessing results of getResources, returned results do not benefit from the fix.

**What is the chosen solution to this problem?**
* Group common code between getResource() and getResources() for S3 access
* Fix potential NPE in toS3Location.

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
