### PR TITLE
fix(TDC-4420): Fix incorrect value type inference for path expressions

### DIFF
--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
@@ -239,7 +239,7 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
         // Check if accessor type is numeric (if numeric, use parseDouble or use string equals for others)
         Class<?> returnType = value.getClass();
         if (accessors.length > 0) {
-            returnType = accessors[0].getReturnType();
+            returnType = accessors[accessors.length - 1].getReturnType();
             if (returnType.isPrimitive()) {
                 // Handle case where return type is primitive (e.g. "int" not "Integer")
                 returnType = ClassUtils.primitiveToWrapper(returnType);

--- a/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
+++ b/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
@@ -508,6 +508,18 @@ public class BeanPredicateVisitorTest {
         assertTrue(predicate.test(bean));
     }
 
+    @Test
+    public void testNestedIntComparison() {
+        // given
+        final Expression query = Tql.parse("nested.nestedDouble = 10.1");
+
+        // when
+        final Predicate<Bean> predicate = query.accept(new BeanPredicateVisitor<>(Bean.class));
+
+        // then
+        assertTrue(predicate.test(bean));
+    }
+
     // Test class
     public static class Bean {
 
@@ -550,6 +562,10 @@ public class BeanPredicateVisitorTest {
 
         public int getNestedInt() {
             return 10;
+        }
+
+        public double getNestedDouble() {
+            return 10.1;
         }
 
         public String getNestedValue() {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
There's an issue in value type inference (based on method return type). When path contain multiple elements, type is taken from first path element instead of last one.

**What is the chosen solution to this problem?**

* Make sure to infer type based on last part of path.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDC-4420
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
