### PR TITLE
Tdkn 301 maintenance 3.1

### DIFF
--- a/daikon-audit/audit-all/pom.xml
+++ b/daikon-audit/audit-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-audit</artifactId>
 

--- a/daikon-audit/audit-all/pom.xml
+++ b/daikon-audit/audit-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-audit</artifactId>
 

--- a/daikon-audit/audit-all/pom.xml
+++ b/daikon-audit/audit-all/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-audit</artifactId>
 

--- a/daikon-audit/audit-common/pom.xml
+++ b/daikon-audit/audit-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>audit-common</artifactId>
 

--- a/daikon-audit/audit-common/pom.xml
+++ b/daikon-audit/audit-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>audit-common</artifactId>
 

--- a/daikon-audit/audit-common/pom.xml
+++ b/daikon-audit/audit-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>audit-common</artifactId>
 

--- a/daikon-audit/audit-kafka/pom.xml
+++ b/daikon-audit/audit-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>audit-kafka</artifactId>
 

--- a/daikon-audit/audit-kafka/pom.xml
+++ b/daikon-audit/audit-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>audit-kafka</artifactId>
 

--- a/daikon-audit/audit-kafka/pom.xml
+++ b/daikon-audit/audit-kafka/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>audit-kafka</artifactId>
 

--- a/daikon-audit/audit-log4j1/pom.xml
+++ b/daikon-audit/audit-log4j1/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>audit-log4j1</artifactId>
 

--- a/daikon-audit/audit-log4j1/pom.xml
+++ b/daikon-audit/audit-log4j1/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>audit-log4j1</artifactId>
 

--- a/daikon-audit/audit-log4j1/pom.xml
+++ b/daikon-audit/audit-log4j1/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>audit-log4j1</artifactId>
 

--- a/daikon-audit/audit-log4j2/pom.xml
+++ b/daikon-audit/audit-log4j2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>audit-log4j2</artifactId>
 

--- a/daikon-audit/audit-log4j2/pom.xml
+++ b/daikon-audit/audit-log4j2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>audit-log4j2</artifactId>
 

--- a/daikon-audit/audit-log4j2/pom.xml
+++ b/daikon-audit/audit-log4j2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>audit-log4j2</artifactId>
 

--- a/daikon-audit/audit-logback/pom.xml
+++ b/daikon-audit/audit-logback/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>audit-logback</artifactId>
 

--- a/daikon-audit/audit-logback/pom.xml
+++ b/daikon-audit/audit-logback/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>audit-logback</artifactId>
 

--- a/daikon-audit/audit-logback/pom.xml
+++ b/daikon-audit/audit-logback/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>audit-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>audit-logback</artifactId>
 

--- a/daikon-audit/pom.xml
+++ b/daikon-audit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>audit-parent</artifactId>
     <packaging>pom</packaging>

--- a/daikon-audit/pom.xml
+++ b/daikon-audit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>audit-parent</artifactId>
     <packaging>pom</packaging>

--- a/daikon-audit/pom.xml
+++ b/daikon-audit/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>audit-parent</artifactId>
     <packaging>pom</packaging>

--- a/daikon-bom/pom.xml
+++ b/daikon-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-parent</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-bom/pom.xml
+++ b/daikon-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-parent</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-bom/pom.xml
+++ b/daikon-bom/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-parent</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-crypto/crypto-utils/pom.xml
+++ b/daikon-crypto/crypto-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-crypto</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>crypto-utils</artifactId>

--- a/daikon-crypto/crypto-utils/pom.xml
+++ b/daikon-crypto/crypto-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-crypto</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>crypto-utils</artifactId>

--- a/daikon-crypto/crypto-utils/pom.xml
+++ b/daikon-crypto/crypto-utils/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-crypto</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
 
     <artifactId>crypto-utils</artifactId>

--- a/daikon-crypto/daikon-signature-verifier/pom.xml
+++ b/daikon-crypto/daikon-signature-verifier/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-crypto</artifactId>
-		<version>3.1.6-SNAPSHOT</version>
+		<version>3.1.6</version>
 	</parent>
 	<artifactId>daikon-signature-verifier</artifactId>
 	<name>daikon signature verifier library</name>

--- a/daikon-crypto/daikon-signature-verifier/pom.xml
+++ b/daikon-crypto/daikon-signature-verifier/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-crypto</artifactId>
-		<version>3.1.5</version>
+		<version>3.1.6-SNAPSHOT</version>
 	</parent>
 	<artifactId>daikon-signature-verifier</artifactId>
 	<name>daikon signature verifier library</name>

--- a/daikon-crypto/daikon-signature-verifier/pom.xml
+++ b/daikon-crypto/daikon-signature-verifier/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-crypto</artifactId>
-		<version>3.1.6</version>
+		<version>3.1.7-SNAPSHOT</version>
 	</parent>
 	<artifactId>daikon-signature-verifier</artifactId>
 	<name>daikon signature verifier library</name>

