### PR TITLE
TDKN-305 - Update Commons IO + Commons Codec

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -52,7 +52,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <avro.version>1.10.0</avro.version>
         <bcprov.version>1.68</bcprov.version>
         <commons-compress.version>1.20</commons-compress.version>
-        <commons-io.version>2.6</commons-io.version>
+        <commons-io.version>2.8.0</commons-io.version>
         <reactor-core.version>3.1.6.RELEASE</reactor-core.version>
 
         <de.flapdoodle.embed.mongo.version>2.2.0</de.flapdoodle.embed.mongo.version>
@@ -236,6 +236,16 @@
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
                 <version>${commons-compress.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons-io.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
There are some medium level CVEs in Daikon due to transitive dependencies of commons-io / commons-codec that we can update.