### PR TITLE
chore(): Create SCA scan Jenkins job

### DIFF
--- a/Jenkinsfile-srcclr
+++ b/Jenkinsfile-srcclr
@@ -1,0 +1,106 @@
+/**
+ * Pod configuration
+ */
+
+def slackChannel = 'eng-daikon'
+def projectName = 'daikon'
+def podLabel = "${projectName}-${UUID.randomUUID().toString()}".take(53)
+
+def podConfiguration = """
+apiVersion: v1
+kind: Pod
+spec:
+  imagePullSecrets:
+    - talend-registry
+  containers:
+    - name: veracode
+      image: artifactory.datapwn.com/tlnd-docker-prod/talend/common/tsbi/jdk8-svc-springboot-builder:2.7.2-20210616074048
+      command:
+      - cat
+      tty: true
+      resources:
+          requests:
+            memory: "4Gi"
+            cpu: "1"
+          limits:
+            memory: "4Gi"
+            cpu: "1"
+      volumeMounts:
+      - name: docker
+        mountPath: /var/run/docker.sock
+      - name: m2
+        mountPath: /root/daikon/.m2/repository
+  volumes:
+  - name: docker
+    hostPath:
+      path: /var/run/docker.sock
+  - name: m2
+    persistentVolumeClaim:
+      claimName: efs-jenkins-common-m2
+"""
+
+
+pipeline {
+
+      agent {
+            kubernetes {
+                  label podLabel
+                  yaml podConfiguration
+            }
+      }
+
+      stages {
+            stage('Clone repo') {
+                      	steps {
+                      		container('veracode') {
+                      			withCredentials([sshUserPrivateKey(credentialsId: "github-ssh", keyFileVariable: 'ID_RSA')]) {
+                      				sh '''
+                      				#!/bin/bash
+                      				set +x
+                      				# Configure SSH Agent to install daikon repo
+                      				ssh-agent
+                      				eval \$(ssh-agent) && ssh-add ${ID_RSA} && ssh-add -l
+                      				mkdir -p ~/.ssh && echo "Host *" > ~/.ssh/config && echo " StrictHostKeyChecking no" >> ~/.ssh/config
+                      				# Step up to clone daikon
+                      				cd ../
+                      				git clone git@github.com:Talend/daikon.git
+                      				'''
+                      			}
+                      		}
+                      	}
+                      }
+            stage("Scan 3rd parties vulnerabilities") {
+                 steps {
+                        container('veracode') {
+                              configFileProvider([configFile(fileId: 'maven-settings-nexus-zl', variable: 'MAVEN_SETTINGS')]) {
+                                    withCredentials([string(credentialsId: 'veracode-token', variable: 'SRCCLR_API_TOKEN')]) {
+                                         sh """#!/bin/bash
+                                         cp ${MAVEN_SETTINGS} ~/.m2/settings.xml
+                                         curl -sSL https://download.sourceclear.com/ci.sh | DEBUG=1 sh -s -- scan;
+                                         """
+                                    }
+                              }
+                        }
+                 }
+            }
+      }
+
+      post {
+           success {
+                    slackSend color: 'good', message: "${currentBuild.currentResult}: Job ${env.JOB_NAME} build ${env.BUILD_NUMBER}\n More info at: ${env.BUILD_URL}", channel: "${slackChannel}"
+           }
+
+           unstable {
+                    slackSend color: 'warning', message: "${currentBuild.currentResult}: Job ${env.JOB_NAME} build ${env.BUILD_NUMBER}\n More info at: ${env.BUILD_URL}", channel: "${slackChannel}"
+           }
+
+           failure {
+                    slackSend color: '#e81f3f', message: "${currentBuild.currentResult}: Job ${env.JOB_NAME} build ${env.BUILD_NUMBER}\n More info at: ${env.BUILD_URL}", channel: "${slackChannel}"
+           }
+
+           aborted {
+                    slackSend color: 'warning', message: "${currentBuild.currentResult}: Job ${env.JOB_NAME} build ${env.BUILD_NUMBER}\n More info at: ${env.BUILD_URL}", channel: "${slackChannel}"
+           }
+      }
+
+}

--- a/Jenkinsfile-srcclr
+++ b/Jenkinsfile-srcclr
@@ -14,7 +14,7 @@ spec:
     - talend-registry
   containers:
     - name: veracode
-      image: artifactory.datapwn.com/tlnd-docker-prod/talend/common/tsbi/jdk8-svc-springboot-builder:2.7.2-20210616074048
+      image: artifactory.datapwn.com/tlnd-docker-prod/talend/common/tsbi/java8-base:2.7.2-20210616074048
       command:
       - cat
       tty: true

--- a/Jenkinsfile-srcclr
+++ b/Jenkinsfile-srcclr
@@ -73,7 +73,7 @@ pipeline {
                  steps {
                         container('veracode') {
                               configFileProvider([configFile(fileId: 'maven-settings-nexus-zl', variable: 'MAVEN_SETTINGS')]) {
-                                    withCredentials([string(credentialsId: 'veracode-token', variable: 'SRCCLR_API_TOKEN')]) {
+                                    withCredentials([string(credentialsId: 'veracode-daikon-token', variable: 'SRCCLR_API_TOKEN')]) {
                                          sh """#!/bin/bash
                                          cp ${MAVEN_SETTINGS} ~/.m2/settings.xml
                                          curl -sSL https://download.sourceclear.com/ci.sh | DEBUG=1 sh -s -- scan;


### PR DESCRIPTION
Taken from https://github.com/Talend/tmdm-server-ee/blob/master/org.talend.mdm.nsis/Jenkinsfile-srcclr

**What is the problem this Pull Request is trying to solve?**
 Daikon needs to be regularly scanned for dependencies via Jenkins + Veracode
 
**What is the chosen solution to this problem?**
 Integrate a Jenkins job that will regularly scan the dependencies
 
**Please check if the Pull Request fulfills these requirements**
- [X] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [NA] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [NA] Docs have been added / updated (for bug fixes / features)
- [NA] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
