### PR TITLE
feat(TPSVC-15266): lower log level for AuditLogException

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -62,9 +62,10 @@ public class AuditLogSenderImpl implements AuditLogSender {
             // Finally send the log
             this.sendAuditLog(auditLogContextBuilder.build());
             LOGGER.info("audit log generated with metadata {}", auditLogAnnotation);
-        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException
-                | AuditLogException e) {
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             LOGGER.error("audit log with metadata {} has not been generated", auditLogAnnotation, e);
+        } catch (AuditLogException e) {
+            LOGGER.debug("audit log with metadata {} has not been generated", auditLogAnnotation, e);
         }
     }
 

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -91,6 +91,7 @@ public class AuditLogTest {
         Logger logger = (Logger) LoggerFactory.getLogger(AuditLogSenderImpl.class);
         logListAppender = new ListAppender<>();
         logListAppender.start();
+        logger.setLevel(Level.DEBUG);
         logger.addAppender(logListAppender);
     }
 
@@ -154,7 +155,7 @@ public class AuditLogTest {
                 .andExpect(status().isUnauthorized());
 
         verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
-        assertThat(logListAppender.list.get(0).getLevel(), is(Level.ERROR));
+        assertThat(logListAppender.list.iterator().next().getLevel(), is(Level.DEBUG));
     }
 
     @Test
@@ -186,7 +187,7 @@ public class AuditLogTest {
                 .andExpect(status().isOk());
 
         verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
-        assertThat(logListAppender.list.get(0).getLevel(), is(Level.ERROR));
+        assertThat(logListAppender.list.iterator().next().getLevel(), is(Level.DEBUG));
     }
 
     @Test


### PR DESCRIPTION
backport https://github.com/Talend/daikon/pull/640
**What is the problem this Pull Request is trying to solve?**
 https://jira.talendforge.org/browse/TPSVC-15266
Kibana logs show us a lot of errors alike
`org.talend.daikon.spring.audit.logs.exception.AuditLogException: UNEXPECTED_EXCEPTION:{message=audit log context is incomplete, missing information: [ACCOUNT_ID]}`
**What is the chosen solution to this problem?**
 During investigation were found that in all cases it is because unauthenticated user tries to access resource
So the solution is to lower log level for this type of exceptions
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
