### PR TITLE
TDKN-298 - Update Commons Validator to 1.7 in daikon-spring-audit-logs

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
         </dependency>
         <!-- Test dependencies -->
         <dependency>


### PR DESCRIPTION
This task is to update Commons Validator to 1.7 in daikon-spring-audit-logs. This fixes a high level CVE in a transitive dependency (BeanUtils 1.9.2).