### PR TITLE
fix(tql-client): Escape ' char

### DIFF
--- a/daikon-tql/daikon-tql-client/package.json
+++ b/daikon-tql/daikon-tql-client/package.json
@@ -58,5 +58,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "1.3.0"
+  "version": "1.3.1"
 }

--- a/daikon-tql/daikon-tql-client/src/converter/__tests__/query.spec.js
+++ b/daikon-tql/daikon-tql-client/src/converter/__tests__/query.spec.js
@@ -138,4 +138,11 @@ describe('Query', () => {
 			'(f2 > 42) or not((q2f1 = 76) or (q2f2 > 666)) and (f2 < 666)',
 		);
 	});
+	it('should be able to perform AND statements', () => {
+		const q = new Query();
+
+		q.equal('f1', "should ' esca ' pe");
+
+		expect(q.serialize()).toBe("(f1 = 'should \\' esca \\' pe')");
+	});
 });

--- a/daikon-tql/daikon-tql-client/src/converter/operators/operator.js
+++ b/daikon-tql/daikon-tql-client/src/converter/operators/operator.js
@@ -8,7 +8,7 @@ function isString(value) {
 }
 
 export function wrap(value) {
-	return isString(value) ? `'${value}'` : value;
+	return isString(value) ? `'${value.replace(/'/g, "\\'")}'` : value;
 }
 
 export function isDefined(value) {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

Operand are not escaped, resulting in unparseable query:

`((0001 = 'Au p'tit pain nantais'))`

should be

`((0001 = 'Au p\'tit pain nantais'))`
 
**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
