### PR TITLE
feat(TDKN-297): Add ability to disable message output

### DIFF
--- a/daikon-audit/README.adoc
+++ b/daikon-audit/README.adoc
@@ -250,10 +250,6 @@ NOTE: If application is running it needs to be restarted for this change to take
 
 === Disable audit message in audit event
 
-You may use constant `org.talend.logging.audit.impl.AbstractAuditLoggerBase.MDC_OUTPUT_MESSAGE` in the MDC to disable
-message output in case all interesting information is located in MDC.
+It is possible for an `AbstractBackend` to disable log messages if it doesn't need it (e.g. performance consideration).
 
-```
-Context ctx = ContextBuilder.create(MDC_OUTPUT_MESSAGE, "false").build();
-
-```
+To do that, the implementation of the `AbstractBackend` have to override the method `enableMessageFormat` in order to return `false` (default value is `true` - backward compatibility considerations).

--- a/daikon-audit/README.adoc
+++ b/daikon-audit/README.adoc
@@ -247,3 +247,13 @@ log.appender=none
 ----
 
 NOTE: If application is running it needs to be restarted for this change to take effect.
+
+=== Disable audit message in audit event
+
+You may use constant `org.talend.logging.audit.impl.AbstractAuditLoggerBase.MDC_OUTPUT_MESSAGE` in the MDC to disable
+message output in case all interesting information is located in MDC.
+
+```
+Context ctx = ContextBuilder.create(MDC_OUTPUT_MESSAGE, "false").build();
+
+```

--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
@@ -1,28 +1,15 @@
 package org.talend.logging.audit.impl;
 
-import java.util.Map;
-
 import org.talend.logging.audit.Context;
 import org.talend.logging.audit.ContextBuilder;
 import org.talend.logging.audit.LogLevel;
+
+import java.util.Map;
 
 /**
  *
  */
 public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
