### PR TITLE
TDKN-313 - Support argon2id and bcrypt as a password digester

### DIFF
--- a/daikon-crypto/crypto-utils/README.md
+++ b/daikon-crypto/crypto-utils/README.md
@@ -18,6 +18,80 @@ This library offers utilities for both password digest and encryption.
 
 ## Password Digest
 
+It is not permitted to use a SHA digest to digest passwords, instead they must be digested using
+one of the approved implementations detailed in this section. Argon2Id should be the preferred solution for password digests.
+
+### Argon2Id
+
+```java
+public static void main(String[] args) throws Exception {
+    PasswordDigester digester = new Argon2PasswordDigester();
+    
+    final String digest = digester.digest("tiger");
+    System.out.println("digest = " + digest);
+    
+    System.out.println("Validate 'tiger': " + digester.validate("tiger", digest));
+    System.out.println("Validate 'password': " + digester.validate("password", digest));
+}
+```
+
+The code above produces this example:
+```text
+digest = $argon2id$v=19$m=4096,t=3,p=1$LqFyRbm7jnNpUEjlpapM6A$yqkHrp8eEJkCvM2lkAxraJtFN2vt2LhSynpKJosPgE8
+Validate 'tiger': true
+Validate 'password': false
+```
+The Argon2PasswordDigester uses spring-security-crypto as the underlying implementation, which is an optional jar
+in crypto-utils, so to use this algorithm this jar will need to be added to dependency control. In addition, the BouncyCastle
+bcprov-jdk15on jar is also required to be added.
+
+According to the
+[OWASP password storage cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html):
+
+> Use Argon2id with a minimum configuration of 15 MiB of memory, an iteration count of 2, and 1 degree of parallelism.
+
+By default, the Argon2PasswordDigester uses the following values, which should be considered to be secure:
+
+ * Salt Length: 16
+ * Hash Length: 32
+ * Iterations: 3
+ * Parallelism: 1
+ * Memory: 4096 (Kb)
+
+### BCrypt
+
+```java
+public static void main(String[] args) throws Exception {
+    PasswordDigester digester = new BCryptPasswordDigester();
+    
+    final String digest = digester.digest("tiger");
+    System.out.println("digest = " + digest);
+    
+    System.out.println("Validate 'tiger': " + digester.validate("tiger", digest));
+    System.out.println("Validate 'password': " + digester.validate("password", digest));
+}
+```
+
+The code above produces this example:
+```text
+digest = $2a$10$f0vioWEm1hFi6gUnxTUK.u4GssfYd6KsdUsBTDVZ8RdXw6gU85Hvi
+Validate 'tiger': true
+Validate 'password': false
+```
+
+The BCryptPasswordDigester uses spring-security-crypto as the underlying implementation, which is an optional jar
+in crypto-utils, so to use this algorithm this jar will need to be added to dependency control.
+
+According to the
+[OWASP password storage cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html),
+a minimum strength of 10 should be used with BCrypt (this is the default). You should not need to configure the
+BCrypt algorithm, but instead just use the default version.
+
+Please note that BCrypt does not work with passwords greater than 72 bytes, one of the other implementations
+should be chosen instead for this requirement.
+
+### PBKDF2
+
 ```java
 public static void main(String[] args) throws Exception {
     PasswordDigester digester = new PBKDF2PasswordDigester();
@@ -36,15 +110,14 @@ digest = rGl+Xu8NbNqqJdmbTk6uHg==-YUdLMtZL+3renFPkDt6SSoDKobFhmijkOmpXuvhjapo=
 Validate 'tiger': true
 Validate 'password': false
 ```
-It is not permitted to use a SHA digest to digest passwords, they must be digested instead using
-PBKDF2PasswordDigester. An iteration count of 310,000 should be used with PBKDF2 according to the 
+According to the
 [OWASP password storage cheatsheet](https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html):
 
 > If FIPS-140 compliance is required, use PBKDF2 with a work factor of 310,000 or more and set with an internal hash function of HMAC-SHA-256.
 
 The PBKDF2PasswordDigester uses a random 16 byte salt by default, with a 256 bit key length and 310,000 iteration count.
 
-### Encryption
+## Encryption
 
 The main entry point for this module is the class `Encryption`. It needs as input:
 

