### PR TITLE
TMC-23122 [Audit Log] Response body is null for CREATE operation

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/GenerateAuditLog.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/api/GenerateAuditLog.java
@@ -48,6 +48,13 @@ public @interface GenerateAuditLog {
     boolean includeBodyResponse() default true;
 
     /**
+     * Should include or not the HTTP location header in the generated audit log
+     *
+     * @return boolean indicating if the HTTP location header is included or not
+     */
+    boolean includeLocationHeader() default false;
+
+    /**
      * Filter whose purpose is to filter HTTP request/response before generation
      *
      * @return Filter class

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -1,5 +1,6 @@
 package org.talend.daikon.spring.audit.logs.config;
 
+import java.net.URI;
 import java.util.Optional;
 import java.util.Properties;
 
@@ -112,6 +113,17 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
             @Override
             public Object getResponseBody(Object responseObject) {
                 return responseObject instanceof ResponseEntity ? ((ResponseEntity) responseObject).getBody() : null;
+            }
+
+            @Override
+            public String getLocation(Object responseObject) {
+                if (responseObject instanceof ResponseEntity) {
+                    URI location = ((ResponseEntity) responseObject).getHeaders().getLocation();
+                    if (location != null) {
+                        return location.getPath();
+                    }
+                }
+                return null;
             }
         };
     }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/model/AuditLogFieldEnum.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/model/AuditLogFieldEnum.java
@@ -28,7 +28,8 @@ public enum AuditLogFieldEnum {
     REQUEST("request", Arrays.asList(URL, METHOD, USER_AGENT, REQUEST_BODY)),
     RESPONSE_BODY("body", false),
     RESPONSE_CODE("code"),
-    RESPONSE("response", Arrays.asList(RESPONSE_BODY, RESPONSE_CODE));
+    RESPONSE_LOCATION("location", false),
+    RESPONSE("response", Arrays.asList(RESPONSE_BODY, RESPONSE_CODE, RESPONSE_LOCATION));
 
     private String id;
 

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilder.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogContextBuilder.java
@@ -132,6 +132,10 @@ public class AuditLogContextBuilder {
         return this.with(RESPONSE_BODY.getId(), responseBody, response);
     }
 
+    public AuditLogContextBuilder withResponseLocation(Object responseLocation) {
+        return this.with(RESPONSE_LOCATION.getId(), responseLocation, response);
+    }
+
     public Context build() throws AuditLogException {
         try {
             // Compute request fields only at build step to leverage ip extractor
@@ -161,8 +165,8 @@ public class AuditLogContextBuilder {
         return withRequestBody(requestBody);
     }
 
-    public AuditLogContextBuilder withResponse(int httpStatus, Object body) {
-        return withResponseCode(httpStatus).withResponseBody(body);
+    public AuditLogContextBuilder withResponse(int httpStatus, Object body, Object location) {
+        return withResponseCode(httpStatus).withResponseBody(body).withResponseLocation(location);
     }
 
     public void checkAuditContextIsValid() throws AuditLogException {

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorAspect.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorAspect.java
@@ -72,12 +72,12 @@ public class AuditLogGeneratorAspect {
                 // for some responses such 204|302 we should have empty body and retrieve it from response
                 auditLogResponseObject = responseExtractor.getResponseBody(responseObject);
             }
-
+            String locationHeader = responseExtractor.getLocation(responseObject);
             // Send logs only in case of success or if responseCode can't be defined
             if (responseCode == 0 || !HttpStatus.valueOf(responseCode).isError()) {
                 // Finally send the audit log
                 auditLogSender.sendAuditLog(request, extractRequestBody(proceedingJoinPoint), responseCode,
-                        auditLogResponseObject, auditLogAnnotation);
+                        auditLogResponseObject, locationHeader, auditLogAnnotation);
             }
         }
         return responseObject;

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogGeneratorInterceptor.java
@@ -64,7 +64,8 @@ public class AuditLogGeneratorInterceptor extends HandlerInterceptorAdapter {
             String responseBodyString = Optional.ofNullable(response).map(this::extractContent).orElse(null);
             // Only log if code is not successful
             if (HttpStatus.valueOf(responseCode).isError()) {
-                this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBodyString, generateAuditLog.get());
+                this.auditLogSender.sendAuditLog(request, requestBody, responseCode, responseBodyString, null,
+                        generateAuditLog.get());
             }
         } else {
             super.afterCompletion(request, response, handler, ex);

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSender.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSender.java
@@ -34,7 +34,7 @@ public interface AuditLogSender {
      * @param responseObject response body object
      * @param auditLogAnnotation generate audit log annotation containing basic properties
      */
-    void sendAuditLog(HttpServletRequest request, Object requestBody, int responseCode, Object responseObject,
+    void sendAuditLog(HttpServletRequest request, Object requestBody, int responseCode, Object responseObject, Object location,
             GenerateAuditLog auditLogAnnotation);
 
     /**

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -36,7 +36,7 @@ public class AuditLogSenderImpl implements AuditLogSender {
      */
     @Override
     public void sendAuditLog(HttpServletRequest request, Object requestBody, int responseCode, Object responseObject,
-            GenerateAuditLog auditLogAnnotation) {
+            Object location, GenerateAuditLog auditLogAnnotation) {
         try {
             // Build context from request, response & annotation info
             AuditLogContextBuilder auditLogContextBuilder = AuditLogContextBuilder.create() //
@@ -52,7 +52,8 @@ public class AuditLogSenderImpl implements AuditLogSender {
                     .withEmail(auditUserProvider.getUserEmail()) //
                     .withAccountId(auditUserProvider.getAccountId()) //
                     .withRequest(request, requestBody) //
-                    .withResponse(responseCode, auditLogAnnotation.includeBodyResponse() ? responseObject : null)
+                    .withResponse(responseCode, auditLogAnnotation.includeBodyResponse() ? responseObject : null,
+                            auditLogAnnotation.includeLocationHeader() ? location : null)
                     .withIpExtractor(this.auditLogIpExtractor);
 
             // Filter the context if needed

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/ResponseExtractor.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/ResponseExtractor.java
@@ -18,4 +18,11 @@ public interface ResponseExtractor {
      * @return extracted response body
      */
     Object getResponseBody(Object responseObject);
+
+    /**
+     *
+     * @param responseObject object returned by endpoint
+     * @return extracted location header for HATEOAS architectures
+     */
+    String getLocation(Object responseObject);
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 Response body is null for CREATE operation for all create operations in TMC

**What is the chosen solution to this problem?**
add location header to log, to keep track of entities that was created 
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TMC-23122


**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
