### PR TITLE
TDKN-301 - Update HttpClient to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <json-smart.version>2.2.1</json-smart.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-configuration2.version>2.7</commons-configuration2.version>
-        <httpclient.version>4.5.7</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <feign-core.version>8.18.0</feign-core.version>
         <gson.version>2.8.6</gson.version>
         <jackson.1x.version>1.9.15-TALEND</jackson.1x.version>


### PR DESCRIPTION
Veracode is reporting a new CVE for Apache HTTP Client:

"httpclient is vulnerable to validation bypass. A malformed authority component in the request URIs that is passed to the library as java.net.URI object would result in the request execution for a wrong target host."

CVE-2020-13956

This issue was fixed in version 4.5.13