### PR TITLE
Fix(): Switch srcclr jenkins image to jdk8-svc-springboot-builder

### DIFF
--- a/Jenkinsfile-srcclr
+++ b/Jenkinsfile-srcclr
@@ -14,7 +14,7 @@ spec:
     - talend-registry
   containers:
     - name: veracode
-      image: artifactory.datapwn.com/tlnd-docker-prod/talend/common/tsbi/java8-base:2.7.2-20210616074048
+      image: artifactory.datapwn.com/tlnd-docker-prod/talend/common/tsbi/jdk8-svc-springboot-builder:2.8.0-2.3-20210622090337
       command:
       - cat
       tty: true


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 The current SCA job isn't working, resulting in an error 
 ```
 process apparently never started in /home/jenkins/agent/workspace/daikon-security/daikon-srcclr@tmp/durable-d66df695
(running Jenkins temporarily with -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.LAUNCH_DIAGNOSTICS=true might make the problem clearer)
```
**What is the chosen solution to this problem?**
 Switching to a TSBI builder image should fix the problem
 
**Please check if the Pull Request fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
