### PR TITLE
feat(TPSVC-15563): remove port from X-Forwarded-Host

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilder.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilder.java
@@ -231,11 +231,17 @@ public class AuditLogContextBuilder {
         if (!StringUtils.isEmpty(httpServletRequest.getHeader("X-Forwarded-Host"))) {
             return UriComponentsBuilder.fromPath(httpServletRequest.getRequestURI())
                     .scheme(Optional.ofNullable(httpServletRequest.getHeader("X-Forwarded-Proto")).orElse("https"))
-                    .host(httpServletRequest.getHeader("X-Forwarded-Host")).query(httpServletRequest.getQueryString()).build()
-                    .toUri().toString();
+                    .host(retrieveHost(httpServletRequest))
+                    .query(httpServletRequest.getQueryString())
+                    .build().toUri().toString();
         } else {
             return httpServletRequest.getRequestURL().toString();
         }
+    }
+
+    private String retrieveHost(HttpServletRequest httpServletRequest) {
+        String hostWithPort = httpServletRequest.getHeader("X-Forwarded-Host");
+        return hostWithPort.split(":")[0];
     }
 
     private String convertToString(Object value) {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 https://jira.talendforge.org/browse/TPSVC-15563 : [AZ-sandbox] Public api is not accessible through Portal
The issue is that on Azure sandbox  thre is port number in X-Forwarded-Host header which causes exception during audit log generation

**What is the chosen solution to this problem?**
Remove the port part from header before creating URI
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
