### PR TITLE
fix(TDKN-331): Json2Avro: Fields in a record doesn't have to be in a specific order

### DIFF
--- a/daikon/src/test/java/org/talend/daikon/avro/converter/JsonGenericRecordConverterTest.java
+++ b/daikon/src/test/java/org/talend/daikon/avro/converter/JsonGenericRecordConverterTest.java
@@ -281,18 +281,8 @@ public class JsonGenericRecordConverterTest {
 
     @Test
     public void testConvertFieldsOrderInsensitive() {
-        Schema schema = SchemaBuilder
-                .record("OuterRecord")
-                .fields()
-                .name("comment")
-                .type()
-                .record("InnerRecord")
-                .fields()
-                .requiredString("content")
-                .requiredInt("stars")
-                .endRecord()
-                .noDefault()
-                .endRecord();
+        Schema schema = SchemaBuilder.record("OuterRecord").fields().name("comment").type().record("InnerRecord").fields()
+                .requiredString("content").requiredInt("stars").endRecord().noDefault().endRecord();
 
         jsonGenericRecordConverter = new JsonGenericRecordConverter(schema);
 
@@ -312,7 +302,7 @@ public class JsonGenericRecordConverterTest {
     private static byte[] serializeGenericRecord(GenericRecord record, Schema schema) {
         DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
         try (ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-             DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter)) {
+                DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter)) {
             dataFileWriter.create(schema, buffer);
             dataFileWriter.append(record);
             dataFileWriter.close();


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
 When converting a JSON string to Avro record, the order in which the fields are present in the JSON string should not impact the conversion.
  
**What is the chosen solution to this problem?**
Reuse the reference schema instead of re-inferring the nested fields schema.
 
**Link to the JIRA issue**
https://jira.talendforge.org/browse/TDKN-331
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
