### PR TITLE
CVE-2022-45688 com.github.erosb:everit-json-schema to 1.14.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,12 +119,11 @@
         <yaml.codegen.maven.plugin.version>0.0.6</yaml.codegen.maven.plugin.version>
         <maven.enforcer.plugin.version>3.0.0</maven.enforcer.plugin.version>
 
-
         <testcontainers.version>1.17.6</testcontainers.version>
-
 
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <kafka-confluent>7.3.3</kafka-confluent>
+        <everit-json-schema.version>1.14.2</everit-json-schema.version>
 
     </properties>
     <modules>
@@ -353,6 +352,12 @@
                 <groupId>io.confluent</groupId>
                 <artifactId>kafka-json-schema-serializer</artifactId>
                 <version>${kafka-confluent}</version>
+            </dependency>
+            <!-- TPRUN-TODO CVE-2022-45688 This is to force library version to a safe one. To be removed when all libraries that includes it are updated to the below version or newest -->
+            <dependency>
+                <groupId>com.github.erosb</groupId>
+                <artifactId>everit-json-schema</artifactId>
+                <version>${everit-json-schema.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>


### PR DESCRIPTION
**What is the problem this Pull Request is trying to solve?**
CVE on org.json:json:jar:20220320 can be fixed by upgrading  com.github.erosb:everit-json-schema to 1.14.2

**What is the chosen solution to this problem?**
 
**Link to the JIRA issue**
<!--e.g. https://jira.talendforge.org/browse/XXX -->
 
**Please check if the Pull Request fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/Talend/daikon/blob/master/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in JIRA), if any, are all linked or available in the Pull Request

<!-- You can add more checkboxes here -->
 
**[ ] This Pull Request introduces a breaking change**
 
<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
