### PR TITLE
TDKN-310 - Don't use CryptoHelper to encrypt properties in StringProp…

### DIFF
--- a/daikon/src/main/java/org/talend/daikon/properties/property/StringProperty.java
+++ b/daikon/src/main/java/org/talend/daikon/properties/property/StringProperty.java
@@ -102,12 +102,13 @@ public class StringProperty extends Property<String> {
     public void encryptStoredValue(boolean encrypt) {
         if (isFlag(Property.Flags.ENCRYPT)) {
             String value = (String) getStoredValue();
-            CryptoHelper ch = new CryptoHelper(CryptoHelper.PASSPHRASE);
             if (encrypt) {
-                setStoredValue(ch.encrypt(value));
-            } else {
-                setStoredValue(ch.decrypt(value));
+                // Encryption using CryptoHelper is no longer supported
+                throw new TalendRuntimeException(CommonErrorCodes.UNEXPECTED_EXCEPTION);
             }
+            // This is deprecated functionality for migration purposes.
+            CryptoHelper ch = new CryptoHelper(CryptoHelper.PASSPHRASE);
+            setStoredValue(ch.decrypt(value));
         }
     }
 

--- a/daikon/src/test/java/org/talend/daikon/serialize/jsonio/PasswordSerializeTest.java
+++ b/daikon/src/test/java/org/talend/daikon/serialize/jsonio/PasswordSerializeTest.java
@@ -20,6 +20,7 @@ import java.util.EnumSet;
 import org.junit.Test;
 import org.talend.daikon.properties.PropertiesImpl;
 import org.talend.daikon.properties.property.Property;
+import org.talend.daikon.security.CryptoHelper;
 import org.talend.daikon.serialize.SerializerDeserializer;
 
 public class PasswordSerializeTest {
@@ -53,6 +54,23 @@ public class PasswordSerializeTest {
             super.setupProperties();
             nested = new NestedProperties("nested");
             nested.userPassword = userPassword;
+        }
+
+        protected void encryptData(Property property, boolean encrypt) {
+
+            if (property.getStoredValue() == null) {
+                return;
+            }
+
+            if (property.isFlag(Property.Flags.ENCRYPT)) {
+                String value = (String) property.getStoredValue();
+                CryptoHelper ch = new CryptoHelper(CryptoHelper.PASSPHRASE);
+                if (encrypt) {
+                    property.setStoredValue(ch.encrypt(value));
+                } else {
+                    super.encryptData(property, encrypt);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
In StringProperty, the encryptStoredValue method uses CryptoHelper for both encryption and decryption. This task is to remove the "encrypt" part of this functionality, as in components it already overrides this:

https://github.com/Talend/components/blob/39419b8192721805e09bade037fd5104ee162289/core/components-api/src/main/java/org/talend/components/api/properties/ComponentBasePropertiesImpl.java#L33

