### PR TITLE
TDKN-311 - Update JSON Smart to 2.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <hamcrest-json.version>0.2</hamcrest-json.version>
         <json-path-assert.version>2.2.0</json-path-assert.version>
         <log4j.version>1.2.17</log4j.version>
-        <json-smart.version>2.4.2</json-smart.version>
+        <json-smart.version>2.4.7</json-smart.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-configuration2.version>2.7</commons-configuration2.version>
         <httpclient.version>4.5.13</httpclient.version>


### PR DESCRIPTION
This task is to update JSON Smart to 2.4.7, to pick up a CVE fix in 2.4.5 that is 9.1 High:
json-smart is vulnerable to denial of service (DoS). An unhandled ArrayIndexOutOfBoundsException thrown from the indexOf function of JSONParserByteArray allows a remote attacker to crash the program or leak confidential information.
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31684

Options