### PR TITLE
chore: Bump Avro to 1.10.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <log4j1.version>1.2.17</log4j1.version>
         <logback.version>1.2.3</logback.version>
         <easymock.version>3.5.1</easymock.version>
-        <avro.version>1.10.0</avro.version>
+        <avro.version>1.10.2</avro.version>
         <bcprov.version>1.68</bcprov.version>
         <commons-compress.version>1.20</commons-compress.version>
         <commons-io.version>2.8.0</commons-io.version>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 
[Avro 1.10.2](https://github.com/apache/avro/releases/tag/release-1.10.2) is released with bugfixes and CVE updates.  This is a minor (not patch) release with source compatibility with 1.10.1.

**What is the chosen solution to this problem?**
Bump! 

**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [X] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
