### PR TITLE
fix(TPRUN-3858) Map the entitlements correctly in Opaque workflow

### DIFF
--- a/daikon-spring/daikon-spring-reactive/daikon-spring-reactive-auth/src/main/java/org/talend/daikon/spring/reactive/sat/config/ReactiveAuthenticationManagerFactory.java
+++ b/daikon-spring/daikon-spring-reactive/daikon-spring-reactive-auth/src/main/java/org/talend/daikon/spring/reactive/sat/config/ReactiveAuthenticationManagerFactory.java
@@ -20,6 +20,7 @@ import org.springframework.util.StringUtils;
 import org.talend.daikon.spring.reactive.sat.authentication.Auth0ReactiveAuthenticationManager;
 import org.talend.daikon.spring.reactive.sat.authentication.Auth0ReactiveAuthenticationProvider;
 import org.talend.daikon.spring.reactive.sat.authentication.TalendJwtConverter;
+import org.talend.daikon.spring.reactive.sat.introspection.AuthUserDetailsConverterIntrospector;
 
 import lombok.Getter;
 import reactor.core.publisher.Mono;
@@ -68,11 +69,12 @@ public class ReactiveAuthenticationManagerFactory {
 
     private ReactiveAuthenticationManager opaqueReactiveAuthenticationManager(OAuth2ResourceServerProperties oauth2Properties) {
         if (StringUtils.hasText(oauth2Properties.getOpaquetoken().getIntrospectionUri())) {
+            NimbusReactiveOpaqueTokenIntrospector nimbusReactiveOpaqueTokenIntrospector = new NimbusReactiveOpaqueTokenIntrospector(
+                    oauth2Properties.getOpaquetoken().getIntrospectionUri(),
+                    Optional.ofNullable(oauth2Properties.getOpaquetoken().getClientId()).orElse(""),
+                    Optional.ofNullable(oauth2Properties.getOpaquetoken().getClientSecret()).orElse(""));
             return new OpaqueTokenReactiveAuthenticationManager(
-                    new NimbusReactiveOpaqueTokenIntrospector(oauth2Properties.getOpaquetoken().getIntrospectionUri(),
-                            Optional.ofNullable(oauth2Properties.getOpaquetoken().getClientId()).orElse(""),
-                            Optional.ofNullable(oauth2Properties.getOpaquetoken().getClientSecret()).orElse("")));
-
+                    new AuthUserDetailsConverterIntrospector(nimbusReactiveOpaqueTokenIntrospector));
         }
         LOGGER.debug(
                 "spring.security.oauth2.resourceserver.opaque-token.introspection-uri has no value: no opaque token authentication will be available");

--- a/daikon-spring/daikon-spring-reactive/daikon-spring-reactive-auth/src/main/java/org/talend/daikon/spring/reactive/sat/introspection/AuthUserDetailsConverterIntrospector.java
+++ b/daikon-spring/daikon-spring-reactive/daikon-spring-reactive-auth/src/main/java/org/talend/daikon/spring/reactive/sat/introspection/AuthUserDetailsConverterIntrospector.java
@@ -1,0 +1,20 @@
+package org.talend.daikon.spring.reactive.sat.introspection;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticatedPrincipal;
+import org.springframework.security.oauth2.server.resource.introspection.ReactiveOpaqueTokenIntrospector;
+import org.talend.daikon.spring.auth.common.model.userdetails.UserDetailsConverter;
+
+import reactor.core.publisher.Mono;
+
+public class AuthUserDetailsConverterIntrospector implements ReactiveOpaqueTokenIntrospector {
+
+    private final ReactiveOpaqueTokenIntrospector delegate;
+
+    public AuthUserDetailsConverterIntrospector(ReactiveOpaqueTokenIntrospector delegate) {
+        this.delegate = delegate;
+    }
+
+    public Mono<OAuth2AuthenticatedPrincipal> introspect(String token) {
+        return delegate.introspect(token).map(principal -> UserDetailsConverter.convert(principal.getAttributes()));
+    }
+}


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
Entitlements are not correctly mapped in Opaque workflow
 
**What is the chosen solution to this problem?**
Map the user details and entitlements correctly in opaque workflow
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
