### PR TITLE
bug(TMC-22830) wrong response body is logged in audit logs

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/ResponseExtractor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/ResponseExtractor.java
@@ -1,0 +1,8 @@
+package org.talend.daikon.spring.audit.logs.service;
+
+public interface ResponseExtractor {
+
+    int getStatusCode(Object responseObject);
+
+    Object getResponseBody(Object responseObject);
+}

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/ResponseExtractor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/ResponseExtractor.java
@@ -1,8 +1,21 @@
 package org.talend.daikon.spring.audit.logs.service;
 
+/**
+ * Audit log response extractor interface, to support different networking libraries
+ */
 public interface ResponseExtractor {
 
+    /**
+     *
+     * @param responseObject object returned by endpoint
+     * @return response status
+     */
     int getStatusCode(Object responseObject);
 
+    /**
+     *
+     * @param responseObject object returned by endpoint
+     * @return extracted response body
+     */
     Object getResponseBody(Object responseObject);
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?** 
wrong response body and code is logged in audit logs in TMC web app

**What is the chosen solution to this problem?**
add response extractor bean to make more flexible mechanism to extract right response code
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TMC-22830
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
