### PR TITLE
fix(web event) duration is nanoseconds, event.start|end are date

### DIFF
--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/ecs/EcsSerializer.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/ecs/EcsSerializer.java
@@ -2,16 +2,17 @@ package org.talend.daikon.logging.ecs;
 
 import co.elastic.logging.AdditionalField;
 import co.elastic.logging.EcsJsonSerializer;
-import java.util.*;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.AbstractMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.talend.daikon.logging.config.LoggingProperties;
 import org.talend.daikon.logging.event.field.HostData;
-
-import co.elastic.logging.AdditionalField;
-import co.elastic.logging.EcsJsonSerializer;
 
 /**
  * Utility ECS serializer class
@@ -191,18 +192,34 @@ public class EcsSerializer {
     }
 
     /**
-     * Serialize the event start time.
-     * 
+     * Serialize the event start date.
+     *
      * @param builder
-     * @param timeStamp
+     * @param eventStart
      */
-    public static void serializeEventStart(StringBuilder builder, long timeStamp) {
-        builder.append("\"").append(EcsFields.EVENT_START.fieldName).append("\":").append(timeStamp).append(",");
+    public static void serializeEventStart(StringBuilder builder, long eventStart) {
+        if (eventStart > 0) {
+            builder.append("\"").append(EcsFields.EVENT_START.fieldName).append("\":\"")
+                    .append(Instant.ofEpochMilli(eventStart).atZone(ZoneId.of("Z"))).append("\",");
+        }
+    }
+
+    /**
+     * Serialize the event end date.
+     *
+     * @param builder
+     * @param eventEnd
+     */
+    public static void serializeEventEnd(StringBuilder builder, long eventEnd) {
+        if (eventEnd > 0) {
+            builder.append("\"").append(EcsFields.EVENT_END.fieldName).append("\":\"")
+                    .append(Instant.ofEpochMilli(eventEnd).atZone(ZoneId.of("Z"))).append("\",");
+        }
     }
 
     /**
      * Serialize the request query string if any.
-     * 
+     *
      * @param builder
      * @param queryString
      */

--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/ecs/EcsSerializer.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/ecs/EcsSerializer.java
@@ -200,7 +200,7 @@ public class EcsSerializer {
     public static void serializeEventStart(StringBuilder builder, long eventStart) {
         if (eventStart > 0) {
             builder.append("\"").append(EcsFields.EVENT_START.fieldName).append("\":\"")
-                    .append(Instant.ofEpochMilli(eventStart).atZone(ZoneId.of("Z"))).append("\",");
+                    .append(Instant.ofEpochMilli(eventStart)).append("\",");
         }
     }
 
@@ -213,7 +213,7 @@ public class EcsSerializer {
     public static void serializeEventEnd(StringBuilder builder, long eventEnd) {
         if (eventEnd > 0) {
             builder.append("\"").append(EcsFields.EVENT_END.fieldName).append("\":\"")
-                    .append(Instant.ofEpochMilli(eventEnd).atZone(ZoneId.of("Z"))).append("\",");
+                    .append(Instant.ofEpochMilli(eventEnd)).append("\",");
         }
     }
 

--- a/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONAccessEventLayout.java
+++ b/daikon-logging/logging-event-layout/src/main/java/org/talend/daikon/logging/event/layout/LogbackJSONAccessEventLayout.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.StringUtils;
 import org.talend.daikon.logging.ecs.EcsSerializer;
@@ -115,8 +116,12 @@ public class LogbackJSONAccessEventLayout extends LayoutBase<IAccessEvent> {
         EcsSerializer.serializeHttpResponseBodyBytes(builder, event.getContentLength());
 
         // event start and duration
-        EcsSerializer.serializeEventDuration(builder, event.getElapsedTime() * 1000); // nano seconds
-        EcsSerializer.serializeEventStart(builder, event.getTimeStamp());
+        EcsSerializer.serializeEventDuration(builder,
+                TimeUnit.NANOSECONDS.convert(event.getElapsedTime(), TimeUnit.MILLISECONDS));
+        if (event.getServerAdapter() != null) {
+            EcsSerializer.serializeEventStart(builder, event.getServerAdapter().getRequestTimestamp());
+        }
+        EcsSerializer.serializeEventEnd(builder, event.getTimeStamp());
         EcsSerializer.serializeClientIp(builder, event.getRemoteAddr());
         EcsSerializer.serializeClientPort(builder, event.getRequest().getRemotePort());
 

--- a/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/ecs/EcsSerializerTest.java
+++ b/daikon-logging/logging-event-layout/src/test/java/org/talend/daikon/logging/ecs/EcsSerializerTest.java
@@ -1,16 +1,13 @@
 package org.talend.daikon.logging.ecs;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-
+import co.elastic.logging.AdditionalField;
 import java.util.*;
 
 import org.junit.Test;
 import org.talend.daikon.logging.event.field.HostData;
 
-import co.elastic.logging.AdditionalField;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 
 public class EcsSerializerTest {
 
@@ -82,4 +79,5 @@ public class EcsSerializerTest {
         EcsSerializer.serializeEcsVersion(builder);
         assertThat(builder.toString(), containsString("\"ecs.version\":\"4.2.0\""));
     }
+
 }

--- a/daikon-logging/logging-spring-test/src/test/java/org/talend/daikon/logging/spring/AccessLogbackJsonLayoutTest.java
+++ b/daikon-logging/logging-spring-test/src/test/java/org/talend/daikon/logging/spring/AccessLogbackJsonLayoutTest.java
@@ -70,5 +70,8 @@ public class AccessLogbackJsonLayoutTest {
         JsonNode jsonNode = objectMapper.readTree(secondMessage.get());
         assertNotNull(jsonNode.get(EcsFields.TRACE_ID.fieldName));
         assertNotNull(jsonNode.get(EcsFields.SPAN_ID.fieldName));
+        assertNotNull(jsonNode.get(EcsFields.EVENT_DURATION.fieldName));
+        assertNotNull(jsonNode.get(EcsFields.EVENT_START.fieldName));
+        assertNotNull(jsonNode.get(EcsFields.EVENT_END.fieldName));
     }
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
`LogbackJSONAccessEventLayout` does not respect ecs format for `event.duration`, `event.start|end` fields.

**What is the chosen solution to this problem?**
Fix them
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
