### PR TITLE
feat(TDKN-297): backport disable message output

### DIFF
--- a/daikon-audit/README.adoc
+++ b/daikon-audit/README.adoc
@@ -247,3 +247,9 @@ log.appender=none
 ----
 
 NOTE: If application is running it needs to be restarted for this change to take effect.
+
+=== Disable audit message in audit event
+
+It is possible for an `AbstractBackend` to disable log messages if it doesn't need it (e.g. performance consideration).
+
+To do that, the implementation of the `AbstractBackend` have to override the method `enableMessageFormat` in order to return `false` (default value is `true` - backward compatibility considerations).

--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
@@ -67,9 +67,12 @@ public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
         final Map<String, String> oldContext = logger.getCopyOfContextMap();
         final Map<String, String> completeContext = setNewContext(logger, oldContext, enrichedContext);
         try {
-            final String formattedMessage = formatMessage(message, completeContext);
-
-            logger.log(category, level, formattedMessage, throwable);
+            if (logger.enableMessageFormat()) {
+                message = formatMessage(message, completeContext);
+                logger.log(category, level, message, throwable);
+            } else {
+                logger.log(category, level, throwable);
+            }
         } finally {
             resetContext(logger, oldContext);
         }

--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractAuditLoggerBase.java
@@ -12,22 +12,6 @@ import org.talend.logging.audit.LogLevel;
  */
 public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
 
