### PR TITLE
TDKN-314 - Update Kafka version to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <guava.version>30.0-jre</guava.version>
         <aspectjweaver.version>1.8.9</aspectjweaver.version>
         <bnd.version>3.0.0</bnd.version>
-        <kafka-clients.version>0.10.0.0</kafka-clients.version>
+        <kafka-clients.version>2.5.1</kafka-clients.version>
         <jsonassert.version>1.2.3</jsonassert.version>
         <commons-codec.version>1.14</commons-codec.version>
         <javax.inject.version>1</javax.inject.version>


### PR DESCRIPTION
Veracode reports mutiple medium level CVEs against the Kafka clients version we use in Daikon (0.10.0.0), e.g.:

https://sca.analysiscenter.veracode.com/workspaces/gZZUxkE/issues/vulnerabilities/57736058

"kafka-clients is vulnerable to user impersonation attacks. The vulnerabilities exists due to the lack of authentication checks in the `SASL/PLAIN` and `SASL/SCRAM` authentication methods using the built-in `PLAIN` or `SCRAM` server implementation in kafka-clients."

CVE-2017-12610

We should update to 2.5.1 to align with the audit logs service.