### PR TITLE
feat(TPSVC-15956): [Audit-log] Mitigate audit log failure impact on login

### DIFF
--- a/daikon-audit/audit-kafka/src/main/java/org/talend/logging/audit/kafka/KafkaBackend.java
+++ b/daikon-audit/audit-kafka/src/main/java/org/talend/logging/audit/kafka/KafkaBackend.java
@@ -57,7 +57,7 @@ public class KafkaBackend extends AbstractBackend {
     @Override
     public void log(String category, LogLevel level, String message, Throwable throwable) {
         try {
-            this.kafkaProducer.send(createRecordFromContext(getCopyOfContextMap())).get(60, TimeUnit.SECONDS);
+            this.kafkaProducer.send(createRecordFromContext(getCopyOfContextMap())).get(this.kafkaSendTimeoutSeconds, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException("Failure when sending the audit log to Kafka", e);
         }

--- a/daikon-spring/daikon-spring-audit-logs/README.adoc
+++ b/daikon-spring/daikon-spring-audit-logs/README.adoc
@@ -258,3 +258,10 @@ x-forwarded-header: "62.23.50.122, 42.42.42.42, 10.12.15.26, 172.169.12.54"
    "...": "..."
 }
 ```
+
+== Logger problem
+In order not to block the client application if a problem occurs on logger side (e.g. if Kafka is down), preventing the audit log generation, no exception is thrown, but a simple `WARNING` log is creating with the following format :
+```
+Error sending audit logs to Kafka : {timestamp=2021-04-29T18:28:09.723741+02:00, applicationId=Daikon, eventType=test type, eventCategory=test category, accountId=9bfdd9a0-7852-4cd5-94a0-6212ebe281b6}
+```
+

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
@@ -11,6 +11,8 @@ public class AuditKafkaProperties {
 
     private String partitionKeyName = "accountId";
 
+    private int sendTimeoutSeconds = 30;
+
     public String getBootstrapServers() {
         return bootstrapServers;
     }
@@ -33,5 +35,13 @@ public class AuditKafkaProperties {
 
     public void setPartitionKeyName(String partitionKeyName) {
         this.partitionKeyName = partitionKeyName;
+    }
+
+    public int getSendTimeoutSeconds() {
+        return sendTimeoutSeconds;
+    }
+
+    public void setSendTimeoutSeconds(int sendTimeoutSeconds) {
+        this.sendTimeoutSeconds = sendTimeoutSeconds;
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -49,6 +49,7 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
         properties.put("kafka.bootstrap.servers", auditKafkaProperties.getBootstrapServers());
         properties.put("kafka.topic", auditKafkaProperties.getTopic());
         properties.put("kafka.partition.key.name", auditKafkaProperties.getPartitionKeyName());
+        properties.put("kafka.send.timeout.seconds", auditKafkaProperties.getSendTimeoutSeconds());
         return properties;
     }
 

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -1,8 +1,12 @@
 package org.talend.daikon.spring.audit.logs.service;
 
+import static org.talend.daikon.spring.audit.logs.model.AuditLogFieldEnum.*;
+
 import java.lang.reflect.InvocationTargetException;
 import java.time.OffsetDateTime;
 import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -73,7 +77,7 @@ public class AuditLogSenderImpl implements AuditLogSender {
      * Build a context from a context builder and send the generated context
      */
     public void sendAuditLog(AuditLogContextBuilder builder) {
-        auditLogger.sendAuditLog(builder.withIpExtractor(this.auditLogIpExtractor).build());
+        this.sendAuditLog(builder.withIpExtractor(this.auditLogIpExtractor).build());
     }
 
     /**
@@ -81,7 +85,21 @@ public class AuditLogSenderImpl implements AuditLogSender {
      */
     @Override
     public void sendAuditLog(Context context) {
-        auditLogger.sendAuditLog(context);
+        try {
+            auditLogger.sendAuditLog(context);
+        } catch (Exception e) {
+            // Clean audit log context from PIIs
+            context.keySet().retainAll(Stream.of( //
+                    TIMESTAMP.getId(), //
+                    APPLICATION_ID.getId(), //
+                    ACCOUNT_ID.getId(), //
+                    EVENT_TYPE.getId(), //
+                    EVENT_CATEGORY.getId(), //
+                    EVENT_OPERATION //
+            ).collect(Collectors.toSet()));
+            LOGGER.warn("Error sending audit logs to Kafka : {}", context);
+
+        }
     }
 
     @Override

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -97,7 +97,7 @@ public class AuditLogSenderImpl implements AuditLogSender {
                     EVENT_CATEGORY.getId(), //
                     EVENT_OPERATION //
             ).collect(Collectors.toSet()));
-            LOGGER.warn("Error sending audit logs to Kafka : {}", context);
+            LOGGER.warn("Error sending audit logs to Kafka : {}", context, e);
 
         }
     }

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -16,6 +16,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -94,6 +95,31 @@ public class AuditLogTest {
         logListAppender.start();
         logger.setLevel(Level.DEBUG);
         logger.addAppender(logListAppender);
+    }
+
+    @Test
+    @WithUserDetails
+    public void testLoggerProblem() throws Exception {
+        // Given Kafka is down
+        Mockito //
+                .doThrow(new RuntimeException("Failure when sending the audit log to Kafka")) //
+                .when(auditLoggerBase) //
+                .log(any(), any(), any(), any(), any());
+
+        // When a request generating an audit logs is performed
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY).header(REMOTE_IP_HEADER, MY_IP))
+                // Then it must be a success anyway
+                .andExpect(status().isOk());
+
+        // And a simple log must be generated
+        ILoggingEvent lastLog = logListAppender.list.iterator().next();
+        assertThat(lastLog.getLevel(), is(Level.WARN));
+        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogFieldEnum.TIMESTAMP.getId()));
+        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.ACCOUNT_ID));
+        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.APPLICATION));
+        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_CATEGORY));
+        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_OPERATION));
+        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_TYPE));
     }
 
     @Test

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -120,6 +120,7 @@ public class AuditLogTest {
         assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_CATEGORY));
         assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_OPERATION));
         assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_TYPE));
+        assertThat(lastLog.getThrowableProxy().getMessage(), containsString("Failure when sending the audit log to Kafka"));
     }
 
     @Test


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Client application is blocked if audit log can't generated due to Kafka issue.
 
**What is the chosen solution to this problem?**
Losing logs is more acceptable than having Talend Cloud down.
As a consequence, the fact that Kafka is down shouldn't block the client application.
In that case a simple log is generated.

The Kafka send timeout can now be configured from the client application.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-15956
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
