### PR TITLE
fix(): switch ScriptEngine to Graal VM JS engine

### DIFF
--- a/daikon/pom.xml
+++ b/daikon/pom.xml
@@ -137,6 +137,23 @@
             <version>3.22.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.js</groupId>
+            <artifactId>js-scriptengine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.graalvm.truffle</groupId>
+            <artifactId>truffle-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+
     </dependencies>
     <build>
         <plugins>

--- a/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
+++ b/daikon/src/test/java/org/talend/daikon/pattern/character/CharPatternToRegexTest.java
@@ -1,5 +1,9 @@
 package org.talend.daikon.pattern.character;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.Test;
 
 import javax.script.ScriptEngine;
@@ -7,10 +11,6 @@ import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CharPatternToRegexTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <json-schema-validator.version>1.0.64</json-schema-validator.version>
         <maven.enforcer.plugin.version>3.0.0</maven.enforcer.plugin.version>
         <junit-pioneer.version>1.6.2</junit-pioneer.version>
+        <graalvm.js.version>22.1.0.1</graalvm.js.version>
     </properties>
     <modules>
         <module>daikon</module>
@@ -174,6 +175,24 @@
     </distributionManagement>
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.graalvm.js</groupId>
+                <artifactId>js</artifactId>
+                <version>${graalvm.js.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.js</groupId>
+                <artifactId>js-scriptengine</artifactId>
+                <version>${graalvm.js.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.graalvm.truffle</groupId>
+                <artifactId>truffle-api</artifactId>
+                <version>${graalvm.js.version}</version>
+                <scope>test</scope>
+            </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**

TU failed on ScriptEngine as NashornScriptEngine is deprecated and removed. 
 
**What is the chosen solution to this problem?**

Switch to graal VM JS engine
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
