### PR TITLE
chore(versions) Inherits from daikon SB versions

### DIFF
--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/pom.xml
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/pom.xml
@@ -12,7 +12,7 @@
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
-                <version>Hoxton.SR8</version>
+                <version>${spring-cloud-dependencies.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/src/main/java/org/talend/demo/Worker.java
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-metrics/src/main/java/org/talend/demo/Worker.java
@@ -21,5 +21,4 @@ public class Worker {
         }
     }
 
-
 }

--- a/daikon-spring/daikon-spring-examples/daikon-spring-example-security/src/main/java/org/talend/demo/actuator/ActuatorApplication.java
+++ b/daikon-spring/daikon-spring-examples/daikon-spring-example-security/src/main/java/org/talend/demo/actuator/ActuatorApplication.java
@@ -2,12 +2,11 @@ package org.talend.demo.actuator;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 public class ActuatorApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(ActuatorApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(ActuatorApplication.class, args);
+    }
 }

--- a/daikon-spring/daikon-spring-examples/pom.xml
+++ b/daikon-spring/daikon-spring-examples/pom.xml
@@ -2,23 +2,16 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.11.RELEASE</version>
-        <relativePath />
+        <groupId>org.talend.daikon</groupId>
+        <artifactId>daikon-spring</artifactId>
+        <version>5.11.0-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.talend.daikon</groupId>
     <artifactId>daikon-spring-examples</artifactId>
     <packaging>pom</packaging>
     <name>Examples using Daikon spring related modules.</name>
     <url>https://github.com/Talend/daikon</url>
     <version>5.11.0-SNAPSHOT</version>
-
-    <properties>
-        <spring-boot.version>2.3.11.RELEASE</spring-boot.version>
-    </properties>
-
 
     <modules>
         <module>daikon-spring-example-security</module>


### PR DESCRIPTION

**What is the problem this Pull Request is trying to solve?**
 
Spring samples use a different POM hierarchy which makes SB upgrades very error prone.

**What is the chosen solution to this problem?**

* Change parent hierarchy for Spring examples (to ease next releases).
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