-
-    /**
-     * <p>
-     * A MDC key to use to customize whether audit logger should output message in audit events. This is interesting
-     * in case only when MDC (Context) contains all the interesting information for the audit ingestion and no message
-     * is required.
-     * </p>
-     * <p>
-     * When set to "false", message in audit event will be replaced by an empty string. It defaults to <code>true</code>
-     * for backward compatibility issues (and also because audit system are generally interested in message).
-     * </p>
-     */
-    public static final String MDC_OUTPUT_MESSAGE = "__output-message__";
 
     private static String formatMessage(String message, Map<String, String> mdcContext) {
         if (mdcContext == null) {
@@ -63,11 +50,11 @@ public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
         final Map<String, String> oldContext = logger.getCopyOfContextMap();
         final Map<String, String> completeContext = logger.setNewContext(oldContext, enrichedContext);
         try {
-            if (Boolean.parseBoolean(completeContext.getOrDefault(MDC_OUTPUT_MESSAGE, Boolean.TRUE.toString()))) {
+            if (logger.enableMessageFormat()) {
                 message = formatMessage(message, completeContext);
                 logger.log(category, level, message, throwable);
             } else {
-                logger.log(category, level, "", throwable);
+                logger.log(category, level, throwable);
             }
         } finally {
             logger.resetContext(oldContext);

--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
@@ -56,8 +56,7 @@ public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
 
     private void logInternal(LogLevel level, String category, Context context, Throwable throwable, String message) {
         // creating copy of passed context to be able to modify it
-        Context actualContext =
-                context == null ? ContextBuilder.emptyContext() : ContextBuilder.create(context).build();
+        Context actualContext = context == null ? ContextBuilder.emptyContext() : ContextBuilder.create(context).build();
         Map<String, String> enrichedContext = getEnricher().enrich(category, actualContext);
 
         final AbstractBackend logger = getLogger();

--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
@@ -1,15 +1,28 @@
 package org.talend.logging.audit.impl;
 
+import java.util.Map;
+
 import org.talend.logging.audit.Context;
 import org.talend.logging.audit.ContextBuilder;
 import org.talend.logging.audit.LogLevel;
-
-import java.util.Map;
 
 /**
  *
  */
 public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
+
+    /**
+     * <p>
+     * A MDC key to use to customize whether audit logger should output message in audit events. This is interesting
+     * in case only when MDC (Context) contains all the interesting information for the audit ingestion and no message
+     * is required.
+     * </p>
+     * <p>
+     * When set to "false", message in audit event will be replaced by an empty string. It defaults to <code>true</code>
+     * for backward compatibility issues (and also because audit system are generally interested in message).
+     * </p>
+     */
+    public static final String MDC_OUTPUT_MESSAGE = "__output-message__";
 
     private static String formatMessage(String message, Map<String, String> mdcContext) {
         if (mdcContext == null) {
@@ -43,16 +56,20 @@ public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
 
     private void logInternal(LogLevel level, String category, Context context, Throwable throwable, String message) {
         // creating copy of passed context to be able to modify it
-        Context actualContext = context == null ? ContextBuilder.emptyContext() : ContextBuilder.create(context).build();
+        Context actualContext =
+                context == null ? ContextBuilder.emptyContext() : ContextBuilder.create(context).build();
         Map<String, String> enrichedContext = getEnricher().enrich(category, actualContext);
 
         final AbstractBackend logger = getLogger();
         final Map<String, String> oldContext = logger.getCopyOfContextMap();
         final Map<String, String> completeContext = logger.setNewContext(oldContext, enrichedContext);
         try {
-            final String formattedMessage = formatMessage(message, completeContext);
-
-            logger.log(category, level, formattedMessage, throwable);
+            if (Boolean.parseBoolean(completeContext.getOrDefault(MDC_OUTPUT_MESSAGE, Boolean.TRUE.toString()))) {
+                message = formatMessage(message, completeContext);
+                logger.log(category, level, message, throwable);
+            } else {
+                logger.log(category, level, "", throwable);
+            }
         } finally {
             logger.resetContext(oldContext);
         }

--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractBackend.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractBackend.java
@@ -1,11 +1,11 @@
 package org.talend.logging.audit.impl;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.talend.logging.audit.Context;
 import org.talend.logging.audit.ContextBuilder;
 import org.talend.logging.audit.LogLevel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *
@@ -21,6 +21,15 @@ public abstract class AbstractBackend {
     }
 
     public abstract void log(String category, LogLevel level, String message, Throwable throwable);
+
+    /**
+     * Log something when you don't have a message.
+     *
+     * For instance, when {@link #enableMessageFormat()} return {@code #false}.
+     */
+    public void log(String category, LogLevel level, Throwable throwable) {
+        log(category, level, "", throwable);
+    }
 
     public abstract Map<String, String> getCopyOfContextMap();
 
@@ -53,6 +62,21 @@ public abstract class AbstractBackend {
 
     public void resetContext(Map<String, String> oldContext) {
         this.setContextMap(oldContext == null ? new LinkedHashMap<>() : oldContext);
+    }
+
+    /**
+     * Indicate to the {@link org.talend.logging.audit.AuditLogger} that a message useful for you backend.
+     *
+     * Remark: default value is {@code true} (backward compatibility)
+     *
+     * @return - {@code true} indicate to the {@link org.talend.logging.audit.AuditLogger} that this {@link AbstractBackend} use log
+     * message to produce a trace.
+     * - {@code false} indicate to the {@link org.talend.logging.audit.AuditLogger} that this {@link AbstractBackend} doesn't use
+     * message to produce a trace and so
+     * that is not necessary to compute one.
+     */
+    protected boolean enableMessageFormat() {
+        return true;
     }
 
 }

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractAuditLoggerBaseTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractAuditLoggerBaseTest.java
@@ -25,6 +25,31 @@ public class AbstractAuditLoggerBaseTest {
 
     @Test
     @SuppressWarnings({ "unchecked" })
+    public void testNoMessageOutput() {
+        // Given
+        String category = "testCat";
+        Context ctx = ContextBuilder.create(AbstractAuditLoggerBase.MDC_OUTPUT_MESSAGE, "false").build();
+
+        AbstractBackend logger = mock(AbstractBackend.class);
+        logger.log(category.toLowerCase(), LogLevel.INFO, "", null);
+        expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<>());
+        expect(logger.setNewContext(anyObject(Map.class), anyObject(Map.class))).andReturn(ctx);
+        logger.resetContext(anyObject(Map.class));
+        expectLastCall();
+        replay(logger);
+
+        TestAuditLoggerBaseTest base = new TestAuditLoggerBaseTest(logger);
+
+        // When
+        base.log(LogLevel.INFO, category, ctx, null, "A discarded message");
+
+        // Then
+
+        verify(logger);
+    }
+
+    @Test
+    @SuppressWarnings({ "unchecked" })
     public void testLog() {
         String category = "testCat";
         Context ctx = ContextBuilder.emptyContext();
@@ -32,7 +57,7 @@ public class AbstractAuditLoggerBaseTest {
 
         AbstractBackend logger = mock(AbstractBackend.class);
         logger.log(category.toLowerCase(), LogLevel.INFO, thr.getMessage(), thr);
-        expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<String, String>());
+        expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<>());
         expect(logger.setNewContext(anyObject(Map.class), anyObject(Map.class))).andReturn(ctx);
         logger.resetContext(anyObject(Map.class));
         expectLastCall();

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractAuditLoggerBaseTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractAuditLoggerBaseTest.java
@@ -1,7 +1,5 @@
 package org.talend.logging.audit.impl;
 
-import static org.easymock.EasyMock.*;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.talend.logging.audit.AuditLoggingException;
@@ -11,6 +9,13 @@ import org.talend.logging.audit.LogLevel;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 
 public class AbstractAuditLoggerBaseTest {
 
@@ -24,14 +29,42 @@ public class AbstractAuditLoggerBaseTest {
     }
 
     @Test
-    @SuppressWarnings({ "unchecked" })
-    public void testNoMessageOutput() {
-        // Given
+    @SuppressWarnings({"unchecked"})
+    public void testLog() {
         String category = "testCat";
-        Context ctx = ContextBuilder.create(AbstractAuditLoggerBase.MDC_OUTPUT_MESSAGE, "false").build();
+        Context ctx = ContextBuilder.emptyContext();
+        Throwable thr = new AuditLoggingException("TestMsg");
 
         AbstractBackend logger = mock(AbstractBackend.class);
-        logger.log(category.toLowerCase(), LogLevel.INFO, "", null);
+        // Init backend so that it has the messages
+        expect(logger.enableMessageFormat()).andReturn(true);
+
+        logger.log(category.toLowerCase(), LogLevel.INFO, thr.getMessage(), thr);
+        expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<>());
+        expect(logger.setNewContext(anyObject(Map.class), anyObject(Map.class))).andReturn(ctx);
+        logger.resetContext(anyObject(Map.class));
+        expectLastCall();
+        replay(logger);
+
+        TestAuditLoggerBaseTest base = new TestAuditLoggerBaseTest(logger);
+
+        base.log(LogLevel.INFO, category, ctx, thr, null);
+
+        verify(logger);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void testNoMessageNeededByTheBackend() {
+        // Given
+        String category = "testCat";
+        Context ctx = ContextBuilder.emptyContext();
+
+        AbstractBackend logger = mock(AbstractBackend.class);
+        // Init backend so that it hasn't the messages
+        expect(logger.enableMessageFormat()).andReturn(false);
+
+        logger.log(category.toLowerCase(), LogLevel.INFO, null);
         expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<>());
         expect(logger.setNewContext(anyObject(Map.class), anyObject(Map.class))).andReturn(ctx);
         logger.resetContext(anyObject(Map.class));
@@ -44,29 +77,6 @@ public class AbstractAuditLoggerBaseTest {
         base.log(LogLevel.INFO, category, ctx, null, "A discarded message");
 
         // Then
-
-        verify(logger);
-    }
-
-    @Test
-    @SuppressWarnings({ "unchecked" })
-    public void testLog() {
-        String category = "testCat";
-        Context ctx = ContextBuilder.emptyContext();
-        Throwable thr = new AuditLoggingException("TestMsg");
-
-        AbstractBackend logger = mock(AbstractBackend.class);
-        logger.log(category.toLowerCase(), LogLevel.INFO, thr.getMessage(), thr);
-        expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<>());
-        expect(logger.setNewContext(anyObject(Map.class), anyObject(Map.class))).andReturn(ctx);
-        logger.resetContext(anyObject(Map.class));
-        expectLastCall();
-        replay(logger);
-
-        TestAuditLoggerBaseTest base = new TestAuditLoggerBaseTest(logger);
-
-        base.log(LogLevel.INFO, category, ctx, thr, null);
-
         verify(logger);
     }
 

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractBackendTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractBackendTest.java
@@ -1,0 +1,16 @@
+package org.talend.logging.audit.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.partialMockBuilder;
+
+public class AbstractBackendTest {
+
+    @Test
+    public void testThatDefaultBahaviourIsToHaveMessages() {
+        AbstractBackend logger = partialMockBuilder(AbstractBackend.class).createMock();
+        Assert.assertTrue(logger.enableMessageFormat());
+    }
+
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

Audit event message processing (including variable substitution) can be a costly operation, especially in use cases when a very high throughput is expected and message is discarded.
 
**What is the chosen solution to this problem?**
 
* Add MDC field to configure whether message go to output or not.
* Update README documentation with additional information.

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-297
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
