### PR TITLE
feat(tql) Add support for "is null" operator

### DIFF
--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
@@ -264,7 +264,7 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
         elt.getField().accept(this);
         final MethodAccessor[] methods = currentMethods.pop();
 
-        return anyMatch(methods, Objects::nonNull);
+        return anyMatch(methods, Objects::isNull);
     }
 
     @Override

--- a/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
+++ b/daikon-tql/daikon-tql-bean/src/main/java/org/talend/tql/bean/BeanPredicateVisitor.java
@@ -20,15 +20,7 @@ import static org.apache.commons.lang3.StringUtils.equalsIgnoreCase;
 import static org.talend.tql.bean.MethodAccessorFactory.build;
 
 import java.lang.reflect.Method;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -40,25 +32,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.talend.daikon.pattern.character.CharPatternToRegex;
 import org.talend.daikon.pattern.word.WordPatternToRegex;
-import org.talend.tql.model.AllFields;
-import org.talend.tql.model.AndExpression;
-import org.talend.tql.model.ComparisonExpression;
-import org.talend.tql.model.ComparisonOperator;
-import org.talend.tql.model.Expression;
-import org.talend.tql.model.FieldBetweenExpression;
-import org.talend.tql.model.FieldCompliesPattern;
-import org.talend.tql.model.FieldContainsExpression;
-import org.talend.tql.model.FieldInExpression;
-import org.talend.tql.model.FieldIsEmptyExpression;
-import org.talend.tql.model.FieldIsInvalidExpression;
-import org.talend.tql.model.FieldIsValidExpression;
-import org.talend.tql.model.FieldMatchesRegex;
-import org.talend.tql.model.FieldReference;
-import org.talend.tql.model.FieldWordCompliesPattern;
-import org.talend.tql.model.LiteralValue;
-import org.talend.tql.model.NotExpression;
-import org.talend.tql.model.OrExpression;
-import org.talend.tql.model.TqlElement;
+import org.talend.tql.model.*;
 import org.talend.tql.visitor.IASTVisitor;
 
 /**
@@ -283,6 +257,14 @@ public class BeanPredicateVisitor<T> implements IASTVisitor<Predicate<T>> {
     @Override
     public Predicate<T> visit(FieldIsInvalidExpression fieldIsInvalidExpression) {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Predicate<T> visit(FieldIsNullExpression elt) {
+        elt.getField().accept(this);
+        final MethodAccessor[] methods = currentMethods.pop();
+
+        return anyMatch(methods, Objects::nonNull);
     }
 
     @Override

--- a/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
+++ b/daikon-tql/daikon-tql-bean/src/test/java/org/talend/tql/bean/BeanPredicateVisitorTest.java
@@ -520,6 +520,30 @@ public class BeanPredicateVisitorTest {
         assertTrue(predicate.test(bean));
     }
 
+    @Test
+    public void testNullComparison() {
+        // given
+        final Expression query = Tql.parse("nullValue is null");
+
+        // when
+        final Predicate<Bean> predicate = query.accept(new BeanPredicateVisitor<>(Bean.class));
+
+        // then
+        assertTrue(predicate.test(bean));
+    }
+
+    @Test
+    public void testNestedNullComparison() {
+        // given
+        final Expression query = Tql.parse("nested.nestedNullValue is null");
+
+        // when
+        final Predicate<Bean> predicate = query.accept(new BeanPredicateVisitor<>(Bean.class));
+
+        // then
+        assertTrue(predicate.test(bean));
+    }
+
     // Test class
     public static class Bean {
 
@@ -555,6 +579,10 @@ public class BeanPredicateVisitorTest {
             attributes.put("tags", Arrays.asList("Complete", "Released"));
             return attributes;
         }
+
+        public Object nullValue() {
+            return null;
+        }
     }
 
     // Test class
@@ -570,6 +598,10 @@ public class BeanPredicateVisitorTest {
 
         public String getNestedValue() {
             return "nested";
+        }
+
+        public Object getNestedNullValue() {
+            return null;
         }
     }
 }

--- a/daikon-tql/daikon-tql-core/src/main/antlr4/TqlLexer.g4
+++ b/daikon-tql/daikon-tql-core/src/main/antlr4/TqlLexer.g4
@@ -45,6 +45,7 @@ VALID : 'valid';
 INVALID : 'invalid';
 TRUE : 'true';
 FALSE : 'false';
+NULL : 'null';
 
 // data types
 INT: ('-')?('0' .. '9')+;

--- a/daikon-tql/daikon-tql-core/src/main/antlr4/TqlParser.g4
+++ b/daikon-tql/daikon-tql-core/src/main/antlr4/TqlParser.g4
@@ -24,6 +24,8 @@ literalComparison : (FIELD | allFields | ~INT | ~DECIMAL) comparisonOperator lit
 
 fieldComparison : (FIELD | allFields | ~INT | ~DECIMAL) comparisonOperator fieldReference;
 
+fieldIsNull : (FIELD | allFields | ~INT | ~DECIMAL) IS NULL;
+
 fieldIsEmpty : (FIELD | allFields | ~INT | ~DECIMAL) IS EMPTY;
 
 fieldIsValid : (FIELD | allFields | ~INT | ~DECIMAL) IS VALID;

--- a/daikon-tql/daikon-tql-core/src/main/antlr4/TqlParser.g4
+++ b/daikon-tql/daikon-tql-core/src/main/antlr4/TqlParser.g4
@@ -56,6 +56,7 @@ atom : booleanComparison
  | literalComparison
  | fieldComparison
  | fieldIsEmpty
+ | fieldIsNull
  | fieldIsValid
  | fieldIsInvalid
  | fieldContains

--- a/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/model/FieldIsNullExpression.java
+++ b/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/model/FieldIsNullExpression.java
@@ -1,0 +1,36 @@
+package org.talend.tql.model;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.talend.tql.visitor.IASTVisitor;
+
+/*
+ * Tql expression for null fields.
+ */
+public class FieldIsNullExpression implements Atom {
+
+    private TqlElement field;
+
+    public FieldIsNullExpression(TqlElement field) {
+        this.field = field;
+    }
+
+    public TqlElement getField() {
+        return field;
+    }
+
+    @Override
+    public String toString() {
+        return "FieldIsNullExpression{" + "field='" + field + '\'' + '}';
+    }
+
+    @Override
+    public <T> T accept(IASTVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    @Override
+    public boolean equals(Object expression) {
+        return expression instanceof FieldIsNullExpression
+                && new EqualsBuilder().append(field, ((FieldIsNullExpression) expression).field).isEquals();
+    }
+}

--- a/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/parser/TqlExpressionVisitor.java
+++ b/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/parser/TqlExpressionVisitor.java
@@ -13,26 +13,7 @@ import org.talend.tql.TqlLexer;
 import org.talend.tql.TqlParser;
 import org.talend.tql.TqlParserVisitor;
 import org.talend.tql.excp.TqlException;
-import org.talend.tql.model.AllFields;
-import org.talend.tql.model.AndExpression;
-import org.talend.tql.model.BooleanValue;
-import org.talend.tql.model.ComparisonExpression;
-import org.talend.tql.model.ComparisonOperator;
-import org.talend.tql.model.Expression;
-import org.talend.tql.model.FieldBetweenExpression;
-import org.talend.tql.model.FieldCompliesPattern;
-import org.talend.tql.model.FieldContainsExpression;
-import org.talend.tql.model.FieldInExpression;
-import org.talend.tql.model.FieldIsEmptyExpression;
-import org.talend.tql.model.FieldIsInvalidExpression;
-import org.talend.tql.model.FieldIsValidExpression;
-import org.talend.tql.model.FieldMatchesRegex;
-import org.talend.tql.model.FieldReference;
-import org.talend.tql.model.FieldWordCompliesPattern;
-import org.talend.tql.model.LiteralValue;
-import org.talend.tql.model.NotExpression;
-import org.talend.tql.model.OrExpression;
-import org.talend.tql.model.TqlElement;
+import org.talend.tql.model.*;
 
 /**
  * Visitor for building the AST Tql tree.
@@ -145,6 +126,15 @@ public class TqlExpressionVisitor implements TqlParserVisitor<TqlElement> {
                 field2TqlElement);
         LOG.debug("End visit field comparison: " + ctx.getText());
         return comparisonExpression;
+    }
+
+    @Override
+    public TqlElement visitFieldIsNull(TqlParser.FieldIsNullContext ctx) {
+        LOG.debug("Visit is field null expression: " + ctx.getText());
+        TqlElement fieldName = ctx.getChild(0).accept(this);
+        FieldIsNullExpression isNullExpression = new FieldIsNullExpression(fieldName);
+        LOG.debug("End visit is field null expression: " + ctx.getText());
+        return isNullExpression;
     }
 
     @Override

--- a/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/visitor/IASTVisitor.java
+++ b/daikon-tql/daikon-tql-core/src/main/java/org/talend/tql/visitor/IASTVisitor.java
@@ -1,24 +1,6 @@
 package org.talend.tql.visitor;
 
-import org.talend.tql.model.AllFields;
-import org.talend.tql.model.AndExpression;
-import org.talend.tql.model.ComparisonExpression;
-import org.talend.tql.model.ComparisonOperator;
-import org.talend.tql.model.Expression;
-import org.talend.tql.model.FieldBetweenExpression;
-import org.talend.tql.model.FieldCompliesPattern;
-import org.talend.tql.model.FieldContainsExpression;
-import org.talend.tql.model.FieldInExpression;
-import org.talend.tql.model.FieldIsEmptyExpression;
-import org.talend.tql.model.FieldIsInvalidExpression;
-import org.talend.tql.model.FieldIsValidExpression;
-import org.talend.tql.model.FieldMatchesRegex;
-import org.talend.tql.model.FieldReference;
-import org.talend.tql.model.FieldWordCompliesPattern;
-import org.talend.tql.model.LiteralValue;
-import org.talend.tql.model.NotExpression;
-import org.talend.tql.model.OrExpression;
-import org.talend.tql.model.TqlElement;
+import org.talend.tql.model.*;
 
 /**
  * Visitor contract to be used whenever the TQL tree should be parsed.
@@ -109,6 +91,13 @@ public interface IASTVisitor<T> {
      * @param elt element to visit
      */
     T visit(FieldIsInvalidExpression elt);
+
+    /**
+     * Visits a {@link FieldIsNullExpression}
+     *
+     * @param elt element to visit
+     */
+    T visit(FieldIsNullExpression elt);
 
     /**
      * Visits a {@link FieldMatchesRegex}

--- a/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
+++ b/daikon-tql/daikon-tql-mongo/src/main/java/org/talend/tqlmongo/ASTVisitor.java
@@ -10,25 +10,7 @@ import org.bson.Document;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.talend.daikon.pattern.character.CharPatternToRegex;
 import org.talend.daikon.pattern.word.WordPatternToRegex;
-import org.talend.tql.model.AllFields;
-import org.talend.tql.model.AndExpression;
-import org.talend.tql.model.ComparisonExpression;
-import org.talend.tql.model.ComparisonOperator;
-import org.talend.tql.model.Expression;
-import org.talend.tql.model.FieldBetweenExpression;
-import org.talend.tql.model.FieldCompliesPattern;
-import org.talend.tql.model.FieldContainsExpression;
-import org.talend.tql.model.FieldInExpression;
-import org.talend.tql.model.FieldIsEmptyExpression;
-import org.talend.tql.model.FieldIsInvalidExpression;
-import org.talend.tql.model.FieldIsValidExpression;
-import org.talend.tql.model.FieldMatchesRegex;
-import org.talend.tql.model.FieldReference;
-import org.talend.tql.model.FieldWordCompliesPattern;
-import org.talend.tql.model.LiteralValue;
-import org.talend.tql.model.NotExpression;
-import org.talend.tql.model.OrExpression;
-import org.talend.tql.model.TqlElement;
+import org.talend.tql.model.*;
 import org.talend.tql.visitor.IASTVisitor;
 import org.talend.tqlmongo.excp.TqlMongoException;
 
@@ -188,6 +170,15 @@ public class ASTVisitor implements IASTVisitor<Object> {
     @Override
     public Object visit(FieldIsInvalidExpression elt) {
         throw new TqlMongoException("Unsupported expression");
+    }
+
+    @Override
+    public Object visit(FieldIsNullExpression elt) {
+        String fieldName = (String) elt.getField().accept(this);
+        if (!isNegation) {
+            return Criteria.where(fieldName).is(null);
+        }
+        return Criteria.where(fieldName).not().is(null);
     }
 
     @Override

--- a/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Complex.java
+++ b/daikon-tql/daikon-tql-mongo/src/test/java/org/talend/tqlmongo/criteria/TestMongoCriteria_Complex.java
@@ -37,6 +37,13 @@ public class TestMongoCriteria_Complex extends TestMongoCriteria_Abstract {
     }
 
     @Test
+    public void testParseFieldIsNull() {
+        Criteria criteria = doTest("field1 is null");
+        Criteria expectedCriteria = Criteria.where("field1").is(null);
+        assertCriteriaEquals(expectedCriteria, criteria);
+    }
+
+    @Test
     public void testParseFieldIsValid() {
         expectedException.expect(TqlMongoException.class);
         doTest("field1 is valid");


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
A field comparison operator should be added to the grammar for allow `field is null` type of predicates.

**What is the chosen solution to this problem?**

Add a `is null` operator to TQL and derived implementations (MongoDB and object predicates).
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