--- a/daikon-crypto/crypto-utils/pom.xml
+++ b/daikon-crypto/crypto-utils/pom.xml
@@ -10,6 +10,18 @@
     <artifactId>crypto-utils</artifactId>
     <packaging>jar</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -35,6 +47,11 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-crypto</artifactId>
+            <optional>true</optional>
         </dependency>
         <!-- tests -->
         <dependency>

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Argon2PasswordDigester.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/Argon2PasswordDigester.java
@@ -1,0 +1,72 @@
+package org.talend.daikon.crypto.digest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * An implementation of PasswordDigester that uses Argon2 (Argon2id).
+ */
+public class Argon2PasswordDigester implements PasswordDigester {
+
+    private static final int SALT_LENGTH = 16;
+
+    private static final int HASH_LENGTH = 32;
+
+    private static final int PARALLELISM = 1;
+
+    private static final int MEMORY = 4096;
+
+    private static final int ITERATIONS = 3;
+
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * Create Argon2PasswordDigester with the following defaults:
+     * - Salt Length: 16
+     * - Hash Length: 32
+     * - Iterations: 3
+     * - Parallelism: 1
+     * - Memory: 4096 (Kb)
+     */
+    public Argon2PasswordDigester() {
+        this(SALT_LENGTH, HASH_LENGTH, PARALLELISM, MEMORY, ITERATIONS);
+    }
+
+    /**
+     * Create Argon2PasswordDigester with the following defaults:
+     * - Salt Length: 16
+     * - Hash Length: 32
+     * 
+     * @param parallelism the parallelism, e.g. 1
+     * @param memory the memory in KB e.g. 4096
+     * @param iterations the iterations, e.g. 3
+     */
+    public Argon2PasswordDigester(int parallelism, int memory, int iterations) {
+        this(SALT_LENGTH, HASH_LENGTH, parallelism, memory, iterations);
+    }
+
+    /**
+     * Create Argon2PasswordDigester
+     * 
+     * @param saltLength the salt length, e.g. 16
+     * @param hashLength the hash length, e.g. 32
+     * @param parallelism the parallelism, e.g. 1
+     * @param memory the memory in KB e.g. 4096
+     * @param iterations the iterations, e.g. 3
+     */
+    public Argon2PasswordDigester(int saltLength, int hashLength, int parallelism, int memory, int iterations) {
+        passwordEncoder = new Argon2PasswordEncoder(saltLength, hashLength, parallelism, memory, iterations);
+    }
+
+    public String digest(String password) throws Exception {
+        return passwordEncoder.encode(password);
+    }
+
+    public boolean validate(String password, String digest) {
+        return passwordEncoder.matches(password, digest);
+    }
+}