--- a/daikon-crypto/pom.xml
+++ b/daikon-crypto/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-crypto</artifactId>
     <packaging>pom</packaging>

--- a/daikon-crypto/pom.xml
+++ b/daikon-crypto/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-crypto</artifactId>
     <packaging>pom</packaging>

--- a/daikon-crypto/pom.xml
+++ b/daikon-crypto/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-crypto</artifactId>
     <packaging>pom</packaging>

--- a/daikon-documentation/pom.xml
+++ b/daikon-documentation/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>daikon-parent</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
 
     <artifactId>daikon-documentation</artifactId>
-    <version>3.1.6-SNAPSHOT</version>
+    <version>3.1.6</version>
     <packaging>maven-plugin</packaging>
 
     <name>daikon-documentation Maven Plugin</name>

--- a/daikon-documentation/pom.xml
+++ b/daikon-documentation/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>daikon-parent</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>daikon-documentation</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.7-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>daikon-documentation Maven Plugin</name>

--- a/daikon-documentation/pom.xml
+++ b/daikon-documentation/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <artifactId>daikon-parent</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>daikon-documentation</artifactId>
-    <version>3.1.5</version>
+    <version>3.1.6-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <name>daikon-documentation Maven Plugin</name>

--- a/daikon-exception/pom.xml
+++ b/daikon-exception/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.1.6-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>daikon-exception</artifactId>

--- a/daikon-exception/pom.xml
+++ b/daikon-exception/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-parent</artifactId>
-		<version>3.1.6-SNAPSHOT</version>
+		<version>3.1.6</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>daikon-exception</artifactId>

--- a/daikon-exception/pom.xml
+++ b/daikon-exception/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-parent</artifactId>
-		<version>3.1.6</version>
+		<version>3.1.7-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>daikon-exception</artifactId>

--- a/daikon-i18n/pom.xml
+++ b/daikon-i18n/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>daikon-i18n</artifactId>
-    <version>3.1.5</version>
+    <version>3.1.6-SNAPSHOT</version>
     <name>Daikon :: i18n</name>
 
     <properties>

--- a/daikon-i18n/pom.xml
+++ b/daikon-i18n/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
 
     <artifactId>daikon-i18n</artifactId>
-    <version>3.1.6-SNAPSHOT</version>
+    <version>3.1.6</version>
     <name>Daikon :: i18n</name>
 
     <properties>

--- a/daikon-i18n/pom.xml
+++ b/daikon-i18n/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>daikon-i18n</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.7-SNAPSHOT</version>
     <name>Daikon :: i18n</name>
 
     <properties>

--- a/daikon-logging/logging-event-layout/pom.xml
+++ b/daikon-logging/logging-event-layout/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
 	<artifactId>logging-event-layout</artifactId>
 	<name>logging-event-layout</name>

--- a/daikon-logging/logging-event-layout/pom.xml
+++ b/daikon-logging/logging-event-layout/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 	<artifactId>logging-event-layout</artifactId>
 	<name>logging-event-layout</name>

--- a/daikon-logging/logging-event-layout/pom.xml
+++ b/daikon-logging/logging-event-layout/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 	<artifactId>logging-event-layout</artifactId>
 	<name>logging-event-layout</name>

--- a/daikon-logging/logging-kafka-interceptor/pom.xml
+++ b/daikon-logging/logging-kafka-interceptor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>logging-kafka-interceptor</artifactId>
     <name>logging-kafka-interceptor</name>

--- a/daikon-logging/logging-kafka-interceptor/pom.xml
+++ b/daikon-logging/logging-kafka-interceptor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>logging-kafka-interceptor</artifactId>
     <name>logging-kafka-interceptor</name>

--- a/daikon-logging/logging-kafka-interceptor/pom.xml
+++ b/daikon-logging/logging-kafka-interceptor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>logging-kafka-interceptor</artifactId>
     <name>logging-kafka-interceptor</name>

--- a/daikon-logging/logging-request-interceptor/pom.xml
+++ b/daikon-logging/logging-request-interceptor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>logging-request-interceptor</artifactId>
     <name>logging-request-interceptor</name>

--- a/daikon-logging/logging-request-interceptor/pom.xml
+++ b/daikon-logging/logging-request-interceptor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>logging-request-interceptor</artifactId>
     <name>logging-request-interceptor</name>

--- a/daikon-logging/logging-request-interceptor/pom.xml
+++ b/daikon-logging/logging-request-interceptor/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>logging-request-interceptor</artifactId>
     <name>logging-request-interceptor</name>

