### PR TITLE
TDKN-295 - DigestSources.sha256 not mixing salt with password

### DIFF
--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/DigestSources.java
@@ -1,5 +1,7 @@
 package org.talend.daikon.crypto.digest;
 
+import java.io.UnsupportedEncodingException;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.talend.daikon.crypto.EncodingUtils;
 import org.talend.daikon.crypto.KeySource;
@@ -21,11 +23,16 @@ public class DigestSources {
             if (salt == null || salt.length == 0) {
                 return EncodingUtils.BASE64_ENCODER.apply(dataDigest);
             } else {
-                final byte[] digestedSalt = DigestUtils.sha256(salt);
-                final byte[] result = new byte[digestedSalt.length + dataDigest.length];
-                System.arraycopy(digestedSalt, 0, result, 0, digestedSalt.length);
-                System.arraycopy(dataDigest, 0, result, digestedSalt.length, dataDigest.length);
-                return EncodingUtils.BASE64_ENCODER.apply(result);
+                try {
+                    final byte[] dataBytes = data.getBytes(EncodingUtils.ENCODING);
+                    final byte[] toDigest = new byte[salt.length + dataBytes.length];
+                    System.arraycopy(salt, 0, toDigest, 0, salt.length);
+                    System.arraycopy(dataBytes, 0, toDigest, salt.length, dataBytes.length);
+                    final byte[] result = DigestUtils.sha256(toDigest);
+                    return EncodingUtils.BASE64_ENCODER.apply(result);
+                } catch (UnsupportedEncodingException e) {
+                    throw new IllegalStateException("Unable to digest value.", e);
+                }
             }
         };
     }

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigestSourcesTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/DigestSourcesTest.java
@@ -1,6 +1,10 @@
 package org.talend.daikon.crypto.digest;
 
+import java.util.Arrays;
+
+import org.apache.commons.codec.digest.DigestUtils;
 import org.junit.Test;
+import org.talend.daikon.crypto.EncodingUtils;
 import org.talend.daikon.crypto.KeySources;
 
 import static org.junit.Assert.*;
@@ -16,7 +20,20 @@ public class DigestSourcesTest {
         final String digest = DigestSources.sha256().digest(data, KeySources.fixedKey("abcd1234").getKey());
 
         // Then
-        assertEquals("6c7nGrky/ehjM40Ivk3p3+OeoEm9r7NCzmWexUULaa7IG36TBiw+3zjgPRtgPlyVMhJAo7BDDZ6176QavT7/Eg==", digest);
+        assertEquals("aUh5A+XLT97dzHBZd5cRV7raB2ZiLNDvjwVlGzdeRlg=", digest);
+    }
+
+    @Test
+    public void digestShouldBe32Bits() throws Exception {
+        // Given
+        final String data = "value to digest";
+
+        // When
+        final String digest = DigestSources.sha256().digest(data, KeySources.fixedKey("abcd1234").getKey());
+
+        // Then
+        byte[] decodedDigest = EncodingUtils.BASE64_DECODER.apply(digest.getBytes(EncodingUtils.ENCODING));
+        assertEquals(32, decodedDigest.length);
     }
 
     @Test
@@ -31,6 +48,21 @@ public class DigestSourcesTest {
         // Then
         assertEquals(digest1, digest2);
         assertEquals("yBt+kwYsPt844D0bYD5clTISQKOwQw2ete+kGr0+/xI=", digest1);
+    }
+
+    @Test
+    public void saltShouldBeUsedWithPasswordDigest() throws Exception {
+        // Given
+        final String data = "value to digest";
+
+        // When
+        final String digest = DigestSources.sha256().digest(data, KeySources.fixedKey("abcd1234").getKey());
+
+        // Then
+        byte[] decodedDigest = EncodingUtils.BASE64_DECODER.apply(digest.getBytes(EncodingUtils.ENCODING));
+        byte[] passwordPart = new byte[decodedDigest.length / 2];
+        System.arraycopy(decodedDigest, decodedDigest.length / 2, passwordPart, 0, decodedDigest.length / 2);
+        assertFalse(Arrays.equals(passwordPart, DigestUtils.sha256(data)));
     }
 
     @Test


### PR DESCRIPTION
DigestSources.sha256 is not actually digesting the salt with the password...it is just digesting them separately and appending them, which defeats the purpose of using a salt. Thankfully, we are not actually using this anywhere.