--- a/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/BCryptPasswordDigester.java
+++ b/daikon-crypto/crypto-utils/src/main/java/org/talend/daikon/crypto/digest/BCryptPasswordDigester.java
@@ -1,0 +1,62 @@
+package org.talend.daikon.crypto.digest;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Locale;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+/**
+ * An implementation of PasswordDigester that uses BCrypt with a default strength of 10. Passwords are limited to
+ * 72 bytes.
+ */
+public class BCryptPasswordDigester implements PasswordDigester {
+
+    private final PasswordEncoder passwordEncoder;
+
+    /**
+     * Create BCryptPasswordDigester with a default strength of 10, and a default "$2a" algorithm.
+     * This should meet most requirements.
+     */
+    public BCryptPasswordDigester() {
+        this(10);
+    }
+
+    /**
+     * Create BCryptPasswordDigester with the specified strength. Note OWASP recommends "10" as the minimum strength.
+     * It uses the "$2a" algorithm by default.
+     * 
+     * @param strength the strength parameter, can be between 4 and 31
+     */
+    public BCryptPasswordDigester(int strength) {
+        this(strength, "$2a");
+    }
+
+    /**
+     * Create BCryptPasswordDigester with the specified strength. Note OWASP recommends "10" as the minimum strength.
+     *
+     * @param strength the strength parameter, can be between 4 and 31
+     * @param algorithm the BCrypt version, can be "$2a", "$2y", "$2b". If null defaults to "$2a".
+     */
+    public BCryptPasswordDigester(int strength, String algorithm) {
+        BCryptPasswordEncoder.BCryptVersion version = BCryptPasswordEncoder.BCryptVersion.$2A;
+        if (algorithm != null) {
+            version = BCryptPasswordEncoder.BCryptVersion.valueOf(algorithm.toUpperCase(Locale.US));
+        }
+        passwordEncoder = new BCryptPasswordEncoder(version, strength);
+    }
+
+    public String digest(String password) throws Exception {
+        if (password != null && password.getBytes(StandardCharsets.UTF_8).length > 72) {
+            throw new IllegalArgumentException("The password is limited to a maximum of 72 bytes");
+        }
+        return passwordEncoder.encode(password);
+    }
+
+    public boolean validate(String password, String digest) {
+        if (password != null && password.getBytes(StandardCharsets.UTF_8).length > 72) {
+            throw new IllegalArgumentException("The password is limited to a maximum of 72 bytes");
+        }
+        return passwordEncoder.matches(password, digest);
+    }
+}

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/Argon2PasswordDigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/Argon2PasswordDigesterTest.java
@@ -1,0 +1,211 @@
+package org.talend.daikon.crypto.digest;
+
+import java.util.Base64;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class Argon2PasswordDigesterTest {
+
+    @Test
+    public void shouldValidateDigest() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digester.validate("tiger", digest));
+        assertFalse(digester.validate("password", digest));
+    }
+
+    @Test
+    public void shouldUseArgon2IdAsAlgorithm() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digest.startsWith("$argon2id$"));
+    }
+
+    @Test
+    public void shouldUseADefaultIterationCountOf3() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digest.contains("t=3"));
+    }
+
+    @Test
+    public void shouldUseADefaultMemorySizeOf4096() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digest.contains("m=4096"));
+    }
+
+    @Test
+    public void shouldUseADefaultParallismOf1() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digest.contains("p=1"));
+    }
+
+    @Test
+    public void shouldUseADefaultSaltLengthOf16() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        String prefix = "$argon2id$v=19$m=4096,t=3,p=1$";
+        String salt = digest.substring(prefix.length(), digest.indexOf("$", prefix.length()));
+        assertEquals(16, Base64.getDecoder().decode(salt).length);
+    }
+
+    @Test
+    public void shouldUseADefaultHashLengthOf32() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        String prefix = "$argon2id$v=19$m=4096,t=3,p=1$";
+        String hash = digest.substring(digest.indexOf("$", prefix.length()) + 1);
+        assertEquals(32, Base64.getDecoder().decode(hash).length);
+    }
+
+    @Test
+    public void shouldHaveDifferentSalts() throws Exception {
+        // given
+        String value = "myPassword";
+
+        // when
+        PasswordDigester digester1 = new Argon2PasswordDigester();
+        PasswordDigester digester2 = new Argon2PasswordDigester();
+        final String digest1 = digester1.digest(value);
+        final String digest2 = digester2.digest(value);
+
+        // then
+        String prefix = "$argon2id$v=19$m=4096,t=3,p=1$";
+        final String salt1 = digest1.substring(prefix.length(), digest1.indexOf("$", prefix.length()));
+        final String salt2 = digest2.substring(prefix.length(), digest2.indexOf("$", prefix.length()));
+        assertFalse(salt1.equals(salt2));
+    }
+
+    @Test
+    public void shouldHaveDifferentHashes() throws Exception {
+        // given
+        String value = "myPassword";
+
+        // when
+        PasswordDigester digester1 = new Argon2PasswordDigester();
+        PasswordDigester digester2 = new Argon2PasswordDigester();
+        final String digest1 = digester1.digest(value);
+        final String digest2 = digester2.digest(value);
+
+        // then
+        String prefix = "$argon2id$v=19$m=4096,t=3,p=1$";
+        final String hash1 = digest1.substring(digest1.indexOf("$", prefix.length()) + 1);
+        final String hash2 = digest2.substring(digest2.indexOf("$", prefix.length()) + 1);
+        assertFalse(hash1.equals(hash2));
+    }
+
+    @Test
+    public void shouldFailValidateWithSaltTampering() throws Exception {
+        // given
+        final String value = "myPassword";
+        final char delimiter = '-';
+
+        // when
+        PasswordDigester digester = new Argon2PasswordDigester();
+        final String digest = digester.digest(value);
+
+        // Modify the 'salt' part
+        String prefix = "$argon2id$v=19$m=4096,t=3,p=1$";
+        final String salt = digest.substring(prefix.length(), digest.indexOf("$", prefix.length()));
+        byte[] saltBytes = Base64.getDecoder().decode(salt);
+        saltBytes[0]++;
+        String tamperedSalt = new String(Base64.getEncoder().encode(saltBytes));
+        final String tampered = digest.replace(salt, tamperedSalt);
+
+        // then
+        assertTrue(digester.validate(value, digest));
+        assertFalse(digester.validate(value, tampered));
+    }
+
+    @Test
+    public void shouldFailValidateWithDigestTampering() throws Exception {
+        // given
+        final String value = "myPassword";
+        final char delimiter = '-';
+
+        // when
+        PasswordDigester digester = new Argon2PasswordDigester();
+        final String digest = digester.digest(value);
+
+        // Modify the 'digest' part
+        String prefix = "$argon2id$v=19$m=4096,t=3,p=1$";
+        String digestPart = digest.substring(digest.indexOf("$", prefix.length()) + 1);
+        byte[] digestBytes = Base64.getDecoder().decode(digestPart);
+        digestBytes[0]++;
+        String tamperedDigest = new String(Base64.getEncoder().encode(digestBytes));
+        final String tampered = digest.replace(digestPart, tamperedDigest);
+
+        // then
+        assertTrue(digester.validate(value, digest));
+        assertFalse(digester.validate(value, tampered));
+    }
+
+    @Test
+    public void shouldBeAbleToConfigureIteration() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester(16, 32, 1, 4096, 5);
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digest.contains("t=5"));
+    }
+
+    @Test
+    public void shouldBeAbleToConfigureParallelism() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester(16, 32, 2, 4096, 3);
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digest.contains("p=2"));
+    }
+
+    @Test
+    public void shouldBeAbleToConfigureMemory() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester(16, 32, 1, 8192, 3);
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digest.contains("m=8192"));
+    }
+
+    @Test
+    public void shouldBeAbleToConfigureSaltLength() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester(18, 32, 1, 4096, 3);
+
+        final String digest = digester.digest("tiger");
+
+        String prefix = "$argon2id$v=19$m=4096,t=3,p=1$";
+        String salt = digest.substring(prefix.length(), digest.indexOf("$", prefix.length()));
+        assertEquals(18, Base64.getDecoder().decode(salt).length);
+    }
+
+    @Test
+    public void shouldBeAbleToConfigureHashLength() throws Exception {
+        PasswordDigester digester = new Argon2PasswordDigester(16, 34, 1, 4096, 3);
+
+        final String digest = digester.digest("tiger");
+
+        String prefix = "$argon2id$v=19$m=4096,t=3,p=1$";
+        String hash = digest.substring(digest.indexOf("$", prefix.length()) + 1);
+        assertEquals(34, Base64.getDecoder().decode(hash).length);
+    }
+}