--- a/daikon-logging/logging-spring-security/pom.xml
+++ b/daikon-logging/logging-spring-security/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>logging-spring-security</artifactId>
     <name>logging-spring-security</name>

--- a/daikon-logging/logging-spring-security/pom.xml
+++ b/daikon-logging/logging-spring-security/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>logging-spring-security</artifactId>
     <name>logging-spring-security</name>

--- a/daikon-logging/logging-spring-security/pom.xml
+++ b/daikon-logging/logging-spring-security/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-logging</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>logging-spring-security</artifactId>
     <name>logging-spring-security</name>

--- a/daikon-logging/pom.xml
+++ b/daikon-logging/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-logging</artifactId>
     <packaging>pom</packaging>

--- a/daikon-logging/pom.xml
+++ b/daikon-logging/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-logging</artifactId>
     <packaging>pom</packaging>

--- a/daikon-logging/pom.xml
+++ b/daikon-logging/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-logging</artifactId>
     <packaging>pom</packaging>

--- a/daikon-messages/messages-demo/demo-listener/pom.xml
+++ b/daikon-messages/messages-demo/demo-listener/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>messages-demo</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <groupId>org.talend.daikon.messages-demo</groupId>
     <artifactId>demo-listener</artifactId>

--- a/daikon-messages/messages-demo/demo-listener/pom.xml
+++ b/daikon-messages/messages-demo/demo-listener/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>messages-demo</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <groupId>org.talend.daikon.messages-demo</groupId>
     <artifactId>demo-listener</artifactId>

--- a/daikon-messages/messages-demo/demo-listener/pom.xml
+++ b/daikon-messages/messages-demo/demo-listener/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>messages-demo</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <groupId>org.talend.daikon.messages-demo</groupId>
     <artifactId>demo-listener</artifactId>

--- a/daikon-messages/messages-demo/demo-producer/pom.xml
+++ b/daikon-messages/messages-demo/demo-producer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>messages-demo</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <groupId>org.talend.daikon.messages-demo</groupId>
     <artifactId>demo-producer</artifactId>

--- a/daikon-messages/messages-demo/demo-producer/pom.xml
+++ b/daikon-messages/messages-demo/demo-producer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>messages-demo</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <groupId>org.talend.daikon.messages-demo</groupId>
     <artifactId>demo-producer</artifactId>

--- a/daikon-messages/messages-demo/demo-producer/pom.xml
+++ b/daikon-messages/messages-demo/demo-producer/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>messages-demo</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <groupId>org.talend.daikon.messages-demo</groupId>
     <artifactId>demo-producer</artifactId>

--- a/daikon-messages/messages-demo/pom.xml
+++ b/daikon-messages/messages-demo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>messages-demo</artifactId>
     <name>messages-demo</name>

--- a/daikon-messages/messages-demo/pom.xml
+++ b/daikon-messages/messages-demo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>messages-demo</artifactId>
     <name>messages-demo</name>

--- a/daikon-messages/messages-demo/pom.xml
+++ b/daikon-messages/messages-demo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>messages-demo</artifactId>
     <name>messages-demo</name>

--- a/daikon-messages/messages-model-spring-support/pom.xml
+++ b/daikon-messages/messages-model-spring-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>messages-model-spring-support</artifactId>
 

--- a/daikon-messages/messages-model-spring-support/pom.xml
+++ b/daikon-messages/messages-model-spring-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>messages-model-spring-support</artifactId>
 

--- a/daikon-messages/messages-model-spring-support/pom.xml
+++ b/daikon-messages/messages-model-spring-support/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>messages-model-spring-support</artifactId>
 

--- a/daikon-messages/messages-model/pom.xml
+++ b/daikon-messages/messages-model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>messages-model</artifactId>
     <name>messages-model</name>

--- a/daikon-messages/messages-model/pom.xml
+++ b/daikon-messages/messages-model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>messages-model</artifactId>
     <name>messages-model</name>

--- a/daikon-messages/messages-model/pom.xml
+++ b/daikon-messages/messages-model/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-messages</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>messages-model</artifactId>
     <name>messages-model</name>

--- a/daikon-messages/pom.xml
+++ b/daikon-messages/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-messages</artifactId>
     <name>daikon-messages</name>

--- a/daikon-messages/pom.xml
+++ b/daikon-messages/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-messages</artifactId>
     <name>daikon-messages</name>

--- a/daikon-messages/pom.xml
+++ b/daikon-messages/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-messages</artifactId>
     <name>daikon-messages</name>

--- a/daikon-multitenant/multitenant-core/pom.xml
+++ b/daikon-multitenant/multitenant-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>multitenant-core</artifactId>
     <packaging>bundle</packaging>

--- a/daikon-multitenant/multitenant-core/pom.xml
+++ b/daikon-multitenant/multitenant-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>multitenant-core</artifactId>
     <packaging>bundle</packaging>

