### PR TITLE
Fix(): Remove useless git clone stage from Jenkinsfile-srcclr

### DIFF
--- a/Jenkinsfile-srcclr
+++ b/Jenkinsfile-srcclr
@@ -50,25 +50,6 @@ pipeline {
       }
 
       stages {
-            stage('Clone repo') {
-                      	steps {
-                      		container('veracode') {
-                      			withCredentials([sshUserPrivateKey(credentialsId: "github-ssh", keyFileVariable: 'ID_RSA')]) {
-                      				sh '''
-                      				#!/bin/bash
-                      				set +x
-                      				# Configure SSH Agent to install daikon repo
-                      				ssh-agent
-                      				eval \$(ssh-agent) && ssh-add ${ID_RSA} && ssh-add -l
-                      				mkdir -p ~/.ssh && echo "Host *" > ~/.ssh/config && echo " StrictHostKeyChecking no" >> ~/.ssh/config
-                      				# Step up to clone daikon
-                      				cd ../
-                      				git clone git@github.com:Talend/daikon.git
-                      				'''
-                      			}
-                      		}
-                      	}
-                      }
             stage("Scan 3rd parties vulnerabilities") {
                  steps {
                         container('veracode') {


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 The previous Jenkinsfile-srcclr was broken because git clone wouldn't launch, it's unnecessary
**What is the chosen solution to this problem?**
 Remove it !
**Link to the JIRA issue**
 
**Please check if the Pull Request fulfills these requirements**
- [X] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
