### PR TITLE
fix: Add toString() method for AuthenticationToken

### DIFF
--- a/daikon-spring/daikon-spring-auth/src/main/java/org/talend/daikon/spring/auth/model/token/AuthenticationToken.java
+++ b/daikon-spring/daikon-spring-auth/src/main/java/org/talend/daikon/spring/auth/model/token/AuthenticationToken.java
@@ -123,4 +123,17 @@ public abstract class AuthenticationToken implements Authentication {
         return permissions.map(String::trim).map(SimpleGrantedAuthority::new).collect(Collectors.toSet());
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getSimpleName()).append(" [");
+        sb.append("Principal=").append(getPrincipal()).append(", ");
+        sb.append("Credentials=[PROTECTED], ");
+        sb.append("Tenant ID=").append(this.authUserDetails.getTenantId()).append(", ");
+        sb.append("Authenticated=").append(isAuthenticated()).append(", ");
+        sb.append("Granted Authorities=").append(this.authorities);
+        sb.append("]");
+        return sb.toString();
+    }
+
 }


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
There is no `toSring()` to print readable info of the token, which would be useful for client side when they try to log .
 
**What is the chosen solution to this problem?**
 Implement `toString()` referencing `org.springframework.security.authentication.AbstractAuthenticationToken.java`
 It will print info like `SatAuthenticationToken [Principal=My awesome service account - Service Account, Credentials=[PROTECTED], Tenant ID=ce8bca4e-c6c2-42b5-8705-02b8af3a94bb, Authenticated=true, Granted Authorities=[TMC_ROLE_MANAGEMENT, TMC_USER_MANAGEMENT, TMC_GROUP_MANAGEMENT]]`
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