--- a/daikon-multitenant/multitenant-core/pom.xml
+++ b/daikon-multitenant/multitenant-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>multitenant-core</artifactId>
     <packaging>bundle</packaging>

--- a/daikon-multitenant/multitenant-spring-async/pom.xml
+++ b/daikon-multitenant/multitenant-spring-async/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>multitenant-spring-async</artifactId>
     <packaging>jar</packaging>

--- a/daikon-multitenant/multitenant-spring-async/pom.xml
+++ b/daikon-multitenant/multitenant-spring-async/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>multitenant-spring-async</artifactId>
     <packaging>jar</packaging>

--- a/daikon-multitenant/multitenant-spring-async/pom.xml
+++ b/daikon-multitenant/multitenant-spring-async/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>multitenant-spring-async</artifactId>
     <packaging>jar</packaging>

--- a/daikon-multitenant/multitenant-spring-web/pom.xml
+++ b/daikon-multitenant/multitenant-spring-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>multitenant-spring-web</artifactId>
     <packaging>jar</packaging>

--- a/daikon-multitenant/multitenant-spring-web/pom.xml
+++ b/daikon-multitenant/multitenant-spring-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>multitenant-spring-web</artifactId>
     <packaging>jar</packaging>

--- a/daikon-multitenant/multitenant-spring-web/pom.xml
+++ b/daikon-multitenant/multitenant-spring-web/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-multitenant</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>multitenant-spring-web</artifactId>
     <packaging>jar</packaging>

--- a/daikon-multitenant/pom.xml
+++ b/daikon-multitenant/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-multitenant</artifactId>
     <packaging>pom</packaging>

--- a/daikon-multitenant/pom.xml
+++ b/daikon-multitenant/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-multitenant</artifactId>
     <packaging>pom</packaging>

--- a/daikon-multitenant/pom.xml
+++ b/daikon-multitenant/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-multitenant</artifactId>
     <packaging>pom</packaging>

--- a/daikon-scala/dynamic-log/dynamic-log-core/pom.xml
+++ b/daikon-scala/dynamic-log/dynamic-log-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>dynamic-log</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log-core</artifactId>

--- a/daikon-scala/dynamic-log/dynamic-log-core/pom.xml
+++ b/daikon-scala/dynamic-log/dynamic-log-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>dynamic-log</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log-core</artifactId>

--- a/daikon-scala/dynamic-log/dynamic-log-core/pom.xml
+++ b/daikon-scala/dynamic-log/dynamic-log-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>dynamic-log</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log-core</artifactId>

--- a/daikon-scala/dynamic-log/dynamic-log-web-play/pom.xml
+++ b/daikon-scala/dynamic-log/dynamic-log-web-play/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>dynamic-log</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log-web-play_2.11</artifactId>

--- a/daikon-scala/dynamic-log/dynamic-log-web-play/pom.xml
+++ b/daikon-scala/dynamic-log/dynamic-log-web-play/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>dynamic-log</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log-web-play_2.11</artifactId>

--- a/daikon-scala/dynamic-log/dynamic-log-web-play/pom.xml
+++ b/daikon-scala/dynamic-log/dynamic-log-web-play/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>dynamic-log</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log-web-play_2.11</artifactId>

--- a/daikon-scala/dynamic-log/pom.xml
+++ b/daikon-scala/dynamic-log/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>scala-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
         <relativePath>../scala-parent/pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log</artifactId>

--- a/daikon-scala/dynamic-log/pom.xml
+++ b/daikon-scala/dynamic-log/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>scala-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../scala-parent/pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log</artifactId>

--- a/daikon-scala/dynamic-log/pom.xml
+++ b/daikon-scala/dynamic-log/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>scala-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
         <relativePath>../scala-parent/pom.xml</relativePath>
     </parent>
     <artifactId>dynamic-log</artifactId>

--- a/daikon-scala/pom.xml
+++ b/daikon-scala/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>daikon-scala</artifactId>

--- a/daikon-scala/pom.xml
+++ b/daikon-scala/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>daikon-scala</artifactId>

--- a/daikon-scala/pom.xml
+++ b/daikon-scala/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>daikon-scala</artifactId>

--- a/daikon-scala/scala-parent/pom.xml
+++ b/daikon-scala/scala-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-scala</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>scala-parent</artifactId>
     <name>scala-parent</name>

--- a/daikon-scala/scala-parent/pom.xml
+++ b/daikon-scala/scala-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-scala</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>scala-parent</artifactId>
     <name>scala-parent</name>

--- a/daikon-scala/scala-parent/pom.xml
+++ b/daikon-scala/scala-parent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-scala</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>scala-parent</artifactId>
     <name>scala-parent</name>