--- a/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/BCryptPasswordDigesterTest.java
+++ b/daikon-crypto/crypto-utils/src/test/java/org/talend/daikon/crypto/digest/BCryptPasswordDigesterTest.java
@@ -1,0 +1,162 @@
+package org.talend.daikon.crypto.digest;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BCryptPasswordDigesterTest {
+
+    @Test
+    public void shouldValidateDigest() throws Exception {
+        PasswordDigester digester = new BCryptPasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digester.validate("tiger", digest));
+        assertFalse(digester.validate("password", digest));
+    }
+
+    @Test
+    public void shouldHave10AsDefaultStrength() throws Exception {
+        int strength = 10;
+        PasswordDigester digester = new BCryptPasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digester.validate("tiger", digest));
+        assertEquals(String.valueOf(strength), digest.substring(4, 6));
+    }
+
+    @Test
+    public void shouldBeAbleToConfigureStrength() throws Exception {
+        int strength = 15;
+        PasswordDigester digester = new BCryptPasswordDigester(strength);
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digester.validate("tiger", digest));
+        assertEquals(String.valueOf(strength), digest.substring(4, 6));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowNegativeStrength() throws Exception {
+        new BCryptPasswordDigester(-5);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotAllowPasswordsGreaterThan72Bytes() throws Exception {
+        PasswordDigester digester = new BCryptPasswordDigester();
+        digester.digest(StringUtils.repeat("x", 100));
+    }
+
+    @Test
+    public void shouldHaveDifferentSalts() throws Exception {
+        // given
+        String value = "myPassword";
+
+        // when
+        PasswordDigester digester1 = new BCryptPasswordDigester();
+        PasswordDigester digester2 = new BCryptPasswordDigester();
+        final String digest1 = digester1.digest(value);
+        final String digest2 = digester2.digest(value);
+
+        // then
+        // BCrypt has a 22 character salt
+        final String salt1 = digest1.substring(7, 7 + 22);
+        final String salt2 = digest2.substring(7, 7 + 22);
+        assertFalse(salt1.equals(salt2));
+    }
+
+    @Test
+    public void shouldHaveDifferentHashes() throws Exception {
+        // given
+        String value = "myPassword";
+
+        // when
+        PasswordDigester digester1 = new BCryptPasswordDigester();
+        PasswordDigester digester2 = new BCryptPasswordDigester();
+        final String digest1 = digester1.digest(value);
+        final String digest2 = digester2.digest(value);
+
+        // then
+        // BCrypt has a 22 character salt, and a 31 character hash
+        final String hash1 = digest1.substring(7 + 22);
+        final String hash2 = digest2.substring(7 + 22);
+        assertFalse(hash1.equals(hash2));
+    }
+
+    @Test
+    public void shouldFailValidateWithSaltTampering() throws Exception {
+        // given
+        final String value = "myPassword";
+        final char delimiter = '-';
+
+        // when
+        PasswordDigester digester = new BCryptPasswordDigester();
+        final String digest = digester.digest(value);
+
+        // Modify the 'salt' part
+        String salt = digest.substring(7, 7 + 22);
+        char[] saltChar = salt.toCharArray();
+        saltChar[0] = Character.reverseBytes(saltChar[0]);
+        String tamperedSalt = new String(saltChar);
+        final String tampered = digest.replace(salt, tamperedSalt);
+
+        // then
+        assertTrue(digester.validate(value, digest));
+        assertFalse(digester.validate(value, tampered));
+    }
+
+    @Test
+    public void shouldFailValidateWithDigestTampering() throws Exception {
+        // given
+        final String value = "myPassword";
+        final char delimiter = '-';
+
+        // when
+        PasswordDigester digester = new BCryptPasswordDigester();
+        final String digest = digester.digest(value);
+
+        // Modify the 'digest' part
+        String digestPart = digest.substring(7 + 22);
+        char[] digestChar = digestPart.toCharArray();
+        digestChar[0] = Character.reverseBytes(digestChar[0]);
+        String tamperedDigest = new String(digestChar);
+        final String tampered = digest.replace(digestPart, tamperedDigest);
+
+        // then
+        assertTrue(digester.validate(value, digest));
+        assertFalse(digester.validate(value, tampered));
+    }
+
+    @Test
+    public void checkDefaultAlgorithmIs2a() throws Exception {
+        PasswordDigester digester = new BCryptPasswordDigester();
+
+        final String digest = digester.digest("tiger");
+
+        assertEquals(digest.substring(1, 3), "2a");
+    }
+
+    @Test
+    public void shouldBeAbleToConfigureAlgorithm() throws Exception {
+        PasswordDigester digester = new BCryptPasswordDigester(10, "$2y");
+
+        final String digest = digester.digest("tiger");
+
+        assertEquals(digest.substring(1, 3), "2y");
+    }
+
+    @Test
+    public void shouldValidateDigestWithDifferentAlgorithm() throws Exception {
+        PasswordDigester digester = new BCryptPasswordDigester(19, "$2b");
+
+        final String digest = digester.digest("tiger");
+
+        assertTrue(digester.validate("tiger", digest));
+        assertFalse(digester.validate("password", digest));
+    }
+}


### PR DESCRIPTION
Right now we only support PBKDF2, whereas bcrypt is widely implemented at Talend. This task is to add a PasswordDigester implementation based on argon2id + bcrypt + to document it.