### PR TITLE
TDKN-309 - Make CryptoHelper base64 methods private

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/security/CryptoHelper.java
+++ b/daikon/src/main/java/org/talend/daikon/security/CryptoHelper.java
@@ -124,7 +124,7 @@ public class CryptoHelper implements Function<String, String> {
      * @param str Binary data to encode.
      * @return The string encoded in Base64, or "" if an encoding error occurred.
      */
-    public static String encode64(byte[] str) {
+    private static String encode64(byte[] str) {
         try {
             return new String(Base64.encodeBase64(str), UTF8);
         } catch (UnsupportedEncodingException e) {
@@ -136,7 +136,7 @@ public class CryptoHelper implements Function<String, String> {
      * @param str A Base64 string to decode.
      * @return The decoded binary data, or an empty array if a decoding error occurred.
      */
-    public static byte[] decode64(String str) {
+    private static byte[] decode64(String str) {
         try {
             return Base64.decodeBase64(str.getBytes(UTF8));
         } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
CryptoHelper is deprecated and we need to discourage it's use outside of Daikon. It has some Base64 helper static methods that are used by a few classes outside of daikon, I have filed JIRAs to fix these. We should make the methods private to discourage outside classes calling them.