### PR TITLE
Updating Commons Codec to 1.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <spring-data-mongodb.version>1.8.1.RELEASE</spring-data-mongodb.version>
         <spring.version>4.3.3.RELEASE</spring.version>
         <jsonassert.version>1.2.3</jsonassert.version>
-        <commons-codec.version>1.6</commons-codec.version>
+        <commons-codec.version>1.14</commons-codec.version>
         <javax.inject.version>1</javax.inject.version>
         <pax-url-aether.version>2.4.7</pax-url-aether.version>
         <mockito-core.version>2.2.15</mockito-core.version>
@@ -198,6 +198,11 @@
                 <groupId>org.codehaus.jackson</groupId>
                 <artifactId>jackson-mapper-asl</artifactId>
                 <version>${jackson.1x.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-codec</groupId>
+                <artifactId>commons-codec</artifactId>
+                <version>${commons-codec.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Updating Commons Codec to 1.14 as per other maintenance branches, to fix a CVE.