### PR TITLE
Removing internal sun APIs from the CertificateGenerater

### DIFF
--- a/daikon-crypto/daikon-signature-verifier/pom.xml
+++ b/daikon-crypto/daikon-signature-verifier/pom.xml
@@ -38,6 +38,12 @@
 			<version>${commons-io.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.bouncycastle</groupId>
+			<artifactId>bcpkix-jdk15on</artifactId>
+			<version>${bcprov.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>
@@ -47,10 +53,6 @@
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
-					<compilerArguments>
-						<verbose />
-						<bootclasspath>${java.home}/lib/rt.jar</bootclasspath>
-					</compilerArguments>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
@RyanSkraba reported to me that the signature verifier tests fail on his machine. I think this is due to the fact that the tests use the internal Sun APIs. Instead I changed the tests to generate certificates using BouncyCastle instead, which means it should run on any JVM.