### PR TITLE
fix(TPSVC-17135): Do not use ECS cloud.account.id field

### DIFF
--- a/daikon-logging/logging-event-layout/src/main/resources/mdc_ecs_mapping.properties
+++ b/daikon-logging/logging-event-layout/src/main/resources/mdc_ecs_mapping.properties
@@ -1,4 +1,4 @@
-accountId=labels.customer_account_id
+accountId=organization.id
 executionId=labels.execution_id
 stackName=labels.stack_name
 userId=user.id

--- a/daikon-logging/logging-event-layout/src/main/resources/mdc_ecs_mapping.properties
+++ b/daikon-logging/logging-event-layout/src/main/resources/mdc_ecs_mapping.properties
@@ -1,4 +1,4 @@
-accountId=labels.account_id
+accountId=labels.customer_account_id
 executionId=labels.execution_id
 stackName=labels.stack_name
 userId=user.id

--- a/daikon-logging/logging-event-layout/src/main/resources/mdc_ecs_mapping.properties
+++ b/daikon-logging/logging-event-layout/src/main/resources/mdc_ecs_mapping.properties
@@ -1,4 +1,4 @@
-accountId=cloud.account.id
+accountId=labels.account_id
 executionId=labels.execution_id
 stackName=labels.stack_name
 userId=user.id


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Custom field `accountId` is mapped to the ECS field `cloud.account.id` used by Filebeat.
 
**What is the chosen solution to this problem?**
Map `accountId` to another suitable field.
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
