### PR TITLE
feat(TPSVC-13666): [Audit logs] Implement a prometheus counter for audit logs

### DIFF
--- a/daikon-spring/daikon-spring-audit-logs/README.adoc
+++ b/daikon-spring/daikon-spring-audit-logs/README.adoc
@@ -266,3 +266,6 @@ In order not to block the client application if a problem occurs on logger side 
 Error sending audit logs to Kafka : {timestamp=2021-04-29T18:28:09.723741+02:00, applicationId=Daikon, eventType=test type, eventCategory=test category, accountId=9bfdd9a0-7852-4cd5-94a0-6212ebe281b6}
 ```
 
+== Prometheus Counter
+In order to have the number of audit logs covered, we need to know the number of audit logs generated. So, we need a way to count every single which is why we leveraged a prometheus counter to achieve this goal. *So each project integrating the audit logs daikon library must expose a prometheus endpoint.*
+

--- a/daikon-spring/daikon-spring-audit-logs/pom.xml
+++ b/daikon-spring/daikon-spring-audit-logs/pom.xml
@@ -58,6 +58,11 @@
             <artifactId>commons-validator</artifactId>
             <version>1.7</version>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -123,6 +123,7 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
 
     @Bean
     public Counter auditLogsGeneratedCounter(final MeterRegistry meterRegistry) {
-        return Counter.builder("generated_count").description("The number of audit logs stored").register(meterRegistry);
+        return Counter.builder("audit_logs_generated_count").description("The number of audit logs stored")
+                .register(meterRegistry);
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -82,10 +82,10 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
 
     @Bean
     public AuditLogSender auditLogSender(Optional<AuditUserProvider> auditUserProvider, AuditLoggerBase auditLoggerBase,
-            AuditLogIpExtractor AuditLogIpExtractor, Counter audiLogGeneratedCounter) {
+            AuditLogIpExtractor AuditLogIpExtractor, Counter auditLogsGeneratedCounter) {
         AuditLogger auditLogger = AuditLoggerFactory.getEventAuditLogger(AuditLogger.class, auditLoggerBase);
         return new AuditLogSenderImpl(auditUserProvider.orElse(new NoOpAuditUserProvider()), auditLogger, AuditLogIpExtractor,
-                audiLogGeneratedCounter);
+                auditLogsGeneratedCounter);
     }
 
     @Bean
@@ -121,7 +121,7 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
         };
     }
 
-    @Bean(name = "AuditLogGeneratedCounter")
+    @Bean
     public Counter auditLogsGeneratedCounter(final MeterRegistry meterRegistry) {
         return Counter.builder("generated_count").description("The number of audit logs stored").register(meterRegistry);
     }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/config/AuditLogAutoConfiguration.java
@@ -84,7 +84,8 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
     public AuditLogSender auditLogSender(Optional<AuditUserProvider> auditUserProvider, AuditLoggerBase auditLoggerBase,
             AuditLogIpExtractor AuditLogIpExtractor, Counter audiLogGeneratedCounter) {
         AuditLogger auditLogger = AuditLoggerFactory.getEventAuditLogger(AuditLogger.class, auditLoggerBase);
-        return new AuditLogSenderImpl(auditUserProvider.orElse(new NoOpAuditUserProvider()), auditLogger, AuditLogIpExtractor, audiLogGeneratedCounter);
+        return new AuditLogSenderImpl(auditUserProvider.orElse(new NoOpAuditUserProvider()), auditLogger, AuditLogIpExtractor,
+                audiLogGeneratedCounter);
     }
 
     @Bean
@@ -120,10 +121,8 @@ public class AuditLogAutoConfiguration implements WebMvcConfigurer {
         };
     }
 
-    @Bean(name = "AudiLogGeneratedCounter")
+    @Bean(name = "AuditLogGeneratedCounter")
     public Counter auditLogsGeneratedCounter(final MeterRegistry meterRegistry) {
-        return Counter.builder("generated_count")
-                .description("The number of audit logs stored")
-                .register(meterRegistry);
+        return Counter.builder("generated_count").description("The number of audit logs stored").register(meterRegistry);
     }
 }

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -103,8 +103,9 @@ public class AuditLogSenderImpl implements AuditLogSender {
                     EVENT_OPERATION //
             ).collect(Collectors.toSet()));
             LOGGER.warn("Error sending audit logs to Kafka : {}", context, e);
+        } finally {
+            auditLogsGeneratedCounter.increment();
         }
-        auditLogsGeneratedCounter.increment();
     }
 
     @Override

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -30,14 +30,14 @@ public class AuditLogSenderImpl implements AuditLogSender {
 
     private final AuditLogIpExtractor auditLogIpExtractor;
 
-    private final Counter audiLogGeneratedCounter;
+    private final Counter auditLogsGeneratedCounter;
 
     public AuditLogSenderImpl(AuditUserProvider auditUserProvider, AuditLogger auditLogger,
-            AuditLogIpExtractor auditLogIpExtractor, Counter audiLogGeneratedCounter) {
+            AuditLogIpExtractor auditLogIpExtractor, Counter auditLogsGeneratedCounter) {
         this.auditUserProvider = auditUserProvider;
         this.auditLogger = auditLogger;
         this.auditLogIpExtractor = auditLogIpExtractor;
-        this.audiLogGeneratedCounter = audiLogGeneratedCounter;
+        this.auditLogsGeneratedCounter = auditLogsGeneratedCounter;
     }
 
     /**
@@ -104,7 +104,7 @@ public class AuditLogSenderImpl implements AuditLogSender {
             ).collect(Collectors.toSet()));
             LOGGER.warn("Error sending audit logs to Kafka : {}", context, e);
         }
-        audiLogGeneratedCounter.increment();
+        auditLogsGeneratedCounter.increment();
     }
 
     @Override

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -18,6 +18,8 @@ import org.talend.daikon.spring.audit.logs.api.GenerateAuditLog;
 import org.talend.daikon.spring.audit.logs.exception.AuditLogException;
 import org.talend.logging.audit.Context;
 
+import io.micrometer.core.instrument.Counter;
+
 public class AuditLogSenderImpl implements AuditLogSender {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuditLogSenderImpl.class);
@@ -28,11 +30,14 @@ public class AuditLogSenderImpl implements AuditLogSender {
 
     private final AuditLogIpExtractor auditLogIpExtractor;
 
+    private final Counter audiLogGeneratedCounter;
+
     public AuditLogSenderImpl(AuditUserProvider auditUserProvider, AuditLogger auditLogger,
-            AuditLogIpExtractor auditLogIpExtractor) {
+                              AuditLogIpExtractor auditLogIpExtractor, Counter audiLogGeneratedCounter) {
         this.auditUserProvider = auditUserProvider;
         this.auditLogger = auditLogger;
         this.auditLogIpExtractor = auditLogIpExtractor;
+        this.audiLogGeneratedCounter= audiLogGeneratedCounter;
     }
 
     /**
@@ -87,6 +92,7 @@ public class AuditLogSenderImpl implements AuditLogSender {
     public void sendAuditLog(Context context) {
         try {
             auditLogger.sendAuditLog(context);
+            audiLogGeneratedCounter.increment();
         } catch (Exception e) {
             // Clean audit log context from PIIs
             context.keySet().retainAll(Stream.of( //

--- a/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/main/java/org/talend/daikon/spring/audit/logs/service/AuditLogSenderImpl.java
@@ -33,11 +33,11 @@ public class AuditLogSenderImpl implements AuditLogSender {
     private final Counter audiLogGeneratedCounter;
 
     public AuditLogSenderImpl(AuditUserProvider auditUserProvider, AuditLogger auditLogger,
-                              AuditLogIpExtractor auditLogIpExtractor, Counter audiLogGeneratedCounter) {
+            AuditLogIpExtractor auditLogIpExtractor, Counter audiLogGeneratedCounter) {
         this.auditUserProvider = auditUserProvider;
         this.auditLogger = auditLogger;
         this.auditLogIpExtractor = auditLogIpExtractor;
-        this.audiLogGeneratedCounter= audiLogGeneratedCounter;
+        this.audiLogGeneratedCounter = audiLogGeneratedCounter;
     }
 
     /**
@@ -92,7 +92,6 @@ public class AuditLogSenderImpl implements AuditLogSender {
     public void sendAuditLog(Context context) {
         try {
             auditLogger.sendAuditLog(context);
-            audiLogGeneratedCounter.increment();
         } catch (Exception e) {
             // Clean audit log context from PIIs
             context.keySet().retainAll(Stream.of( //
@@ -104,8 +103,8 @@ public class AuditLogSenderImpl implements AuditLogSender {
                     EVENT_OPERATION //
             ).collect(Collectors.toSet()));
             LOGGER.warn("Error sending audit logs to Kafka : {}", context, e);
-
         }
+        audiLogGeneratedCounter.increment();
     }
 
     @Override

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -82,7 +82,7 @@ public class AuditLogTest {
     private AuditLoggerBase auditLoggerBase;
 
     @MockBean
-    private Counter auditLogGeneratedCounter;
+    private Counter auditLogsGeneratedCounter;
 
     @Autowired
     private MockMvc mockMvc;
@@ -131,7 +131,7 @@ public class AuditLogTest {
     public void testAuditLogCounter() throws Exception {
         mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY).header(REMOTE_IP_HEADER, MY_IP))
                 .andExpect(status().isOk());
-        verify(auditLogGeneratedCounter, times(1)).increment();
+        verify(auditLogsGeneratedCounter, times(1)).increment();
 
     }
 

--- a/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
+++ b/daikon-spring/daikon-spring-audit-logs/src/test/java/org/talend/daikon/spring/audit/logs/api/AuditLogTest.java
@@ -43,6 +43,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import io.micrometer.core.instrument.Counter;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = AuditLogTestApp.class)
@@ -79,6 +80,9 @@ public class AuditLogTest {
 
     @MockBean
     private AuditLoggerBase auditLoggerBase;
+
+    @MockBean
+    private Counter auditLogGeneratedCounter;
 
     @Autowired
     private MockMvc mockMvc;
@@ -120,6 +124,15 @@ public class AuditLogTest {
         assertThat(lastLog().getFormattedMessage(), containsString(AuditLogTestApp.EVENT_OPERATION));
         assertThat(lastLog().getFormattedMessage(), containsString(AuditLogTestApp.EVENT_TYPE));
         assertThat(lastLog().getThrowableProxy().getMessage(), containsString("Failure when sending the audit log to Kafka"));
+    }
+
+    @Test
+    @WithUserDetails
+    public void testAuditLogCounter() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.get(AuditLogTestApp.GET_200_WITH_BODY).header(REMOTE_IP_HEADER, MY_IP))
+                .andExpect(status().isOk());
+        verify(auditLogGeneratedCounter, times(1)).increment();
+
     }
 
     @Test


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
We don't have any metric regarding the number of audit logs generated. Thus we can't implement the coverage SLO
 
**What is the chosen solution to this problem?**
Implement a prometheus counter for audit logs which will be incremented each time an audit logs is generated 

**Link to the JIRA issue**
https://jira.talendforge.org/browse/TPSVC-13666
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