-    private static Map<String, String> setNewContext(AbstractBackend logger, Map<String, String> oldContext,
-            Map<String, String> newContext) {
-        ContextBuilder builder = ContextBuilder.create();
-        if (oldContext != null) {
-            builder.with(oldContext);
-        }
-        Context completeContext = builder.with(newContext).build();
-
-        logger.setContextMap(completeContext);
-        return completeContext;
-    }
-
-    private static void resetContext(AbstractBackend logger, Map<String, String> oldContext) {
-        logger.setContextMap(oldContext == null ? new LinkedHashMap<String, String>() : oldContext);
-    }
-
     private static String formatMessage(String message, Map<String, String> mdcContext) {
         if (mdcContext == null) {
             return message;
@@ -65,7 +49,7 @@ public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
 
         final AbstractBackend logger = getLogger();
         final Map<String, String> oldContext = logger.getCopyOfContextMap();
-        final Map<String, String> completeContext = setNewContext(logger, oldContext, enrichedContext);
+        final Map<String, String> completeContext = logger.setNewContext(oldContext, enrichedContext);
         try {
             if (logger.enableMessageFormat()) {
                 message = formatMessage(message, completeContext);
@@ -74,7 +58,7 @@ public abstract class AbstractAuditLoggerBase implements AuditLoggerBase {
                 logger.log(category, level, throwable);
             }
         } finally {
-            resetContext(logger, oldContext);
+            logger.resetContext(oldContext);
         }
     }
 

--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractBackend.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractBackend.java
@@ -69,7 +69,8 @@ public abstract class AbstractBackend {
      *
      * Remark: default value is {@code true} (backward compatibility)
      *
-     * @return - {@code true} indicate to the {@link org.talend.logging.audit.AuditLogger} that this {@link AbstractBackend} use log
+     * @return - {@code true} indicate to the {@link org.talend.logging.audit.AuditLogger} that this {@link AbstractBackend} use
+     * log
      * message to produce a trace.
      * - {@code false} indicate to the {@link org.talend.logging.audit.AuditLogger} that this {@link AbstractBackend} doesn't use
      * message to produce a trace and so

--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractBackend.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AbstractBackend.java
@@ -1,8 +1,11 @@
 package org.talend.logging.audit.impl;
 
-import java.util.Map;
-
+import org.talend.logging.audit.Context;
+import org.talend.logging.audit.ContextBuilder;
 import org.talend.logging.audit.LogLevel;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *
@@ -19,8 +22,61 @@ public abstract class AbstractBackend {
 
     public abstract void log(String category, LogLevel level, String message, Throwable throwable);
 
+    /**
+     * Log something when you don't have a message.
+     *
+     * For instance, when {@link #enableMessageFormat()} return {@code #false}.
+     */
+    public void log(String category, LogLevel level, Throwable throwable) {
+        log(category, level, "", throwable);
+    }
+
     public abstract Map<String, String> getCopyOfContextMap();
 
     public abstract void setContextMap(Map<String, String> newContext);
+
+    public Map<String, String> setNewContext(Map<String, String> oldContext, Map<String, String> newContext) {
+        ContextBuilder builder = ContextBuilder.create();
+        if (oldContext != null) {
+            builder.with(oldContext);
+        }
+        if (newContext != null) {
+            builder.with(newContext);
+        }
+        Context completeContext = builder.build();
+
+        this.setContextMap(completeContext);
+        return completeContext;
+    }
+
+    public Map<String, String> setNewContext(Map<String, String> oldContext) {
+        ContextBuilder builder = ContextBuilder.create();
+        if (oldContext != null) {
+            builder.with(oldContext);
+        }
+        Context completeContext = builder.build();
+
+        this.setContextMap(completeContext);
+        return completeContext;
+    }
+
+    public void resetContext(Map<String, String> oldContext) {
+        this.setContextMap(oldContext == null ? new LinkedHashMap<>() : oldContext);
+    }
+
+    /**
+     * Indicate to the {@link org.talend.logging.audit.AuditLogger} that a message useful for you backend.
+     *
+     * Remark: default value is {@code true} (backward compatibility)
+     *
+     * @return - {@code true} indicate to the {@link org.talend.logging.audit.AuditLogger} that this {@link AbstractBackend} use log
+     * message to produce a trace.
+     * - {@code false} indicate to the {@link org.talend.logging.audit.AuditLogger} that this {@link AbstractBackend} doesn't use
+     * message to produce a trace and so
+     * that is not necessary to compute one.
+     */
+    protected boolean enableMessageFormat() {
+        return true;
+    }
 
 }

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractAuditLoggerBaseTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractAuditLoggerBaseTest.java
@@ -29,7 +29,7 @@ public class AbstractAuditLoggerBaseTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     public void testLog() {
         String category = "testCat";
         Context ctx = ContextBuilder.emptyContext();
@@ -54,7 +54,7 @@ public class AbstractAuditLoggerBaseTest {
     }
 
     @Test
-    @SuppressWarnings({"unchecked"})
+    @SuppressWarnings({ "unchecked" })
     public void testNoMessageNeededByTheBackend() {
         // Given
         String category = "testCat";

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractAuditLoggerBaseTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractAuditLoggerBaseTest.java
@@ -1,7 +1,5 @@
 package org.talend.logging.audit.impl;
 
-import static org.easymock.EasyMock.*;
-
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.talend.logging.audit.AuditLoggingException;
@@ -11,6 +9,13 @@ import org.talend.logging.audit.LogLevel;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import static org.easymock.EasyMock.anyObject;
+import static org.easymock.EasyMock.expect;
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.mock;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
 
 public class AbstractAuditLoggerBaseTest {
 
@@ -24,23 +29,54 @@ public class AbstractAuditLoggerBaseTest {
     }
 
     @Test
-    @SuppressWarnings({ "unchecked" })
+    @SuppressWarnings({"unchecked"})
     public void testLog() {
         String category = "testCat";
         Context ctx = ContextBuilder.emptyContext();
         Throwable thr = new AuditLoggingException("TestMsg");
 
         AbstractBackend logger = mock(AbstractBackend.class);
+        // Init backend so that it has the messages
+        expect(logger.enableMessageFormat()).andReturn(true);
+
         logger.log(category.toLowerCase(), LogLevel.INFO, thr.getMessage(), thr);
-        expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<String, String>());
-        logger.setContextMap(anyObject(Map.class));
-        expectLastCall().times(2);
+        expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<>());
+        expect(logger.setNewContext(anyObject(Map.class), anyObject(Map.class))).andReturn(ctx);
+        logger.resetContext(anyObject(Map.class));
+        expectLastCall();
         replay(logger);
 
         TestAuditLoggerBaseTest base = new TestAuditLoggerBaseTest(logger);
 
         base.log(LogLevel.INFO, category, ctx, thr, null);
 
+        verify(logger);
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked"})
+    public void testNoMessageNeededByTheBackend() {
+        // Given
+        String category = "testCat";
+        Context ctx = ContextBuilder.emptyContext();
+
+        AbstractBackend logger = mock(AbstractBackend.class);
+        // Init backend so that it hasn't the messages
+        expect(logger.enableMessageFormat()).andReturn(false);
+
+        logger.log(category.toLowerCase(), LogLevel.INFO, null);
+        expect(logger.getCopyOfContextMap()).andReturn(new LinkedHashMap<>());
+        expect(logger.setNewContext(anyObject(Map.class), anyObject(Map.class))).andReturn(ctx);
+        logger.resetContext(anyObject(Map.class));
+        expectLastCall();
+        replay(logger);
+
+        TestAuditLoggerBaseTest base = new TestAuditLoggerBaseTest(logger);
+
+        // When
+        base.log(LogLevel.INFO, category, ctx, null, "A discarded message");
+
+        // Then
         verify(logger);
     }
 

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractBackendTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AbstractBackendTest.java
@@ -1,0 +1,16 @@
+package org.talend.logging.audit.impl;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.easymock.EasyMock.partialMockBuilder;
+
+public class AbstractBackendTest {
+
+    @Test
+    public void testThatDefaultBahaviourIsToHaveMessages() {
+        AbstractBackend logger = partialMockBuilder(AbstractBackend.class).createMock();
+        Assert.assertTrue(logger.enableMessageFormat());
+    }
+
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
This PR backports the enhancement brought by [TDKN-297](https://jira.talendforge.org/browse/TDKN-297) to the 1.x maintenance branch (used in the jobs)

**What is the chosen solution to this problem?**

Cherry-pick the feature commits
 
**Link to the JIRA issue**

[TDKN-297](https://jira.talendforge.org/browse/TDKN-297)
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