--- a/daikon-scala/scala-play2-dependencies/pom.xml
+++ b/daikon-scala/scala-play2-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-scala</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>scala-play2-dependencies</artifactId>
     <name>scala-play2-dependencies</name>

--- a/daikon-scala/scala-play2-dependencies/pom.xml
+++ b/daikon-scala/scala-play2-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-scala</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>scala-play2-dependencies</artifactId>
     <name>scala-play2-dependencies</name>

--- a/daikon-scala/scala-play2-dependencies/pom.xml
+++ b/daikon-scala/scala-play2-dependencies/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-scala</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>scala-play2-dependencies</artifactId>
     <name>scala-play2-dependencies</name>

--- a/daikon-spring/daikon-content-service/content-service-common/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>content-service-common</artifactId>

--- a/daikon-spring/daikon-content-service/content-service-common/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>content-service-common</artifactId>

--- a/daikon-spring/daikon-content-service/content-service-common/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-common/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>content-service-common</artifactId>

--- a/daikon-spring/daikon-content-service/content-service-journal-mongo/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-journal-mongo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-content-service/content-service-journal-mongo/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-journal-mongo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-content-service/content-service-journal-mongo/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-journal-mongo/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-content-service/content-service-journal/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-journal/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-content-service/content-service-journal/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-journal/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-content-service/content-service-journal/pom.xml
+++ b/daikon-spring/daikon-content-service/content-service-journal/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-content-service/local-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/local-content-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>local-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/local-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/local-content-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>local-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/local-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/local-content-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>local-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/s3-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/s3-content-service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>s3-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/s3-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/s3-content-service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>s3-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/s3-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/s3-content-service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-content-service</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
 
     <artifactId>s3-content-service</artifactId>

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/LocationUtils.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/LocationUtils.java
@@ -21,6 +21,9 @@ class LocationUtils {
      * @return The location ready to processed in all the S3 related classes.
      */
     public static String toS3Location(String location) {
+        if (location == null) {
+            return null;
+        }
         if (location.startsWith("/") && location.length() > 1) {
             return location.substring(1);
         } else {

--- a/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/main/java/org/talend/daikon/content/s3/S3ResourceResolver.java
@@ -1,11 +1,7 @@
 package org.talend.daikon.content.s3;
 
-import static org.talend.daikon.content.s3.LocationUtils.toS3Location;
-import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
-import static org.talend.daikon.content.s3.S3ContentServiceConfiguration.EC2_AUTHENTICATION;
-
-import java.io.IOException;
-
+import com.amazonaws.services.s3.AmazonS3;
+import io.micrometer.core.annotation.Timed;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.core.io.WritableResource;
@@ -14,9 +10,11 @@ import org.talend.daikon.content.AbstractResourceResolver;
 import org.talend.daikon.content.DeletableResource;
 import org.talend.daikon.content.s3.provider.S3BucketProvider;
 
-import com.amazonaws.services.s3.AmazonS3;
+import java.io.IOException;
 
-import io.micrometer.core.annotation.Timed;
+import static org.talend.daikon.content.s3.LocationUtils.S3PathBuilder.builder;
+import static org.talend.daikon.content.s3.LocationUtils.toS3Location;
+import static org.talend.daikon.content.s3.S3ContentServiceConfiguration.EC2_AUTHENTICATION;
 
 public class S3ResourceResolver extends AbstractResourceResolver {
 
@@ -59,17 +57,7 @@ public class S3ResourceResolver extends AbstractResourceResolver {
                 .append(toS3Location(location)) //
                 .build();
 
-        final String authentication = environment
-                .getProperty(S3ContentServiceConfiguration.CONTENT_SERVICE_STORE_AUTHENTICATION, EC2_AUTHENTICATION)
-                .toUpperCase();
-        switch (authentication) {
-        case S3ContentServiceConfiguration.MINIO_AUTHENTICATION:
-        case S3ContentServiceConfiguration.CUSTOM_AUTHENTICATION:
-            final String host = environment.getProperty(S3ContentServiceConfiguration.S3_ENDPOINT_URL);
-            return new FixedURLS3Resource(host, s3Location, super.getResource("s3://" + s3Location));
-        default:
-            return super.getResource("s3://" + s3Location);
-        }
+        return super.getResource("s3://" + s3Location);
     }
 
     @Override
@@ -81,7 +69,26 @@ public class S3ResourceResolver extends AbstractResourceResolver {
 
     @Override
     protected DeletableResource convert(WritableResource writableResource) {
-        return new S3DeletableResource(writableResource, amazonS3, writableResource.getFilename(), bucket.getBucketName(),
-                bucket.getRoot());
+        final String authentication = environment
+                .getProperty(S3ContentServiceConfiguration.CONTENT_SERVICE_STORE_AUTHENTICATION, EC2_AUTHENTICATION)
+                .toUpperCase();
+        final String filename = writableResource.getFilename();
+        final String bucketName = bucket.getBucketName();
+        final String bucketRoot = bucket.getRoot();
+
+        final S3DeletableResource resource = new S3DeletableResource(writableResource, amazonS3, filename, bucketName,
+                bucketRoot);
+        switch (authentication) {
+        case S3ContentServiceConfiguration.MINIO_AUTHENTICATION:
+        case S3ContentServiceConfiguration.CUSTOM_AUTHENTICATION:
+            final String host = environment.getProperty(S3ContentServiceConfiguration.S3_ENDPOINT_URL);
+            final String s3Location = builder(bucketName) //
+                    .append(bucketRoot) //
+                    .append(toS3Location(filename)) //
+                    .build();
+            return new FixedURLS3Resource(host, s3Location, resource);
+        default:
+            return resource;
+        }
     }
 }

--- a/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3ContentServiceConfigurationTest.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3ContentServiceConfigurationTest.java
@@ -59,6 +59,8 @@ public class S3ContentServiceConfigurationTest {
         when(environment.getProperty(eq("content-service.store.s3.authentication"), anyString())).thenReturn("TOKEN");
         when(environment.getProperty("content-service.store.s3.secretKey")).thenReturn("verySecret");
         when(environment.getProperty("content-service.store.s3.accessKey")).thenReturn("anAccessKey");
+        when(environment.containsProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn(true);
+        when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENDPOINT_URL))).thenReturn("http://fake.io:9001");
         when(environment.getProperty(eq(S3ContentServiceConfiguration.S3_ENABLE_PATH_STYLE), eq(Boolean.class), any()))
                 .thenReturn(false);
 

--- a/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3DeletablePathResolverTest.java
+++ b/daikon-spring/daikon-content-service/s3-content-service/src/test/java/org/talend/daikon/content/s3/S3DeletablePathResolverTest.java
@@ -1,9 +1,19 @@
 package org.talend.daikon.content.s3;
 
 import org.springframework.boot.SpringBootConfiguration;
+import org.talend.daikon.content.DeletableResource;
 import org.talend.daikon.content.DeletableResourceLoaderTest;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
 
 @SpringBootConfiguration
 public class S3DeletablePathResolverTest extends DeletableResourceLoaderTest {
-    // All standard test
+
+    @Override
+    protected void assertGetResources(DeletableResource[] resources) {
+        super.assertGetResources(resources);
+        assertTrue(Arrays.stream(resources).allMatch(r -> r instanceof FixedURLS3Resource));
+    }
 }

--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring-examples</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring-examples</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring-examples</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring-examples</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>daikon-spring-example-security</artifactId>
-    <version>3.1.5</version>
+    <version>3.1.6-SNAPSHOT</version>
 
     <build>
         <plugins>

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring-examples</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>daikon-spring-example-security</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.7-SNAPSHOT</version>
 
     <build>
         <plugins>

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-security/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring-examples</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
 
     <artifactId>daikon-spring-example-security</artifactId>
-    <version>3.1.6-SNAPSHOT</version>
+    <version>3.1.6</version>
 
     <build>
         <plugins>

--- a/daikon-spring/daikon-spring-examples/pom.xml
+++ b/daikon-spring/daikon-spring-examples/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
     <name>Examples using Daikon spring related modules.</name>
     <url>https://github.com/Talend/daikon</url>
-    <version>3.1.6</version>
+    <version>3.1.7-SNAPSHOT</version>
 
     <properties>
         <spring-boot.version>2.1.13.RELEASE</spring-boot.version>
@@ -39,6 +39,6 @@
     </build>
 
   <scm>
-    <tag>3.1.6</tag>
+    <tag>3.1.5</tag>
   </scm>
 </project>

--- a/daikon-spring/daikon-spring-examples/pom.xml
+++ b/daikon-spring/daikon-spring-examples/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
     <name>Examples using Daikon spring related modules.</name>
     <url>https://github.com/Talend/daikon</url>
-    <version>3.1.6-SNAPSHOT</version>
+    <version>3.1.6</version>
 
     <properties>
         <spring-boot.version>2.1.13.RELEASE</spring-boot.version>
@@ -39,6 +39,6 @@
     </build>
 
   <scm>
-    <tag>3.1.5</tag>
+    <tag>3.1.6</tag>
   </scm>
 </project>

--- a/daikon-spring/daikon-spring-examples/pom.xml
+++ b/daikon-spring/daikon-spring-examples/pom.xml
@@ -13,7 +13,7 @@
     <packaging>pom</packaging>
     <name>Examples using Daikon spring related modules.</name>
     <url>https://github.com/Talend/daikon</url>
-    <version>3.1.5</version>
+    <version>3.1.6-SNAPSHOT</version>
 
     <properties>
         <spring-boot.version>2.1.13.RELEASE</spring-boot.version>

--- a/daikon-spring/daikon-spring-metrics/pom.xml
+++ b/daikon-spring/daikon-spring-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-metrics/pom.xml
+++ b/daikon-spring/daikon-spring-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-metrics/pom.xml
+++ b/daikon-spring/daikon-spring-metrics/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-spring</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-mongo/pom.xml
+++ b/daikon-spring/daikon-spring-mongo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-spring-mongo</artifactId>
     <name>daikon-spring-mongo</name>

--- a/daikon-spring/daikon-spring-mongo/pom.xml
+++ b/daikon-spring/daikon-spring-mongo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-spring-mongo</artifactId>
     <name>daikon-spring-mongo</name>

--- a/daikon-spring/daikon-spring-mongo/pom.xml
+++ b/daikon-spring/daikon-spring-mongo/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-spring-mongo</artifactId>
     <name>daikon-spring-mongo</name>

--- a/daikon-spring/daikon-spring-security/pom.xml
+++ b/daikon-spring/daikon-spring-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-spring-security</artifactId>

--- a/daikon-spring/daikon-spring-security/pom.xml
+++ b/daikon-spring/daikon-spring-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-spring-security</artifactId>

--- a/daikon-spring/daikon-spring-security/pom.xml
+++ b/daikon-spring/daikon-spring-security/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-spring-security</artifactId>

--- a/daikon-spring/daikon-spring-tenancy/pom.xml
+++ b/daikon-spring/daikon-spring-tenancy/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>daikon-spring-tenancy</artifactId>
-    <version>3.1.5</version>
+    <version>3.1.6-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/daikon-spring/daikon-spring-tenancy/pom.xml
+++ b/daikon-spring/daikon-spring-tenancy/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>daikon-spring-tenancy</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.7-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/daikon-spring/daikon-spring-tenancy/pom.xml
+++ b/daikon-spring/daikon-spring-tenancy/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>daikon-spring-tenancy</artifactId>
-    <version>3.1.6-SNAPSHOT</version>
+    <version>3.1.6</version>
 
     <dependencies>
         <dependency>

--- a/daikon-spring/daikon-spring-zipkin/pom.xml
+++ b/daikon-spring/daikon-spring-zipkin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-zipkin/pom.xml
+++ b/daikon-spring/daikon-spring-zipkin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/daikon-spring-zipkin/pom.xml
+++ b/daikon-spring/daikon-spring-zipkin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-spring</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/daikon-spring/pom.xml
+++ b/daikon-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-spring</artifactId>
     <packaging>pom</packaging>

--- a/daikon-spring/pom.xml
+++ b/daikon-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-spring</artifactId>
     <packaging>pom</packaging>

--- a/daikon-spring/pom.xml
+++ b/daikon-spring/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-spring</artifactId>
     <packaging>pom</packaging>

--- a/daikon-tql/daikon-tql-bean/pom.xml
+++ b/daikon-tql/daikon-tql-bean/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-tql</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-tql-bean</artifactId>

--- a/daikon-tql/daikon-tql-bean/pom.xml
+++ b/daikon-tql/daikon-tql-bean/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-tql</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-tql-bean</artifactId>

--- a/daikon-tql/daikon-tql-bean/pom.xml
+++ b/daikon-tql/daikon-tql-bean/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>daikon-tql</artifactId>
         <groupId>org.talend.daikon</groupId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>daikon-tql-bean</artifactId>

--- a/daikon-tql/daikon-tql-core/pom.xml
+++ b/daikon-tql/daikon-tql-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-tql</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-tql-core</artifactId>
     <name>Daikon TQL core libraries.</name>

--- a/daikon-tql/daikon-tql-core/pom.xml
+++ b/daikon-tql/daikon-tql-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-tql</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-tql-core</artifactId>
     <name>Daikon TQL core libraries.</name>

--- a/daikon-tql/daikon-tql-core/pom.xml
+++ b/daikon-tql/daikon-tql-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-tql</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-tql-core</artifactId>
     <name>Daikon TQL core libraries.</name>

--- a/daikon-tql/daikon-tql-mongo/pom.xml
+++ b/daikon-tql/daikon-tql-mongo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-tql</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
     <artifactId>daikon-tql-mongo</artifactId>
     <name>Daikon TQL libraries for MongoDB.</name>

--- a/daikon-tql/daikon-tql-mongo/pom.xml
+++ b/daikon-tql/daikon-tql-mongo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-tql</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-tql-mongo</artifactId>
     <name>Daikon TQL libraries for MongoDB.</name>

--- a/daikon-tql/daikon-tql-mongo/pom.xml
+++ b/daikon-tql/daikon-tql-mongo/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-tql</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
     <artifactId>daikon-tql-mongo</artifactId>
     <name>Daikon TQL libraries for MongoDB.</name>

--- a/daikon-tql/pom.xml
+++ b/daikon-tql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
 
     <artifactId>daikon-tql</artifactId>

--- a/daikon-tql/pom.xml
+++ b/daikon-tql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>daikon-tql</artifactId>

--- a/daikon-tql/pom.xml
+++ b/daikon-tql/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>daikon-tql</artifactId>

--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>daikon</artifactId>

--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>daikon</artifactId>

--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>daikon</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.daikon</groupId>
     <artifactId>daikon-parent</artifactId>
-    <version>3.1.6</version>
+    <version>3.1.7-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Daikon - parent pom</name>
     <url>https://github.com/Talend/daikon</url>
@@ -99,7 +99,7 @@
         <connection>scm:git:https://github.com/Talend/daikon.git</connection>
         <developerConnection>scm:git:https://github.com/Talend/daikon.git</developerConnection>
         <url>https://github.com/Talend/daikon</url>
-      <tag>3.1.6</tag>
+      <tag>3.1.5</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.daikon</groupId>
     <artifactId>daikon-parent</artifactId>
-    <version>3.1.6-SNAPSHOT</version>
+    <version>3.1.6</version>
     <packaging>pom</packaging>
     <name>Daikon - parent pom</name>
     <url>https://github.com/Talend/daikon</url>
@@ -99,7 +99,7 @@
         <connection>scm:git:https://github.com/Talend/daikon.git</connection>
         <developerConnection>scm:git:https://github.com/Talend/daikon.git</developerConnection>
         <url>https://github.com/Talend/daikon</url>
-      <tag>3.1.5</tag>
+      <tag>3.1.6</tag>
   </scm>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,13 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit4</artifactId>
+                            <version>2.22.1</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <json-smart.version>2.2.1</json-smart.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-configuration2.version>2.7</commons-configuration2.version>
-        <httpclient.version>4.5.7</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <feign-core.version>8.18.0</feign-core.version>
         <gson.version>2.8.6</gson.version>
         <jackson.1x.version>1.9.15-TALEND</jackson.1x.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.talend.daikon</groupId>
     <artifactId>daikon-parent</artifactId>
-    <version>3.1.5</version>
+    <version>3.1.6-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Daikon - parent pom</name>
     <url>https://github.com/Talend/daikon</url>

--- a/releases/3.1.6.adoc
+++ b/releases/3.1.6.adoc
@@ -1,0 +1,7 @@
+= Daikon Release Notes (3.1.6) - 11/12/2020
+
+Thanks to @Francois Huaulme
+
+== Other
+- chore(build) Fix build for Spring examples
+- fix(content-service) Fix content service getResource  (link:https://github.com/Talend/daikon/pull/672[#672])

--- a/releases/pom.xml
+++ b/releases/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6</version>
+        <version>3.1.7-SNAPSHOT</version>
     </parent>
 
     <artifactId>releases</artifactId>

--- a/releases/pom.xml
+++ b/releases/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.6-SNAPSHOT</version>
+        <version>3.1.6</version>
     </parent>
 
     <artifactId>releases</artifactId>

--- a/releases/pom.xml
+++ b/releases/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.5</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>releases</artifactId>

--- a/releases/pom.xml.releaseBackup
+++ b/releases/pom.xml.releaseBackup
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.talend.daikon</groupId>
         <artifactId>daikon-parent</artifactId>
-        <version>3.1.4-SNAPSHOT</version>
+        <version>3.1.6-SNAPSHOT</version>
     </parent>
 
     <artifactId>releases</artifactId>

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-parent</artifactId>
-		<version>3.1.6</version>
+		<version>3.1.7-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>reporting</artifactId>
-	<version>3.1.6</version>
+	<version>3.1.7-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Aggregation of jacoco reports</name>

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.1.6-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>reporting</artifactId>
-	<version>3.1.5</version>
+	<version>3.1.6-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Aggregation of jacoco reports</name>

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -4,11 +4,11 @@
 	<parent>
 		<groupId>org.talend.daikon</groupId>
 		<artifactId>daikon-parent</artifactId>
-		<version>3.1.6-SNAPSHOT</version>
+		<version>3.1.6</version>
 	</parent>
 
 	<artifactId>reporting</artifactId>
-	<version>3.1.6-SNAPSHOT</version>
+	<version>3.1.6</version>
 	<packaging>pom</packaging>
 
 	<name>Aggregation of jacoco reports</name>


### PR DESCRIPTION
Veracode is reporting a new CVE for Apache HTTP Client:

"httpclient is vulnerable to validation bypass. A malformed authority component in the request URIs that is passed to the library as java.net.URI object would result in the request execution for a wrong target host."

CVE-2020-13956

This issue was fixed in version 4.5.13