### PR TITLE
fix(TPSVC-15956): [Audit-log] Mitigate audit log failure impact on login - Fix Kafka block timeout

### DIFF
--- a/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AuditConfiguration.java
+++ b/daikon-audit/audit-common/src/main/java/org/talend/logging/audit/impl/AuditConfiguration.java
@@ -41,7 +41,7 @@ public enum AuditConfiguration {
     PROPAGATE_APPENDER_EXCEPTIONS(PropagateExceptions.class, PropagateExceptions.NONE),
     BACKEND(Backends.class, Backends.AUTO),
     KAFKA_BOOTSTRAP_SERVERS(String.class, null, true),
-    KAFKA_SEND_TIMEOUT_SECONDS(Integer.class, 60),
+    KAFKA_BLOCK_TIMEOUT_MS(Long.class, 60000L),
     KAFKA_TOPIC(String.class, null, true),
     KAFKA_PARTITION_KEY_NAME(String.class, null, true);
 

--- a/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AuditConfigurationTest.java
+++ b/daikon-audit/audit-common/src/test/java/org/talend/logging/audit/impl/AuditConfigurationTest.java
@@ -60,6 +60,6 @@ public class AuditConfigurationTest {
         assertEquals("testTopic", AuditConfiguration.KAFKA_TOPIC.getString(config));
         assertEquals("key", AuditConfiguration.KAFKA_PARTITION_KEY_NAME.getString(config));
         assertEquals("localhost:9092", AuditConfiguration.KAFKA_BOOTSTRAP_SERVERS.getString(config));
-        assertEquals((Integer) 30, AuditConfiguration.KAFKA_SEND_TIMEOUT_SECONDS.getInteger(config));
+        assertEquals((Long) 30000L, AuditConfiguration.KAFKA_BLOCK_TIMEOUT_MS.getLong(config));
     }
 }

--- a/daikon-audit/audit-common/src/test/resources/test.audit.properties
+++ b/daikon-audit/audit-common/src/test/resources/test.audit.properties
@@ -36,4 +36,4 @@ backend=logBack
 kafka.bootstrap.servers=localhost:9092
 kafka.topic=testTopic
 kafka.partition.key.name=key
-kafka.send.timeout.seconds=30
+kafka.block.timeout.ms=30000

--- a/daikon-audit/audit-kafka/src/main/java/org/talend/logging/audit/kafka/KafkaBackend.java
+++ b/daikon-audit/audit-kafka/src/main/java/org/talend/logging/audit/kafka/KafkaBackend.java
@@ -14,6 +14,9 @@ import org.talend.logging.audit.impl.AuditConfigurationMap;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class KafkaBackend extends AbstractBackend {
 
@@ -56,8 +59,9 @@ public class KafkaBackend extends AbstractBackend {
     @Override
     public void log(String category, LogLevel level, String message, Throwable throwable) {
         try {
-            this.kafkaProducer.send(createRecordFromContext(getCopyOfContextMap()));
-        } catch (Exception e) {
+            this.kafkaProducer.send(createRecordFromContext(getCopyOfContextMap())).get(this.blockTimeoutMs,
+                    TimeUnit.MILLISECONDS);
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException("Failure when sending the audit log to Kafka", e);
         }
     }

--- a/daikon-audit/audit-kafka/src/main/java/org/talend/logging/audit/kafka/KafkaBackend.java
+++ b/daikon-audit/audit-kafka/src/main/java/org/talend/logging/audit/kafka/KafkaBackend.java
@@ -14,9 +14,6 @@ import org.talend.logging.audit.impl.AuditConfigurationMap;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class KafkaBackend extends AbstractBackend {
 
@@ -28,7 +25,7 @@ public class KafkaBackend extends AbstractBackend {
 
     private final String bootstrapServers;
 
-    private final Integer kafkaSendTimeoutSeconds;
+    private final Long blockTimeoutMs;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -36,29 +33,31 @@ public class KafkaBackend extends AbstractBackend {
         super(null);
         StringSerializer keyValueSerializer = new StringSerializer();
         this.bootstrapServers = config.getString(AuditConfiguration.KAFKA_BOOTSTRAP_SERVERS);
-        Map<String, Object> producerConfig = new HashMap<>();
-        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        this.kafkaProducer = new KafkaProducer<>(producerConfig, keyValueSerializer, keyValueSerializer);
         this.kafkaTopic = config.getString(AuditConfiguration.KAFKA_TOPIC);
         this.partitionKeyName = config.getString(AuditConfiguration.KAFKA_PARTITION_KEY_NAME);
-        this.kafkaSendTimeoutSeconds = config.getInteger(AuditConfiguration.KAFKA_SEND_TIMEOUT_SECONDS);
+        this.blockTimeoutMs = config.getLong(AuditConfiguration.KAFKA_BLOCK_TIMEOUT_MS);
+        Map<String, Object> producerConfig = new HashMap<>();
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        producerConfig.put(ProducerConfig.ACKS_CONFIG, "1");
+        producerConfig.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, blockTimeoutMs);
+        this.kafkaProducer = new KafkaProducer<>(producerConfig, keyValueSerializer, keyValueSerializer);
     }
 
     public KafkaBackend(KafkaProducer<String, String> kafkaProducer, String kafkaTopic, String partitionKeyName,
-            String bootstrapServers, Integer kafkaSendTimeoutSeconds) {
+            String bootstrapServers, Long blockTimeoutMs) {
         super(null);
         this.kafkaProducer = kafkaProducer;
         this.kafkaTopic = kafkaTopic;
         this.partitionKeyName = partitionKeyName;
         this.bootstrapServers = bootstrapServers;
-        this.kafkaSendTimeoutSeconds = kafkaSendTimeoutSeconds;
+        this.blockTimeoutMs = blockTimeoutMs;
     }
 
     @Override
     public void log(String category, LogLevel level, String message, Throwable throwable) {
         try {
-            this.kafkaProducer.send(createRecordFromContext(getCopyOfContextMap())).get(this.kafkaSendTimeoutSeconds, TimeUnit.SECONDS);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            this.kafkaProducer.send(createRecordFromContext(getCopyOfContextMap()));
+        } catch (Exception e) {
             throw new RuntimeException("Failure when sending the audit log to Kafka", e);
         }
     }
@@ -96,7 +95,7 @@ public class KafkaBackend extends AbstractBackend {
         return bootstrapServers;
     }
 
-    Integer getKafkaSendTimeoutSeconds() {
-        return kafkaSendTimeoutSeconds;
+    Long getBlockTimeoutMs() {
+        return blockTimeoutMs;
     }
 }

--- a/daikon-audit/audit-kafka/src/test/java/org/talend/logging/audit/kafka/KafkaBackendTest.java
+++ b/daikon-audit/audit-kafka/src/test/java/org/talend/logging/audit/kafka/KafkaBackendTest.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.concurrent.Future;
 
 import static org.junit.Assert.*;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +29,7 @@ public class KafkaBackendTest {
         assertEquals("testTopic", kafkaBackend.getKafkaTopic());
         assertEquals("tenantId", kafkaBackend.getPartitionKeyName());
         assertEquals("localhost:9092", kafkaBackend.getBootstrapServers());
-        assertEquals((Integer) 30, kafkaBackend.getKafkaSendTimeoutSeconds());
+        assertEquals((Long) 30000L, kafkaBackend.getBlockTimeoutMs());
     }
 
     @Test
@@ -40,14 +39,14 @@ public class KafkaBackendTest {
         assertEquals("testTopic", kafkaBackend.getKafkaTopic());
         assertNull(kafkaBackend.getPartitionKeyName());
         assertEquals("localhost:9092", kafkaBackend.getBootstrapServers());
-        assertEquals((Integer) 60, kafkaBackend.getKafkaSendTimeoutSeconds());
+        assertEquals((Long) 60000L, kafkaBackend.getBlockTimeoutMs());
     }
 
     @Test
     public void testLogEmptyMap() {
         KafkaProducer<String, String> kafkaProducerMock = mock(KafkaProducer.class);
         Future futureMock = mock(Future.class);
-        kafkaBackend = new KafkaBackend(kafkaProducerMock, "testTopic", "partitionKey", "localhost", 30);
+        kafkaBackend = new KafkaBackend(kafkaProducerMock, "testTopic", "partitionKey", "localhost", 30000L);
 
         ArgumentCaptor<ProducerRecord<String, String>> captor = ArgumentCaptor.forClass(ProducerRecord.class);
         when(kafkaProducerMock.send(captor.capture())).thenReturn(futureMock);
@@ -63,7 +62,7 @@ public class KafkaBackendTest {
     public void testLogEventMap() {
         KafkaProducer<String, String> kafkaProducerMock = mock(KafkaProducer.class);
         Future futureMock = mock(Future.class);
-        kafkaBackend = new KafkaBackend(kafkaProducerMock, "testTopic", "partitionKey", "localhost", 30);
+        kafkaBackend = new KafkaBackend(kafkaProducerMock, "testTopic", "partitionKey", "localhost", 30000L);
 
         Map<String, String> eventMap = new HashMap<>();
         eventMap.put("partitionKey", "ID1234");

--- a/daikon-audit/audit-kafka/src/test/resources/audit.full.properties
+++ b/daikon-audit/audit-kafka/src/test/resources/audit.full.properties
@@ -4,4 +4,4 @@ log.appender=none
 kafka.bootstrap.servers=localhost:9092
 kafka.topic=testTopic
 kafka.partition.key.name=tenantId
-kafka.send.timeout.seconds=30
+kafka.block.timeout.ms=30000

--- a/daikon-spring/daikon-content-service/s3-content-service/pom.xml
+++ b/daikon-spring/daikon-content-service/s3-content-service/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>io.findify</groupId>
             <artifactId>s3mock_2.12</artifactId>
-            <version>0.1.6</version>
+            <version>0.1.8</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
@@ -70,10 +70,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <repositories>
-        <repository>
-            <id>findify</id>
-            <url>https://dl.bintray.com/findify/maven/</url>
-        </repository>
-    </repositories>
 </project>

--- a/daikon-spring/daikon-spring-audit-logs/README.adoc
+++ b/daikon-spring/daikon-spring-audit-logs/README.adoc
@@ -41,6 +41,7 @@ audit:
         bootstrapServers: localhost:9092 # Kafka bootstrap server urls for audit logs sending
         topic: audit-logs # Kafka topic for audit logs sending
         partitionKeyName: accountId # Kafka partitionKey for audit logs sending
+        blockTimeoutMs: 10000 # Block timeout before considering audit log has not been sent to Kafka
 ```
 
 == @GenerateAuditLog

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
@@ -11,7 +11,7 @@ public class AuditKafkaProperties {
 
     private String partitionKeyName = "accountId";
 
-    private int sendTimeoutSeconds = 30;
+    private String blockTimeoutMs = "30000";
 
     public String getBootstrapServers() {
         return bootstrapServers;
@@ -37,11 +37,7 @@ public class AuditKafkaProperties {
         this.partitionKeyName = partitionKeyName;
     }
 
-    public int getSendTimeoutSeconds() {
-        return sendTimeoutSeconds;
-    }
-
-    public void setSendTimeoutSeconds(int sendTimeoutSeconds) {
-        this.sendTimeoutSeconds = sendTimeoutSeconds;
+    public String getBlockTimeoutMs() {
+        return blockTimeoutMs;
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditKafkaProperties.java
@@ -40,4 +40,8 @@ public class AuditKafkaProperties {
     public String getBlockTimeoutMs() {
         return blockTimeoutMs;
     }
+
+    public void setBlockTimeoutMs(String blockTimeoutMs) {
+        this.blockTimeoutMs = blockTimeoutMs;
+    }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -49,7 +49,7 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
         properties.put("kafka.bootstrap.servers", auditKafkaProperties.getBootstrapServers());
         properties.put("kafka.topic", auditKafkaProperties.getTopic());
         properties.put("kafka.partition.key.name", auditKafkaProperties.getPartitionKeyName());
-        properties.put("kafka.send.timeout.seconds", auditKafkaProperties.getSendTimeoutSeconds());
+        properties.put("kafka.block.timeout.ms", auditKafkaProperties.getBlockTimeoutMs());
         return properties;
     }
 

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -42,6 +42,7 @@ public class AuditLogSenderImpl implements AuditLogSender {
     public void sendAuditLog(HttpServletRequest request, Object requestBody, int responseCode, Object responseObject,
             GenerateAuditLog auditLogAnnotation) {
         try {
+            LOGGER.info("generating audit log with metadata {}", auditLogAnnotation);
             // Build context from request, response & annotation info
             AuditLogContextBuilder auditLogContextBuilder = AuditLogContextBuilder.create() //
                     .withTimestamp(OffsetDateTime.now().toString()) //
@@ -65,7 +66,6 @@ public class AuditLogSenderImpl implements AuditLogSender {
 
             // Finally send the log
             this.sendAuditLog(auditLogContextBuilder.build());
-            LOGGER.info("audit log generated with metadata {}", auditLogAnnotation);
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
             LOGGER.error("audit log with metadata {} has not been generated", auditLogAnnotation, e);
         } catch (AuditLogException e) {

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -51,7 +51,8 @@ import ch.qos.logback.core.read.ListAppender;
         "audit.enabled=true", //
         "spring.application.name=daikon", //
         "audit.kafka.bootstrapServers=localhost:9092", //
-        "audit.trusted-proxies=" + TRUSTED_PROXIES //
+        "audit.trusted-proxies=" + TRUSTED_PROXIES, //
+        "audit.kafka.block-timeout-ms=10000"
 })
 @Import(AuditLogTestConfig.class)
 public class AuditLogTest {

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -52,8 +52,7 @@ import ch.qos.logback.core.read.ListAppender;
         "spring.application.name=daikon", //
         "audit.kafka.bootstrapServers=localhost:9092", //
         "audit.trusted-proxies=" + TRUSTED_PROXIES, //
-        "audit.kafka.block-timeout-ms=10000"
-})
+        "audit.kafka.block-timeout-ms=10000" })
 @Import(AuditLogTestConfig.class)
 public class AuditLogTest {
 
@@ -113,15 +112,14 @@ public class AuditLogTest {
                 .andExpect(status().isOk());
 
         // And a simple log must be generated
-        ILoggingEvent lastLog = logListAppender.list.iterator().next();
-        assertThat(lastLog.getLevel(), is(Level.WARN));
-        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogFieldEnum.TIMESTAMP.getId()));
-        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.ACCOUNT_ID));
-        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.APPLICATION));
-        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_CATEGORY));
-        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_OPERATION));
-        assertThat(lastLog.getFormattedMessage(), containsString(AuditLogTestApp.EVENT_TYPE));
-        assertThat(lastLog.getThrowableProxy().getMessage(), containsString("Failure when sending the audit log to Kafka"));
+        assertThat(lastLog().getLevel(), is(Level.WARN));
+        assertThat(lastLog().getFormattedMessage(), containsString(AuditLogFieldEnum.TIMESTAMP.getId()));
+        assertThat(lastLog().getFormattedMessage(), containsString(AuditLogTestApp.ACCOUNT_ID));
+        assertThat(lastLog().getFormattedMessage(), containsString(AuditLogTestApp.APPLICATION));
+        assertThat(lastLog().getFormattedMessage(), containsString(AuditLogTestApp.EVENT_CATEGORY));
+        assertThat(lastLog().getFormattedMessage(), containsString(AuditLogTestApp.EVENT_OPERATION));
+        assertThat(lastLog().getFormattedMessage(), containsString(AuditLogTestApp.EVENT_TYPE));
+        assertThat(lastLog().getThrowableProxy().getMessage(), containsString("Failure when sending the audit log to Kafka"));
     }
 
     @Test
@@ -184,7 +182,7 @@ public class AuditLogTest {
                 .andExpect(status().isUnauthorized());
 
         verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
-        assertThat(logListAppender.list.iterator().next().getLevel(), is(Level.DEBUG));
+        assertThat(lastLog().getLevel(), is(Level.DEBUG));
     }
 
     @Test
@@ -216,7 +214,7 @@ public class AuditLogTest {
                 .andExpect(status().isOk());
 
         verify(auditLoggerBase, times(0)).log(any(), any(), any(), any(), any());
-        assertThat(logListAppender.list.iterator().next().getLevel(), is(Level.DEBUG));
+        assertThat(lastLog().getLevel(), is(Level.DEBUG));
     }
 
     @Test
@@ -459,6 +457,10 @@ public class AuditLogTest {
                         : containsString(String.format("\"%s\":\"%s\"", AuditLogFieldEnum.RESPONSE_BODY.getId(),
                                 StringEscapeUtils.escapeJson(body))), //
         };
+    }
+
+    private ILoggingEvent lastLog() {
+        return logListAppender.list.get(logListAppender.list.size() - 1);
     }
 
     /**


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Thanks to #735 the operations generating audit logs still work if Kafka is down. 
But the client apps are still blocked during 60 seconds and this timeout can't be configured.
 
**What is the chosen solution to this problem?**
Use `max.block.ms` Kafka producer property to define the blocking timeout (other than default 60000 ms).
Provide a way for the client apps to configure it.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-15956
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
